### PR TITLE
don't spit log messages for non-dump directories

### DIFF
--- a/src/lib/abrt_sock.c
+++ b/src/lib/abrt_sock.c
@@ -38,7 +38,7 @@ static int connect_to_abrtd_socket()
     int r = connect(socketfd, (struct sockaddr*)&local, sizeof(local));
     if (r != 0)
     {
-        pwarn_msg("Can't connect to '%s'", SOCKET_FILE);
+        VERB1 pwarn_msg("Can't connect to '%s'", SOCKET_FILE);
         close(socketfd);
         return -1;
     }

--- a/src/lib/dump_dir.c
+++ b/src/lib/dump_dir.c
@@ -122,7 +122,7 @@ static time_t parse_time_file(const char *filename)
     int fd = open(filename, O_RDONLY | O_NOFOLLOW);
     if (fd < 0)
     {
-        pwarn_msg("Can't open '%s'", filename);
+        VERB2 pwarn_msg("Can't open '%s'", filename);
         return -1;
     }
 
@@ -135,7 +135,7 @@ static time_t parse_time_file(const char *filename)
 
     if (rdsz == -1)
     {
-        pwarn_msg("Can't read from '%s'", filename);
+        VERB2 pwarn_msg("Can't read from '%s'", filename);
         return -1;
     }
     /* approximate maximal number of digits in timestamp is sizeof(time_t)*3 */
@@ -144,8 +144,8 @@ static time_t parse_time_file(const char *filename)
     /* than string representing maximal time stamp */
     if (rdsz == sizeof(time_buf))
     {
-        warn_msg("File '%s' is too long to be valid unix "
-                 "time stamp (max size %u)", filename, (int)sizeof(time_buf));
+        VERB2 warn_msg("File '%s' is too long to be valid unix "
+                       "time stamp (max size %u)", filename, (int)sizeof(time_buf));
         return -1;
     }
 
@@ -169,8 +169,8 @@ static time_t parse_time_file(const char *filename)
      || val >= MAX_TIME_T
      || !isdigit_str(time_buf) /* this filters out "-num", "   num", "" */
     ) {
-        pwarn_msg("File '%s' doesn't contain valid unix "
-                         "time stamp ('%s')", filename, time_buf);
+        VERB2 pwarn_msg("File '%s' doesn't contain valid unix "
+                        "time stamp ('%s')", filename, time_buf);
         return -1;
     }
 
@@ -1343,7 +1343,7 @@ int dump_dir_accessible_by_uid(const char *dirname, uid_t uid)
     if (ddstat >= 0)
         return ddstat & DD_STAT_ACCESSIBLE_BY_UID;
 
-    pwarn_msg("can't determine accessibility of '%s' by %ld uid", dirname, (long)uid);
+    VERB3 pwarn_msg("can't determine accessibility of '%s' by %ld uid", dirname, (long)uid);
 
     return 0;
 }

--- a/src/plugins/reporter-print.c
+++ b/src/plugins/reporter-print.c
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
             FILE *outstream = fopen(output_file, open_mode);
             if (!outstream)
             {
-                pwarn_msg("fopen");
+                VERB1 pwarn_msg("fopen");
                 msg = xasprintf(_("Can't open '%s' for writing. "
                                   "Please select another file:"), output_file);
                 continue;


### PR DESCRIPTION
Messages like this are not produced anymore:
can't determine accessibility of '/var/tmp/abrt/last-via-server' by 0
uid: Not a directory"

Closes rhbz#1025161.

Signed-off-by: Richard Marko rmarko@redhat.com
