### PR TITLE
Prevent duplicate values for CODE_* fields being logged to journal.

### DIFF
--- a/src/lib/logging.c
+++ b/src/lib/logging.c
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2010  ABRT team
-    Copyright (C) 2010  RedHat Inc
+    Copyright (C) 2010, 2014  RedHat Inc
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -17,6 +17,8 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #include <syslog.h>
+/* Suppress automatic CODE_* fields as we handle those here */
+#define SD_JOURNAL_SUPPRESS_LOCATION
 #include <systemd/sd-journal.h>
 #include "internal_libreport.h"
 


### PR DESCRIPTION
As code location fields CODE_FILE, CODE_LINE, and CODE_FUNC are
handled by libreport, we do not want the automatic values supplied by
the sd_journal API.

Without suppressing these, both the actual log event source and the
call to sd_journal_send() are logged. For example:

```
[...]
    "CODE_FILE" : [ "logging.c", "abrtd.c" ],
    "CODE_LINE" : [ "143", "629" ],
    "CODE_FUNC" : [ "log_handler", "main" ],
    "MESSAGE" : "Init complete, entering main loop",
[...]
```
