### PR TITLE
Do not load "always editable" files if they are HUGE. Fixes rhbz1010167.

### DIFF
--- a/src/include/problem_data.h
+++ b/src/include/problem_data.h
@@ -38,6 +38,12 @@ enum {
     /* Show this element in "short" info (report-cli -l) */
     CD_FLAG_LIST          = (1 << 4),
     CD_FLAG_UNIXTIME      = (1 << 5),
+    /* If element is HUGE text, it is not read into memory (it can OOM the machine).
+     * Instead, it is treated as binary (CD_FLAG_BIN), but also has CD_FLAG_BIGTXT
+     * bit set in flags. This allows to set proper MIME type when it gets attached
+     * to a bug report etc.
+     */
+    CD_FLAG_BIGTXT        = (1 << 6),
 };
 
 struct problem_item {

--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -543,7 +543,7 @@ int attach_text_item(struct abrt_xmlrpc *ax, const char *bug_id,
 }
 
 static
-int attach_binary_item(struct abrt_xmlrpc *ax, const char *bug_id,
+int attach_file_item(struct abrt_xmlrpc *ax, const char *bug_id,
                 const char *item_name, struct problem_item *item)
 {
     if (!(item->flags & CD_FLAG_BIN))
@@ -564,8 +564,11 @@ int attach_binary_item(struct abrt_xmlrpc *ax, const char *bug_id,
         close(fd);
         return 0;
     }
-    log_debug("attaching '%s' as binary", item_name);
-    int r = rhbz_attach_fd(ax, bug_id, item_name, fd, RHBZ_NOMAIL_NOTIFY | RHBZ_BINARY_ATTACHMENT);
+    log_debug("attaching '%s' as file", item_name);
+    int flag = RHBZ_NOMAIL_NOTIFY;
+    if (!(item->flags & CD_FLAG_BIGTXT))
+        flag |= RHBZ_BINARY_ATTACHMENT;
+    int r = rhbz_attach_fd(ax, bug_id, item_name, fd, flag);
     close(fd);
     return (r == 0);
 }
@@ -582,7 +585,7 @@ int attach_item(struct abrt_xmlrpc *ax, const char *bug_id,
         if (item->flags & CD_FLAG_TXT)
             return attach_text_item(ax, bug_id, item_name, item);
         if (item->flags & CD_FLAG_BIN)
-            return attach_binary_item(ax, bug_id, item_name, item);
+            return attach_file_item(ax, bug_id, item_name, item);
         return 0;
     }
 
@@ -627,7 +630,7 @@ int attach_item(struct abrt_xmlrpc *ax, const char *bug_id,
                 done |= attach_text_item(ax, bug_id, name, item);
         }
         if ((item->flags & CD_FLAG_BIN) && binary)
-            done |= attach_binary_item(ax, bug_id, name, item);
+            done |= attach_file_item(ax, bug_id, name, item);
     }
 
     g_list_free(sorted_names); /* names themselves are not freed */

--- a/src/plugins/reporter-rhtsupport.c
+++ b/src/plugins/reporter-rhtsupport.c
@@ -87,7 +87,8 @@ int create_tarball(const char *tempfile, problem_data_t *problem_data)
                         /*on_disk_filename */ content,
                         /*binding_name     */ name,
                         /*recorded_filename*/ xml_name,
-                        /*binary           */ 1);
+                        /*binary           */ !(value->flags & CD_FLAG_BIGTXT)
+                );
                 if (tar_append_file(tar, (char*)content, xml_name) != 0)
                 {
                     free(xml_name);


### PR DESCRIPTION
rhbz#1010167:
"abrt-cli list ends with Out of memory error for large files"

The reproducer has "reason" element with 1500 megabytes of /dev/zero.
This was OOMing the machine because "reason" is an editable item,
and we were treating such items as text and loading them always,
without checking their size.

The change fixes this particular oversight: it will always load
huge files as CD_FLAG_BIN. It will also flag huge, but seemingly
textual files with a new bit, CD_FLAG_BIGTXT. This allows us
to set MIME type of "text/plain" on such files.

With this change, we can roll back increases in CD_MAX_TEXT_SIZE:
we were making it large (8 mbytes) because otherwise big text files
were attached as "application/octet-stream". Now they will have
"text/plain" type.

Signed-off-by: Denys Vlasenko dvlasenk@redhat.com
