### PR TITLE
configure: Support cross compiling with python3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,10 +161,13 @@ PYTHON_LIBS=`python-config --libs 2> /dev/null`
 PYTHON3_CFLAGS=`python3-config --cflags 2> /dev/null`
 PYTHON3_LIBS=`python3-config --libs 2> /dev/null`
 
+AC_SUBST([PYTHON3_PREFIX], ['${prefix}'])
+AC_SUBST([PYTHON3_EXEC_PREFIX], ['${exec_prefix}'])
+
 PYTHON3_DIR=`$PYTHON3 -c "import distutils.sysconfig; \
-    print(distutils.sysconfig.get_python_lib(0,0))"`
+    print(distutils.sysconfig.get_python_lib(0,0,prefix='$PYTHON3_PREFIX'))"`
 PYTHON3_EXECDIR=`$PYTHON3 -c "import distutils.sysconfig; \
-    print(distutils.sysconfig.get_python_lib(1,0))"`
+    print(distutils.sysconfig.get_python_lib(1,0,prefix='$PYTHON3_EXEC_PREFIX'))"`
 
 AC_SUBST(PYTHON_CFLAGS)
 AC_SUBST(PYTHON_LIBS)


### PR DESCRIPTION
$prefix needs to be honored because the build python path may be
different than the target prefix. This is consistent with what the
AM_PATH_PYTHON macro does internally.
