### PR TITLE
disable rhel/fedora workflows for anaconda

### DIFF
--- a/src/workflows/report_fedora.conf
+++ b/src/workflows/report_fedora.conf
@@ -2,7 +2,7 @@ EVENT=workflow_FedoraCCpp analyzer=CCpp
 # this is just a meta event which consists of other events
 # the list is defined in the xml file
 
-EVENT=workflow_FedoraPython analyzer=Python
+EVENT=workflow_FedoraPython analyzer=Python component!=anaconda
 # this is just a meta event which consists of other events
 # the list is defined in the xml file
 

--- a/src/workflows/report_rhel.conf
+++ b/src/workflows/report_rhel.conf
@@ -2,7 +2,7 @@ EVENT=workflow_RHELCCpp analyzer=CCpp
 # this is just a meta event which consists of other events
 # the list is defined in the xml file
 
-EVENT=workflow_RHELPython analyzer=Python
+EVENT=workflow_RHELPython analyzer=Python component!=anaconda
 # this is just a meta event which consists of other events
 # the list is defined in the xml file
 


### PR DESCRIPTION
We have to ship both libreport-fedora and libreport-anaconda with LiveCD because libreport-fedora provides workflows and configuration for standard reporting but excludes anaconda component. Even more abrt-desktop requires libreport-fedora and LiveCD must contain abrt-desktop package.
