### PR TITLE
augeas: exclude bugzilla format configurations

### DIFF
--- a/augeas/libreport.aug
+++ b/augeas/libreport.aug
@@ -24,6 +24,7 @@ module Libreport =
                . (incl (Sys.getenv("HOME") . "/.config/abrt/settings/*"))
                . (incl (Sys.getenv("XDG_CACHE_HOME") . "/abrt/events/*"))
                . (incl (Sys.getenv("HOME") . "/.cache/abrt/events/*"))
+               . (excl "/etc/libreport/plugins/bugzilla_format*")
                . Util.stdexcl
 
     let xfm = transform lns filter


### PR DESCRIPTION
How to test this pull request:

Output of `echo 'print /augeas//error' | augtool` must not contain any line containing `libreport`, whilst output of `echo 'print /files/etc/libreport/' | augtool` must remain unchanged.

See http://augeas.net/index.html for more details.
