### PR TITLE
require dnf instead of yum in f22+

### DIFF
--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -95,7 +95,11 @@ Summary: Python bindings for report-libs
 # Is group correct here? -
 Group: System Environment/Libraries
 Requires: libreport = %{version}-%{release}
+%if 0%{?fedora} >= 22
+Requires: dnf
+%else
 Requires: yum
+%endif
 Provides: report = 0:0.23-1
 Obsoletes: report < 0:0.23-1
 # in report the rhtsupport is in the main package, so we need to install it too


### PR DESCRIPTION
plus some magic inside to use dnfdebuginfo.py

Hi, we want to get rid of yum dependency in core f22 image. Then do the new build for f22, please. Thanks.