### PR TITLE
Use proper json-c requirement in libreport-web.pc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,12 +183,19 @@ AS_HELP_STRING([--with-ureport],[use uReport plugin (default is YES)]),
 LIBREPORT_PARSE_WITH([ureport]))
 if test -z "$NO_UREPORT"; then
 AM_CONDITIONAL(BUILD_UREPORT, true)
-PKG_CHECK_MODULES([JSON_C], [json],,[
-    PKG_CHECK_MODULES([JSON_C], [json-c])
+PKG_CHECK_MODULES([JSON_C], [json], [
+    JSON_C_PACKAGE=json
+], [
+    PKG_CHECK_MODULES([JSON_C], [json-c], [
+        JSON_C_PACKAGE=json-c
+    ])
 ])
 else
 AM_CONDITIONAL(BUILD_UREPORT, false)
+JSON_C_PACKAGE=
 fi dnl end NO_UREPORT
+
+AC_SUBST([JSON_C_PACKAGE])
 
 PKG_PROG_PKG_CONFIG
 

--- a/libreport-web.pc.in
+++ b/libreport-web.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: libreport
 Description: Library providing network API for libreport
 Version: @VERSION@
-Requires: glib-2.0 libcurl libproxy-1.0 libxml-2.0 xmlrpc xmlrpc_client json satyr libreport
+Requires: glib-2.0 libcurl libproxy-1.0 libxml-2.0 xmlrpc xmlrpc_client @JSON_C_PACKAGE@ satyr libreport
 Libs: -L${libdir} -lreport-web
 Cflags:
 


### PR DESCRIPTION
Depending on whether json-c was found as 'json' or 'json-c', require the same package in the generated .pc file.
