### PR TITLE
reprter-bugzilla: if adding to existing BZ, clearly flag comment as a dup. Partially fixes 864891

### DIFF
--- a/src/plugins/bugzilla_format.conf
+++ b/src/plugins/bugzilla_format.conf
@@ -15,6 +15,8 @@
 # - %summary: bug summary format string.
 # - %attach: a list of elements to attach.
 # - text, double colon (::) and the list of comma-separated elements.
+#   Text can be empty (":: elem1, elem2, elem3" works),
+#   in this case "Text:" header line will be omitted.
 #
 # Elements can be:
 # - problem directory element names, which get formatted as

--- a/src/plugins/bugzilla_format_anaconda.conf
+++ b/src/plugins/bugzilla_format_anaconda.conf
@@ -15,6 +15,8 @@
 # - %summary: bug summary format string.
 # - %attach: a list of elements to attach.
 # - text, double colon (::) and the list of comma-separated elements.
+#   Text can be empty (":: elem1, elem2, elem3" works),
+#   in this case "Text:" header line will be omitted.
 #
 # Elements can be:
 # - problem directory element names, which get formatted as

--- a/src/plugins/bugzilla_formatdup.conf
+++ b/src/plugins/bugzilla_formatdup.conf
@@ -15,6 +15,8 @@
 # - %summary: bug summary format string.
 # - %attach: a list of elements to attach.
 # - text, double colon (::) and the list of comma-separated elements.
+#   Text can be empty (":: elem1, elem2, elem3" works),
+#   in this case "Text:" header line will be omitted.
 #
 # Elements can be:
 # - problem directory element names, which get formatted as
@@ -36,8 +38,18 @@
 #   Nonexistent elements are silently ignored.
 #   If none of elements exists, the section will not be created.
 
-%summary:: [abrt] %pkg_name%[[: %crash_function%()]][[: %reason%]][[: TAINTED %tainted_short%]]
+# When we add a comment to an existing BZ, %summary is ignored
+# (it specifies *new bug* summary field):
+# %summary:: blah blah
 
+# When dup is detected, BZ reporter adds a comment to it.
+# This comment may interrupt an ongoing conversation in the BZ.
+# (Three people independently filed a bug against abrt about this).
+# Need to clearly explain what this comment is, to prevent confusion.
+# Hopefully, this line would suffice:
+Another user experienced a similar problem:
+
+# If user filled out comment field, show it:
 :: %bare_comment
 
 # var_log_messages has too much variance (time/date),

--- a/src/plugins/bugzilla_formatdup_anaconda.conf
+++ b/src/plugins/bugzilla_formatdup_anaconda.conf
@@ -15,6 +15,8 @@
 # - %summary: bug summary format string.
 # - %attach: a list of elements to attach.
 # - text, double colon (::) and the list of comma-separated elements.
+#   Text can be empty (":: elem1, elem2, elem3" works),
+#   in this case "Text:" header line will be omitted.
 #
 # Elements can be:
 # - problem directory element names, which get formatted as
@@ -36,8 +38,18 @@
 #   Nonexistent elements are silently ignored.
 #   If none of elements exists, the section will not be created.
 
-%summary:: [abrt] %package%[[: %crash_function%]][[: %reason%]][[: TAINTED %tainted_short%]]
+# When we add a comment to an existing BZ, %summary is ignored
+# (it specifies *new bug* summary field):
+# %summary:: blah blah
 
+# When dup is detected, BZ reporter adds a comment to it.
+# This comment may interrupt an ongoing conversation in the BZ.
+# (Three people independently filed a bug against abrt about this).
+# Need to clearly explain what this comment is, to prevent confusion.
+# Hopefully, this line would suffice:
+Another user experienced a similar problem:
+
+# If user filled out comment field, show it:
 :: %bare_comment
 
 # var_log_messages has too much variance (time/date),


### PR DESCRIPTION
With this commit, the added BZ comment will look like this:

Another user experienced a similar problem:

<comment field goes here>

reporter:       libreport-2.1.9.9.gdef1.dirty
backtrace_rating: 4
cmdline:        will_segfault
crash_function: main
executable:     /usr/bin/will_segfault
kernel:         3.10.11-100.fc18.x86_64
package:        will-crash-0.4-1.fc18
reason:         will_segfault killed by SIGSEGV
runlevel:       N 5
type:           CCpp
uid:            0

Signed-off-by: Denys Vlasenko dvlasenk@redhat.com
