### PR TITLE
ignored words: ignore lxqt-openssh-askpass

### DIFF
--- a/src/gui-wizard-gtk/ignored_words.conf
+++ b/src/gui-wizard-gtk/ignored_words.conf
@@ -49,6 +49,7 @@ libpciaccess.so
 libsecret
 login.so
 libkeyutils
+lxqt-openssh-askpass
 PassOwnPtr
 PassRefPtr
 passed


### PR DESCRIPTION
This was seen in the environment:
SSH_ASKPASS=/usr/libexec/openssh/lxqt-openssh-askpass