### PR TITLE
Make make_description() output less confusing

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -20,6 +20,7 @@ src/lib/create_dump_dir.c
 src/lib/curl.c
 src/lib/event_config.c
 src/lib/json.c
+src/lib/make_descr.c
 src/lib/parse_options.c
 src/lib/problem_data.c
 src/lib/run_event.c

--- a/src/lib/make_descr.c
+++ b/src/lib/make_descr.c
@@ -97,7 +97,6 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
         }
     }
 
-    bool append_empty_line = !empty;
     if (desc_flags & MAKEDESC_SHOW_URLS)
     {
         const char *reported_to = problem_data_get_content_or_NULL(problem_data, FILENAME_REPORTED_TO);
@@ -105,6 +104,11 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
         {
             GList *reports = read_entire_reported_to_data(reported_to);
 
+            /* The value part begins on 17. column */
+            /*                        0123456789ABCDEF*/
+            const char *pad_prefix = "                ";
+            char *first_prefix = xasprintf("%s%*s", _("Reported:"), 16 - strlen(_("Reported:")), "");
+            const char *prefix     = first_prefix;
             for (GList *iter = reports; iter != NULL; iter = g_list_next(iter))
             {
                 const report_result_t *const report = (report_result_t *)iter->data;
@@ -112,21 +116,20 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
                 if (report->url == NULL)
                     continue;
 
-                if (append_empty_line)
-                    strbuf_append_char(buf_dsc, '\n');
-                append_empty_line = false;
-                empty = false;
+                strbuf_append_strf(buf_dsc, "%s%s\n", prefix, report->url);
 
-                int pad = 16 - (strlen(report->label) + 2);
-                if (pad < 0) pad = 0;
-                strbuf_append_strf(buf_dsc, "%s: %*s%s\n", report->label, pad, "", report->url);
+                if (prefix == first_prefix)
+                {   /* Only the first URL is prefix by 'Reported:' */
+                    empty = false;
+                    prefix = pad_prefix;
+                }
             }
-
+            free(first_prefix);
             g_list_free_full(reports, (GDestroyNotify)free_report_result);
         }
     }
 
-    append_empty_line = !empty;
+    bool append_empty_line = !empty;
     if (desc_flags & MAKEDESC_SHOW_FILES)
     {
         /* Print file info. Format:

--- a/tests/make_description.at
+++ b/tests/make_description.at
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
 
     description = make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_URLS);
     char *expected = xasprintf("%s: %*s%s\n",
-            "Bugzilla", 14 - strlen("Bugzilla"), "", "https://bugzilla.redhat.com/1000000");
+            "Reported", 14 - strlen("Reported"), "", "https://bugzilla.redhat.com/1000000");
 
     if (strcmp(expected, description) != 0)
     {
@@ -50,10 +50,11 @@ int main(int argc, char **argv)
             "ABRT Server: URL=https://bug-report.itos.redhat.com\n");
 
     description = make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_URLS);
-    expected = xasprintf("%s: %*s%s\n%s: %*s%s\n%s: %*s%s\n",
-            "Bugzilla",    14 - strlen("Bugzilla"),    "", "https://bugzilla.redhat.com/1000000",
-            "RHTSupport",  14 - strlen("RHTSupport"),  "", "https://access.redhat.com/home",
-            "ABRT Server", 14 - strlen("ABRT Server"), "", "https://bug-report.itos.redhat.com");
+    expected = xasprintf(
+           /*0123456789ABCDEF*/
+            "Reported:       https://bugzilla.redhat.com/1000000\n"
+            "                https://access.redhat.com/home\n"
+            "                https://bug-report.itos.redhat.com\n");
 
     if (strcmp(expected, description) != 0)
     {
@@ -98,16 +99,13 @@ int main(int argc, char **argv)
             "%s: %*s%s\n"
             "%s: %*s%s\n"
             "%s: %*s%s\n"
-            "\n"
-            "%s: %*s%s\n"
-            "%s: %*s%s\n"
-            "%s: %*s%s\n",
+           /*0123456789ABCDEF*/
+            "Reported:       https://bugzilla.redhat.com/1000000\n"
+            "                https://access.redhat.com/home\n"
+            "                https://bug-report.itos.redhat.com\n",
             FILENAME_COUNT,      14 - strlen(FILENAME_COUNT),      "", "0",
             FILENAME_EXECUTABLE, 14 - strlen(FILENAME_EXECUTABLE), "", "/usr/bin/sh",
-            FILENAME_PACKAGE,    14 - strlen(FILENAME_PACKAGE),    "", "libreport",
-            "Bugzilla",          14 - strlen("Bugzilla"),          "", "https://bugzilla.redhat.com/1000000",
-            "RHTSupport",        14 - strlen("RHTSupport"),        "", "https://access.redhat.com/home",
-            "ABRT Server",       14 - strlen("ABRT Server"),       "", "https://bug-report.itos.redhat.com");
+            FILENAME_PACKAGE,    14 - strlen(FILENAME_PACKAGE),    "", "libreport");
 
     if (strcmp(expected, description) != 0)
     {
@@ -128,10 +126,10 @@ int main(int argc, char **argv)
             "%s: %*s%s\n"
             "%s: %*s%s\n"
             "%s: %*s%s\n"
-            "\n"
-            "%s: %*s%s\n"
-            "%s: %*s%s\n"
-            "%s: %*s%s\n"
+           /*0123456789ABCDEF*/
+            "Reported:       https://bugzilla.redhat.com/1000000\n"
+            "                https://access.redhat.com/home\n"
+            "                https://bug-report.itos.redhat.com\n"
             "\n"
             "%s: %*sText file, %llu bytes\n"
             "%s: %*sText file, %llu bytes\n",
@@ -139,9 +137,6 @@ int main(int argc, char **argv)
             FILENAME_COUNT,      14 - strlen(FILENAME_COUNT),      "", "0",
             FILENAME_EXECUTABLE, 14 - strlen(FILENAME_EXECUTABLE), "", "/usr/bin/sh",
             FILENAME_PACKAGE,    14 - strlen(FILENAME_PACKAGE),    "", "libreport",
-            "Bugzilla",          14 - strlen("Bugzilla"),          "", "https://bugzilla.redhat.com/1000000",
-            "RHTSupport",        14 - strlen("RHTSupport"),        "", "https://access.redhat.com/home",
-            "ABRT Server",       14 - strlen("ABRT Server"),       "", "https://bug-report.itos.redhat.com",
             FILENAME_BACKTRACE,  14 - strlen(FILENAME_BACKTRACE),  "", (long long unsigned)strlen(backtrace),
             FILENAME_REPORTED_TO,14 - strlen(FILENAME_REPORTED_TO),"", (long long unsigned)strlen(problem_data_get_content_or_NULL(pd, FILENAME_REPORTED_TO))
             );


### PR DESCRIPTION
Implement ideas of Martin Milata:

I'd remove the empty line before the "Bugzilla:" line, it might not be
immediately clear to which problem the line belongs if there's several
problems in the list.

Also, what about something like:

  Reported:       https://bugzilla.redhat.com/1234
                  https://retrace.fedoraproject.org/report/6789

http://post-office.corp.redhat.com/archives/abrt-devel-list/2013-December/msg00171.html

Related to rhbz#1036585

Signed-off-by: Jakub Filak jfilak@redhat.com
