### PR TITLE
gui: ignore (a|A)ccesib(ility|le) words

### DIFF
--- a/src/gui-wizard-gtk/ignored_words.conf
+++ b/src/gui-wizard-gtk/ignored_words.conf
@@ -2,6 +2,10 @@ access on a process.
 access on the
 accesses on a process.
 accesses on the
+accessibility
+Accessibility
+accessible
+Accessible
 accountsservice
 account_for_vscrollbar
 AccountsService

--- a/src/gui-wizard-gtk/ignored_words.conf
+++ b/src/gui-wizard-gtk/ignored_words.conf
@@ -10,11 +10,41 @@ accountsservice
 account_for_vscrollbar
 AccountsService
 Cannot access memory
+EventKey
+event_key
 gnome-ssh-askpass
+keyboard
+KEYBOARD
+keymap
+KEYMAP
+keyDown
+KeyDown
+KEYDOWN
+KEY_Down
+keyring
+KEYRING
+KeyUp
+KEYUP
+KeyEvent
+key_event
+KEY_EVENT
+keypress
+KeyPress
+key_press
+KEY_PRESS
+key_release
+KEY_RELEASE
+KeyValuePair
+KeyValuePairKeyExtractor
+keyup
+KEYUP
+ksshaskpass
 libpciaccess.so
 libsecret
 login.so
-ksshaskpass
+libkeyutils
+PassOwnPtr
+PassRefPtr
 This access was not denied.
 # not considered sensitive
 USER=


### PR DESCRIPTION
I am reluctant to use single "accesib" because I am afraid of false
negative results.

Related: rhbz#1175720

Signed-off-by: Jakub Filak <jfilak@redhat.com>