### PR TITLE
Use a dgettext function returning strings instead of bytes

### DIFF
--- a/src/client-python/reportclient/__init__.py
+++ b/src/client-python/reportclient/__init__.py
@@ -36,7 +36,7 @@ GETTEXT_PROGNAME = "libreport"
 import locale
 import gettext
 
-_ = lambda x: gettext.ldgettext(GETTEXT_PROGNAME, x)
+_ = lambda x: gettext.dgettext(GETTEXT_PROGNAME, x)
 
 def init_gettext():
     try:


### PR DESCRIPTION
ldgettext returns an array of bytes in system encoding and this, together with
Python3, causes troubles.

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>