### PR TITLE
mailx: improve notification e-mail format

### DIFF
--- a/src/plugins/mailx_event.conf
+++ b/src/plugins/mailx_event.conf
@@ -1,5 +1,15 @@
-EVENT=notify reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
+EVENT=notify
+    # do not rely on the default config nor on the config file
+    Mailx_Subject="[abrt] a crash has been detected" \
+    Mailx_EmailFrom="ABRT Daemon <DoNotReply>" \
+    Mailx_EmailTo="root@localhost" \
+    reporter-mailx --notify-only
 
-EVENT=notify-dup reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
+EVENT=notify-dup
+    # do not rely on the default config nor on the config file
+    Mailx_Subject="[abrt] a crash has been detected again" \
+    Mailx_EmailFrom="ABRT Daemon <DoNotReply>" \
+    Mailx_EmailTo="root@localhost" \
+    reporter-mailx --notify-only
 
 EVENT=report_Mailx      reporter-mailx


### PR DESCRIPTION
Make it more obvious who is the sender. Ensure that the notify*
configuration won't be overwritten by the configuration changes of the
mailx plugin. Distinguish between e-mails for a new crash and a new
occurrence.

The notify\* configuration could be stored in a new configuration file
but such an approach seems a bit overengineered.

Resolves: rhbz#1093375

Signed-off-by: Jakub Filak jfilak@redhat.com
