### PR TITLE
remove file options not matching any setting

### DIFF
--- a/tests/configuration_files.at
+++ b/tests/configuration_files.at
@@ -433,12 +433,11 @@ int main(int argc, char **argv)
         assert(!save_conf_file("../../../../../../../../../../../../../../../proc/cpuinfo/foo/blah/file.conf", first));
         assert(!save_conf_file("/proc/cpuinfo/root/file.conf", first));
 
-        //char tmpdir[] = "/tmp/libreport_save_conf_file.XXXXXX";
-        char tmpdir[] = "/tmp";
+        char tmpdir[] = "/tmp/libreport_save_conf_file.XXXXXX";
 
         /* OK, I know that I should not use tmpnam() but I want to check */
         /* that save_conf_file() creates the directory */
-        //assert(tmpnam(tmpdir) != NULL);
+        assert(tmpnam(tmpdir) != NULL);
 
         char *conf_path = concat_path_file(tmpdir, CONF_NAME);
 
@@ -455,15 +454,54 @@ int main(int argc, char **argv)
 
         {
             map_string_t *second = new_map_string();
+
             unlink(CUSTOM_CONF);
             assert(save_conf_file(CUSTOM_CONF, first) || !"Saved at relative path");
             assert(load_conf_file(CUSTOM_CONF, second, 0) || !"Load the saved at relative path");
+
+            unlink(CUSTOM_CONF);
 
             assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the saved configuration");
 
             free_map_string(second);
         }
 
+        free_map_string(first);
+    }
+
+    {   /* Test that keys removed from the conf map are also removed from the corresponding file */
+        map_string_t *first = new_map_string();
+        insert_map_string(first, xstrdup("success"), xstrdup("total"));
+        insert_map_string(first, xstrdup("failure"), xstrdup("none"));
+        insert_map_string(first, xstrdup("effort"), xstrdup("minimal"));
+        insert_map_string(first, xstrdup("state"), xstrdup("done"));
+
+        unlink(CUSTOM_CONF);
+        assert(save_conf_file(CUSTOM_CONF, first) || !"Saved at relative path");
+
+        remove_map_string_item(first, "failure");
+        remove_map_string_item(first, "state");
+        assert(save_conf_file(CUSTOM_CONF, first) || !"Saved updated configuration");
+
+        map_string_t *second = new_map_string();
+        assert(load_conf_file(CUSTOM_CONF, second, 0) || !"Load the updated conf from relative path");
+
+        assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the saved configuration");
+
+        free_map_string(second);
+
+        remove_map_string_item(first, "success");
+        remove_map_string_item(first, "effort");
+        assert(save_conf_file(CUSTOM_CONF, first) || !"Saved empty configuration");
+
+        second = new_map_string();
+        assert(load_conf_file(CUSTOM_CONF, second, 0) || !"Load the empty conf from relative path");
+
+        assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the empty configuration");
+
+        unlink(CUSTOM_CONF);
+
+        free_map_string(second);
         free_map_string(first);
     }
 


### PR DESCRIPTION
The old configuration manipulation functions always created an empty
file and dumped the settings into this file. Therefore the configuration
file always exactly matched the written settings.

The current augeas based implementation does not need to build the
configuration file from scratch and precisely updates only the
configuration options while keeping old file structure.

The current implementation missed the synchronization step which removes
the unused keys. This patches adds the support for it.

Related to #205

Signed-off-by: Jakub Filak jfilak@redhat.com
