### PR TITLE
fix a overflow condition in parse time fn for x32 arch

### DIFF
--- a/src/lib/dump_dir.c
+++ b/src/lib/dump_dir.c
@@ -166,7 +166,7 @@ static time_t parse_time_file(const char *filename)
     /* Check for various possible errors */
     if (errno
      || (*endptr != '\0')
-     || val > MAX_TIME_T
+     || val >= MAX_TIME_T
      || !isdigit_str(time_buf) /* this filters out "-num", "   num", "" */
     ) {
         VERB2 perror_msg("File '%s' doesn't contain valid unix "


### PR DESCRIPTION
If the result equals to LONG LONG MAX, there are two possible reasons:
1. overflow
2. time is 9223372036854775807s after 1970 (292278994-08-17)

So, we apologize to all future users affected by this simplification.

Uncovered by coverity.

Related to rhbz#1016571

Signed-off-by: Jakub Filak jfilak@redhat.com
