### PR TITLE
RHEL7: RHTSupport: include reported_to in Support cases

### DIFF
--- a/src/plugins/report_RHTSupport.xml.in
+++ b/src/plugins/report_RHTSupport.xml.in
@@ -4,7 +4,7 @@
     <_description>Report to Red Hat support</_description>
 
     <requires-items>package</requires-items>
-    <exclude-items-by-default>count,event_log,reported_to,vmcore</exclude-items-by-default>
+    <exclude-items-by-default>count,event_log,vmcore</exclude-items-by-default>
     <exclude-items-always></exclude-items-always>
     <exclude-binary-items>no</exclude-binary-items>
     <include-items-by-default></include-items-by-default>


### PR DESCRIPTION
We want to provide GSS with an URL to ABRT server.

Related to rhbz#1197108

Signed-off-by: Jakub Filak <jfilak@redhat.com>