### PR TITLE
Fix json-c detection for json-c-0.11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,7 +175,9 @@ AS_HELP_STRING([--with-ureport],[use uReport plugin (default is YES)]),
 LIBREPORT_PARSE_WITH([ureport]))
 if test -z "$NO_UREPORT"; then
 AM_CONDITIONAL(BUILD_UREPORT, true)
-PKG_CHECK_MODULES([JSON_C], [json])
+PKG_CHECK_MODULES([JSON_C], [json],,[
+    PKG_CHECK_MODULES([JSON_C], [json-c])
+])
 else
 AM_CONDITIONAL(BUILD_UREPORT, false)
 fi dnl end NO_UREPORT


### PR DESCRIPTION
json-c-0.11 renamed the pkgconfig file to json-c
https://github.com/json-c/json-c/blob/master/ChangeLog
The configure.ac file was fixed to look for json-c if json
is not available.

Signed-off-by: Markos Chandras hwoarang@gentoo.org
