### PR TITLE
Python 3 compatibility

### DIFF
--- a/src/client-python/debuginfo.py
+++ b/src/client-python/debuginfo.py
@@ -88,8 +88,8 @@ def unpack_rpm(package_file_name, files, tmp_dir, destdir, keeprpm, exact_files=
     unpacked_cpio_path = tmp_dir + "/unpacked.cpio"
     try:
         unpacked_cpio = open(unpacked_cpio_path, 'wb')
-    except IOError, ex:
-        print _("Can't write to '{0}': {1}").format(unpacked_cpio_path, ex)
+    except IOError as ex:
+        print(_("Can't write to '{0}': {1}").format(unpacked_cpio_path, ex))
         return RETURN_FAILURE
 
     rpm2cpio = Popen(["rpm2cpio", package_full_path],
@@ -104,7 +104,7 @@ def unpack_rpm(package_file_name, files, tmp_dir, destdir, keeprpm, exact_files=
             os.unlink(package_full_path)
     else:
         unpacked_cpio.close()
-        print _("Can't extract package '{0}'").format(package_full_path)
+        print(_("Can't extract package '{0}'").format(package_full_path))
         return RETURN_FAILURE
 
     # close the file
@@ -112,7 +112,7 @@ def unpack_rpm(package_file_name, files, tmp_dir, destdir, keeprpm, exact_files=
     # and open it for reading
     unpacked_cpio = open(unpacked_cpio_path, 'rb')
 
-    print _("Caching files from {0} made from {1}").format("unpacked.cpio", package_file_name)
+    print(_("Caching files from {0} made from {1}").format("unpacked.cpio", package_file_name))
 
     file_patterns = ""
     cpio_args = ["cpio", "-idu"]
@@ -131,7 +131,7 @@ def unpack_rpm(package_file_name, files, tmp_dir, destdir, keeprpm, exact_files=
         #print _("Removing temporary cpio file")
         os.unlink(unpacked_cpio_path)
     else:
-        print _("Can't extract files from '{0}'").format(unpacked_cpio_path)
+        print(_("Can't extract files from '{0}'").format(unpacked_cpio_path))
         return RETURN_FAILURE
 
 def clean_up():
@@ -142,7 +142,7 @@ def clean_up():
     if TMPDIR:
         try:
             shutil.rmtree(TMPDIR)
-        except OSError, ex:
+        except OSError as ex:
             if ex.errno != errno.ENOENT:
                 error_msg(_("Can't remove '{0}': {1}").format(TMPDIR, ex))
 
@@ -191,7 +191,7 @@ class MyDownloadCallback(DownloadBaseCallback):
                 #print (_("Downloading (%i of %i) %s: %3u%%")
                 #        % (self.downloaded_pkgs + 1, self.total_pkgs, name, pct)
                 #)
-                print (_("Downloading ({0} of {1}) {2}: {3:3}%").format(
+                print(_("Downloading ({0} of {1}) {2}: {3:3}%").format(
                         self.downloaded_pkgs + 1, self.total_pkgs, name, pct
                         )
                 )
@@ -202,7 +202,7 @@ class MyDownloadCallback(DownloadBaseCallback):
                 self.last_time = t
             # update only every 5 seconds
             if pct == 100 or self.last_time > t or t - self.last_time >= 5:
-                print (_("Downloading ({0} of {1}) {2}: {3:3}%").format(
+                print(_("Downloading ({0} of {1}) {2}: {3:3}%").format(
                         self.downloaded_pkgs + 1, self.total_pkgs, name, pct
                         )
                 )
@@ -217,8 +217,8 @@ def downloadErrorCallback(callBackObj):
     A callback function for mirror errors.
     """
 
-    print _("Problem '{0!s}' occured while downloading from mirror: '{1!s}'. Trying next one").format(
-        callBackObj.exception, callBackObj.mirror)
+    print(_("Problem '{0!s}' occured while downloading from mirror: '{1!s}'. Trying next one").format(
+        callBackObj.exception, callBackObj.mirror))
     # explanation of the return value can be found here:
     # /usr/lib/python2.7/site-packages/urlgrabber/mirror.py
     return {'fail':0}
@@ -243,15 +243,15 @@ class DebugInfoDownload(YumBase):
         #self.conf.cache = os.geteuid() != 0
         # Setup yum (Ts, RPM db, Repo & Sack)
         # doConfigSetup() takes some time, let user know what we are doing
-        print _("Initializing yum")
+        print(_("Initializing yum"))
         try:
             # Saw this exception here:
             # cannot open Packages index using db3 - Permission denied (13)
             # yum.Errors.YumBaseError: Error: rpmdb open failed
             self.doConfigSetup()
-        except YumBaseError, ex:
+        except YumBaseError as ex:
             self.unmute_stdout()
-            print _("Error initializing yum (YumBase.doConfigSetup): '{0!s}'").format(ex)
+            print(_("Error initializing yum (YumBase.doConfigSetup): '{0!s}'").format(ex))
             #return 1 - can't do this in constructor
             exit(1)
         self.unmute_stdout()
@@ -274,21 +274,21 @@ class DebugInfoDownload(YumBase):
             if self.old_stdout != -1:
                 sys.stdout = self.old_stdout
             else:
-                print "ERR: unmute called without mute?"
+                print("ERR: unmute called without mute?")
 
     @ensure_abrt_uid
     def setup_tmp_dirs(self):
         if not os.path.exists(self.tmpdir):
             try:
                 os.makedirs(self.tmpdir)
-            except OSError, ex:
-                print "Can't create tmpdir: %s" % ex
+            except OSError as ex:
+                print("Can't create tmpdir: %s" % ex)
                 return RETURN_FAILURE
         if not os.path.exists(self.cachedir):
             try:
                 os.makedirs(self.cachedir)
-            except OSError, ex:
-                print "Can't create cachedir: %s" % ex
+            except OSError as ex:
+                print("Can't create cachedir: %s" % ex)
                 return RETURN_FAILURE
 
         return RETURN_OK
@@ -322,7 +322,7 @@ class DebugInfoDownload(YumBase):
 
         # make yumdownloader work as non root user
         if not self.setCacheDir():
-            print _("Error: can't make cachedir, exiting")
+            print(_("Error: can't make cachedir, exiting"))
             return RETURN_FAILURE
 
         # disable all not needed
@@ -330,11 +330,11 @@ class DebugInfoDownload(YumBase):
             try:
                 repo.close()
                 self.repos.disableRepo(repo.id)
-            except YumBaseError, ex:
-                print _("Can't disable repository '{0!s}': {1!s}").format(repo.id, str(ex))
+            except YumBaseError as ex:
+                print(_("Can't disable repository '{0!s}': {1!s}").format(repo.id, str(ex)))
 
         # This takes some time, let user know what we are doing
-        print _("Setting up yum repositories")
+        print(_("Setting up yum repositories"))
         # setting-up repos one-by-one, so we can skip the broken ones...
         # this helps when users are using 3rd party repos like rpmfusion
         # in rawhide it results in: Can't find valid base url...
@@ -349,22 +349,22 @@ class DebugInfoDownload(YumBase):
                 # which causes artifacts on output
                 try:
                     setattr(r, "_async", False)
-                except (NameError, AttributeError), ex:
-                    print ex
-                    print _("Can't disable async download, the output might contain artifacts!")
-            except YumBaseError, ex:
-                print _("Can't setup {0}: {1}, disabling").format(r.id, ex)
+                except (NameError, AttributeError) as ex:
+                    print(ex)
+                    print(_("Can't disable async download, the output might contain artifacts!"))
+            except YumBaseError as ex:
+                print(_("Can't setup {0}: {1}, disabling").format(r.id, ex))
                 self.repos.disableRepo(r.id)
 
         # This is somewhat "magic", it unpacks the metadata making it usable.
         # Looks like this is the moment when yum talks to remote servers,
         # which takes time (sometimes minutes), let user know why
         # we have "paused":
-        print _("Looking for needed packages in repositories")
+        print(_("Looking for needed packages in repositories"))
         try:
             self.repos.populateSack(mdtype='metadata', cacheonly=1)
-        except YumBaseError, ex:
-            print _("Error retrieving metadata: '{0!s}'").format(ex)
+        except YumBaseError as ex:
+            print(_("Error retrieving metadata: '{0!s}'").format(ex))
             #we don't want to die here, some metadata might be already retrieved
             # so there is a chance we already have what we need
             #return 1
@@ -376,8 +376,8 @@ class DebugInfoDownload(YumBase):
             # repodata/7e6632b82c91a2e88a66ad848e231f14c48259cbf3a1c3e992a77b1fc0e9d2f6-filelists.sqlite.bz2
             # from fedora-debuginfo: [Errno 256] No more mirrors to try.
             self.repos.populateSack(mdtype='filelists', cacheonly=1)
-        except YumBaseError, ex:
-            print _("Error retrieving filelists: '{0!s}'").format(ex)
+        except YumBaseError as ex:
+            print(_("Error retrieving filelists: '{0!s}'").format(ex))
             # we don't want to die here, some repos might be already processed
             # so there is a chance we already have what we need
             #return 1
@@ -394,7 +394,7 @@ class DebugInfoDownload(YumBase):
             # sometimes one file is provided by more rpms, we can use either of
             # them, so let's use the first match
             if pkg:
-                if pkg[0] in package_files_dict.keys():
+                if pkg[0] in package_files_dict:
                     package_files_dict[pkg[0]].append(debuginfo_path)
                 else:
                     package_files_dict[pkg[0]] = [debuginfo_path]
@@ -413,15 +413,15 @@ class DebugInfoDownload(YumBase):
         self.repos.setMirrorFailureCallback(downloadErrorCallback)
 
         if verbose != 0 or len(not_found) != 0:
-            print _("Can't find packages for {0} debuginfo files").format(len(not_found))
+            print(_("Can't find packages for {0} debuginfo files").format(len(not_found)))
         if verbose != 0 or total_pkgs != 0:
-            print _("Packages to download: {0}").format(total_pkgs)
+            print(_("Packages to download: {0}").format(total_pkgs))
             question = _("Downloading {0:.2f}Mb, installed size: {1:.2f}Mb. Continue?").format(
                          todownload_size / (1024*1024),
                          installed_size / (1024*1024)
                         )
             if self.noninteractive == False and not ask_yes_no(question):
-                print _("Download cancelled by user")
+                print(_("Download cancelled by user"))
                 return RETURN_CANCEL_BY_USER
             # set up tmp and cache dirs so that we can check free space in both
             retval = self.setup_tmp_dirs()
@@ -435,7 +435,7 @@ class DebugInfoDownload(YumBase):
                              " ({1:.2f}Mb left). Continue?").format(
                     self.tmpdir, tmp_space)
                 if not self.noninteractive and not ask_yes_no(question):
-                    print _("Download cancelled by user")
+                    print(_("Download cancelled by user"))
                     return RETURN_CANCEL_BY_USER
             res = os.statvfs(self.cachedir)
             cache_space = float(res.f_bsize * res.f_bavail) / (1024*1024)
@@ -444,7 +444,7 @@ class DebugInfoDownload(YumBase):
                              "'{0}' ({1:.2f}Mb left). Continue?").format(
                     self.cachedir, cache_space)
                 if not self.noninteractive and not ask_yes_no(question):
-                    print _("Download cancelled by user")
+                    print(_("Download cancelled by user"))
                     return RETURN_CANCEL_BY_USER
 
         for pkg, files in package_files_dict.items():
@@ -465,8 +465,8 @@ class DebugInfoDownload(YumBase):
                 log2("copying from local repo: %s", remote)
                 try:
                     shutil.copy(pkg_path, self.tmpdir)
-                except OSError, ex:
-                    print _("Cannot copy file '{0}': {1}").format(pkg_path, ex)
+                except OSError as ex:
+                    print(_("Cannot copy file '{0}': {1}").format(pkg_path, ex))
                     continue
             else:
                 # pkg is in a remote repo, we need to download it to tmpdir
@@ -484,14 +484,14 @@ class DebugInfoDownload(YumBase):
                     os.unlink(self.tmpdir + "/" + package_file_name)
                 except OSError:
                     pass
-                print (_("Downloading package {0} failed").format(pkg))
+                print(_("Downloading package {0} failed").format(pkg))
             else:
                 unpack_result = unpack_rpm(package_file_name, files, self.tmpdir,
                                            self.cachedir, self.keeprpms,
                                            exact_files=download_exact_files)
                 if unpack_result == RETURN_FAILURE:
                     # recursively delete the temp dir on failure
-                    print _("Unpacking failed, aborting download...")
+                    print(_("Unpacking failed, aborting download..."))
                     clean_up()
                     return RETURN_FAILURE
 
@@ -501,7 +501,7 @@ class DebugInfoDownload(YumBase):
             # Was: "All downloaded packages have been extracted, removing..."
             # but it was appearing even if no packages were in fact extracted
             # (say, when there was one package, and it has download error).
-            print (_("Removing {0}").format(self.tmpdir))
+            print(_("Removing {0}").format(self.tmpdir))
             try:
                 os.rmdir(self.tmpdir)
             except OSError:

--- a/tests/gtk-meh-test.py
+++ b/tests/gtk-meh-test.py
@@ -22,10 +22,10 @@ handler = ExceptionHandler(config, intf, ReverseExceptionDump)
 handler.install(None)
 
 
-print "handler set up, about to divide by zero"
+print("handler set up, about to divide by zero")
 
 zero = 0
-print 1 / zero
+print(1 / zero)
 
-print "should have crashed"
+print("should have crashed")
 


### PR DESCRIPTION
This patch just applies what 2to3 found so that the scripts can run both
under python 2 and python 3. More work is needed to fully switch to
python 3.

Related to #172, rhbz#1014684.

Signed-off-by: Martin Milata <mmilata@redhat.com>