### PR TITLE
anaconda: mark anaconda-tb as editable file and remove rootpw lines

### DIFF
--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -1185,7 +1185,7 @@ static void append_item_to_ls_details(gpointer name, gpointer value, gpointer da
     //FIXME: use the human-readable problem_item_format(item) instead of item->content.
     if (item->flags & CD_FLAG_TXT)
     {
-        if (item->flags & CD_FLAG_ISEDITABLE)
+        if (item->flags & CD_FLAG_ISEDITABLE && strcmp(name, FILENAME_ANACONDA_TB) != 0)
         {
             GtkWidget *tab_lbl = gtk_label_new((char *)name);
             GtkWidget *tev = gtk_text_view_new();

--- a/src/include/internal_libreport.h
+++ b/src/include/internal_libreport.h
@@ -913,6 +913,7 @@ struct dump_dir *open_directory_for_writing(
 /* File names related to Anaconda problems
  */
 #define FILENAME_KICKSTART_CFG "ks.cfg"
+#define FILENAME_ANACONDA_TB   "anaconda-tb"
 
 // Not stored as files, added "on the fly":
 #define CD_DUMPDIR            "Directory"

--- a/src/lib/problem_data.c
+++ b/src/lib/problem_data.c
@@ -262,6 +262,7 @@ static const char *const editable_files[] = {
     //FILENAME_REPORTED_TO,
     //FILENAME_EVENT_LOG  ,
     FILENAME_KICKSTART_CFG,
+    FILENAME_ANACONDA_TB,
     NULL
 };
 static bool is_editable_file(const char *file_name)

--- a/src/plugins/bugzilla_anaconda_event.conf
+++ b/src/plugins/bugzilla_anaconda_event.conf
@@ -1,6 +1,6 @@
 EVENT=report_Bugzilla component=anaconda
 	# remove sensitive information from the sensitive files
-	for sf in backtrace ks.cfg; do
+	for sf in backtrace ks.cfg anaconda-tb; do
 		if [ -f $sf ]; then
 			# blindly remove entire line
 			# filing a less usable bug is surely better than publishing passwords


### PR DESCRIPTION
anaconda-tb file contains the main information about Anaconda problems.

report-gtk won't be highlighting forbidden words, because anaconda-tb
contains many false positives words as the file is mainly composed of
log outputs.

Related to #1041558

Signed-off-by: Jakub Filak jfilak@redhat.com
