### PR TITLE
reporter-bugzilla: search duplicate bugs within all products

### DIFF
--- a/doc/reporter-bugzilla.txt
+++ b/doc/reporter-bugzilla.txt
@@ -19,7 +19,7 @@ Or:
 
 Or:
 
-'reporter-bugzilla' [-v] [-c CONFFILE]... -h DUPHASH
+'reporter-bugzilla' [-v] [-c CONFFILE]... -h DUPHASH [-p[PRODUCT]]
 
 DESCRIPTION
 -----------
@@ -157,6 +157,12 @@ OPTIONS
 -h::
 --duphash DUPHASH::
    Search in Bugzilla by abrt's DUPHASH and print BUG_ID.
+
+-p[PRODUCT], --product[PRODUCT]::
+   Specify a Bugzilla's product (ignored without -h). Default: "Fedora". If only -p
+   or --product without PRODUCT is presented either value from environment
+   variable 'Bugzilla_Product' in the first place or 'REDHAT_BUGZILLA_PRODUCT'
+   value from /etc/os-release is used.
 
 -g::
 --group GROUP::

--- a/src/include/dump_dir.h
+++ b/src/include/dump_dir.h
@@ -161,6 +161,8 @@ void dd_sanitize_mode_and_owner(struct dump_dir *dd);
 DIR *dd_init_next_file(struct dump_dir *dd);
 int dd_get_next_file(struct dump_dir *dd, char **short_name, char **full_name);
 
+char *load_text_file(const char *path, unsigned flags);
+
 char* dd_load_text_ext(const struct dump_dir *dd, const char *name, unsigned flags);
 char* dd_load_text(const struct dump_dir *dd, const char *name);
 int dd_load_int32(const struct dump_dir *dd, const char *name, int32_t *value);

--- a/src/lib/dump_dir.c
+++ b/src/lib/dump_dir.c
@@ -109,7 +109,7 @@ uid_t dd_g_super_user_uid = 0;
 gid_t dd_g_fs_group_gid = (gid_t)-1;
 
 
-static char *load_text_file(const char *path, unsigned flags);
+char *load_text_file(const char *path, unsigned flags);
 static char *load_text_file_at(int dir_fd, const char *name, unsigned flags);
 static void copy_file_from_chroot(struct dump_dir* dd, const char *name,
         const char *chroot_dir, const char *file_path);
@@ -1691,7 +1691,7 @@ static char *load_text_file_at(int dir_fd, const char *name, unsigned flags)
     return load_text_from_file_descriptor(fd, name, flags);
 }
 
-static char *load_text_file(const char *path, unsigned flags)
+char *load_text_file(const char *path, unsigned flags)
 {
     const int fd = open(path, O_RDONLY | ((flags & DD_OPEN_FOLLOW) ? 0 : O_NOFOLLOW));
     return load_text_from_file_descriptor(fd, path, flags);


### PR DESCRIPTION
reporter-bugzila -h DUPHASH searched duplicate bug only within Fedora products.
This commit makes the feature usable even on RHEL.

Related to rhbz#1268218

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>