### PR TITLE
Bugzilla: session parameters for XML RPC calls

### DIFF
--- a/src/lib/abrt_xmlrpc.h
+++ b/src/lib/abrt_xmlrpc.h
@@ -23,6 +23,7 @@
  * include/xmlrpc-c/base.h: typedef int32_t xmlrpc_int32;
  */
 
+#include <glib.h>
 #include <xmlrpc-c/base.h>
 #include <xmlrpc-c/client.h>
 
@@ -35,8 +36,7 @@ typedef void (*abrt_xmlrpc_destroy_fn)(void *);
 struct abrt_xmlrpc {
     xmlrpc_client *ax_client;
     xmlrpc_server_info *ax_server_info;
-    void *ax_session_data;
-    abrt_xmlrpc_destroy_fn ax_session_data_free;
+    GList *ax_session_params;
 };
 
 xmlrpc_value *abrt_xmlrpc_array_new(xmlrpc_env *env);
@@ -49,6 +49,7 @@ void abrt_xmlrpc_params_add_array(xmlrpc_env *env, xmlrpc_value *params, const c
 
 struct abrt_xmlrpc *abrt_xmlrpc_new_client(const char *url, int ssl_verify);
 void abrt_xmlrpc_free_client(struct abrt_xmlrpc *ax);
+void abrt_xmlrpc_client_add_session_param_string(xmlrpc_env *env, struct abrt_xmlrpc *ax, const char *name, const char *value);
 void abrt_xmlrpc_die(xmlrpc_env *env) __attribute__((noreturn));
 void abrt_xmlrpc_error(xmlrpc_env *env);
 


### PR DESCRIPTION
The session parameters are added to every XMLRPC call.

abrt_xmlrpc_call*() functions expected formatting string in form of
"({...})" for some good but unknown reason. Since now, the functions
expects formatting string without the outer brackets.

() - means empty array (allowed in xmlrpc-c)
{} - means empty structure (allowed in xmlrpc-c)

Signed-off-by: Jakub Filak jfilak@redhat.com
