### PR TITLE
Bugzilla: pass Bugzilla_token in all relevat XMP RPC calls

### DIFF
--- a/src/lib/abrt_xmlrpc.c
+++ b/src/lib/abrt_xmlrpc.c
@@ -106,6 +106,9 @@ void abrt_xmlrpc_free_client(struct abrt_xmlrpc *ax)
     if (ax->ax_client)
         xmlrpc_client_destroy(ax->ax_client);
 
+    if (ax->ax_session_data && ax->ax_session_data_free)
+        ax->ax_session_data_free(ax->ax_session_data);
+
     free(ax);
 }
 

--- a/src/lib/abrt_xmlrpc.h
+++ b/src/lib/abrt_xmlrpc.h
@@ -30,9 +30,13 @@
 extern "C" {
 #endif
 
+typedef void (*abrt_xmlrpc_destroy_fn)(void *);
+
 struct abrt_xmlrpc {
     xmlrpc_client *ax_client;
     xmlrpc_server_info *ax_server_info;
+    void *ax_session_data;
+    abrt_xmlrpc_destroy_fn ax_session_data_free;
 };
 
 xmlrpc_value *abrt_xmlrpc_array_new(xmlrpc_env *env);

--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -807,40 +807,6 @@ void login(struct abrt_xmlrpc *client, struct bugzilla_struct *rhbz)
     }
 }
 
-static
-xmlrpc_value *rhbz_search_duphash(struct abrt_xmlrpc *ax,
-                        const char *product,
-                        const char *version,
-                        const char *component,
-                        const char *duphash)
-{
-    struct strbuf *query = strbuf_new();
-
-    strbuf_append_strf(query, "ALL whiteboard:\"%s\"", duphash);
-
-    if (product)
-        strbuf_append_strf(query, " product:\"%s\"", product);
-
-    if (version)
-        strbuf_append_strf(query, " version:\"%s\"", version);
-
-    if (component)
-        strbuf_append_strf(query, " component:\"%s\"", component);
-
-    char *s = strbuf_free_nobuf(query);
-    log_debug("search for '%s'", s);
-    xmlrpc_value *search = abrt_xmlrpc_call(ax, "Bug.search", "({s:s})",
-                                         "quicksearch", s);
-    free(s);
-    xmlrpc_value *bugs = rhbz_get_member("bugs", search);
-    xmlrpc_DECREF(search);
-
-    if (!bugs)
-        error_msg_and_die(_("Bug.search(quicksearch) return value did not contain member 'bugs'"));
-
-    return bugs;
-}
-
 int main(int argc, char **argv)
 {
     abrt_init(argv);

--- a/src/plugins/rhbz.h
+++ b/src/plugins/rhbz.h
@@ -112,6 +112,10 @@ struct bug_info *rhbz_find_origin_bug_closed_duplicate(struct abrt_xmlrpc *ax,
                                                        struct bug_info *bi);
 unsigned rhbz_version(struct abrt_xmlrpc *ax);
 
+xmlrpc_value *rhbz_search_duphash(struct abrt_xmlrpc *ax,
+                        const char *product, const char *version, const char *component,
+                        const char *duphash);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Affected functions:
    Bug.update
    Bug.add_attachement
    Bug.add_comment
    Bug.get
    Bug.comments
    Bug.create
    User.logout

Not affected functions:
    Bugzilla.version

Instead of returning a cookie, the User.login call now returns a token
that clients must pass in the Bugzilla_token parameter to subsequent
RPC calls. If the token is not passed, Bugzilla will treat the RPC
call as unauthenticated and will not allow access to non-public data.

See
https://partner-bugzilla.redhat.com/docs/en/html/api/Bugzilla/WebService.html#LOGGING_IN
for more details.

Client scripts that access Red Hat Bugzilla via XML-RPC or JSON-RPC
and use login cookies for authentication must be updated to instead
remember the token received when logging in and pass that token back
to Bugzilla in subsequent RPC calls.

[http://post-office.corp.redhat.com/archives/bugzilla-list/2014-April/msg00005.html]

Signed-off-by: Jakub Filak jfilak@redhat.com
