### PR TITLE
add possibility to configure SSH keys

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -60,11 +60,13 @@ MAN5_TXT += report_rhel_bugzilla.conf.txt
 MAN5_TXT += report_logger.conf.txt
 MAN5_TXT += report_mailx.conf.txt
 MAN5_TXT += report_uploader.conf.txt
+MAN5_TXT += report_Uploader.conf.txt
 MAN5_TXT += report_CentOSBugTracker.conf.txt
 MAN5_TXT += rhtsupport.conf.txt
 MAN5_TXT += rhtsupport_event.conf.txt
 MAN5_TXT += uploader_event.conf.txt
 MAN5_TXT += ureport.conf.txt
+MAN5_TXT += upload.conf.txt
 
 MAN5_PREFORMATTED =
 MAN5_PREFORMATTED += centos_report_event.conf.5

--- a/doc/report_Uploader.conf.txt
+++ b/doc/report_Uploader.conf.txt
@@ -1,0 +1,46 @@
+report_Uploader.conf(5)
+======================
+
+NAME
+----
+report_Uploader.conf - libreport's configuration file for 'report_Uploader' events.
+
+DESCRIPTION
+-----------
+This configuration file contains values for options defined in
+/usr/share/libreport/events/report_Uploader.xml and is placed in
+/etc/libreport/events/report_Uploader.conf.
+
+Configuration file lines should have 'PARAM = VALUE' format. The parameters are:
+
+'Upload_URL'::
+    The URL where should be the tarball uploaded
+
+'Upload_Username'::
+    User name for the upload URL
+
+'Upload_Password'::
+    Password for the upload URL
+
+'Upload_SSHPublicKey'::
+    Path to SSH public key file
+
+'Upload_SSHPrivateKey'::
+    Path to SSH private key file
+
+'http_proxy'::
+    The proxy server to use for HTTP
+
+'HTTPS_PROXY'::
+    The proxy server to use for HTTPS
+
+'FTP_PROXY'::
+    The proxy server to use for FTP
+
+SEE ALSO
+--------
+report_event.conf(5), reporter-upload(1)
+
+AUTHOR
+------
+* ABRT team

--- a/doc/reporter-upload.txt
+++ b/doc/reporter-upload.txt
@@ -7,7 +7,7 @@ reporter-upload - Uploads compressed tarball of problem directory.
 
 SYNOPSIS
 --------
-'reporter-upload' [-c CONFFILE]... [-d DIR] [-u URL]
+'reporter-upload' [-c CONFFILE]... [-d DIR] [-u URL] [-b FILE] [-r FILE]
 
 DESCRIPTION
 -----------
@@ -23,6 +23,12 @@ The options are:
 
 'URL'::
         The URL where tarball should be uploaded.
+
+'SSHPublicKey'::
+        The SSH public key.
+
+'SSHPrivateKey'::
+        The SSH private key.
 
 Integration with ABRT events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -60,6 +66,13 @@ OPTIONS
    If URL ends with a slash, the archive name will be generated and appended
    to URL; otherwise, URL will be used as full file name.
 
+-b::
+--pubkey FILE::
+   Set SSH public key file.
+
+-r::
+--key FILE::
+   Set SSH private key file.
 
 ENVIRONMENT VARIABLES
 ---------------------
@@ -74,6 +87,12 @@ the configuration file.
 
 'Upload_Password'::
    Password for the upload URL
+
+'Upload_SSHPublicKey'::
+   Path to SSH public key file
+
+'Upload_SSHPrivateKey'::
+   Path to SSH private key file
 
 FILES
 -----

--- a/doc/upload.conf.txt
+++ b/doc/upload.conf.txt
@@ -1,0 +1,18 @@
+upload.conf(5)
+===============
+
+NAME
+----
+upload.conf - configuration file for libreport.
+
+DESCRIPTION
+-----------
+This configuration file provides default configuration for 'reporter-upload'.
+
+SEE ALSO
+--------
+reporter-upload(1)
+
+AUTHOR
+------
+* ABRT team

--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -686,8 +686,11 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{_datadir}/%{name}/workflows/workflow_UploadCCpp.xml
 %config(noreplace) %{_sysconfdir}/libreport/plugins/upload.conf
 %{_datadir}/%{name}/conf.d/plugins/upload.conf
+%{_mandir}/man5/upload.conf.5.*
 %config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_uploader.conf
 %{_mandir}/man5/report_uploader.conf.5.*
+%config(noreplace) %{_sysconfdir}/libreport/events/report_Uploader.conf
+%{_mandir}/man5/report_Uploader.conf.5.*
 
 %if 0%{?fedora}
 %files fedora

--- a/src/include/libreport_curl.h
+++ b/src/include/libreport_curl.h
@@ -38,6 +38,9 @@ typedef struct post_state {
     const char  *client_cert_path;
     const char  *client_key_path;
     const char  *cert_authority_cert_path;
+    /* SSH key files */
+    const char  *client_ssh_public_keyfile;
+    const char  *client_ssh_private_keyfile;
     /* Results of POST transaction: */
     int         http_resp_code;
     /* cast from CURLcode enum.

--- a/src/lib/curl.c
+++ b/src/lib/curl.c
@@ -351,6 +351,12 @@ post(post_state_t *state,
         xcurl_easy_setopt_ptr(handle, CURLOPT_PASSWORD, (state->password ? state->password : ""));
     }
 
+    /* set SSH public and private keyfile if configured */
+    if (state->client_ssh_public_keyfile)
+        xcurl_easy_setopt_ptr(handle, CURLOPT_SSH_PUBLIC_KEYFILE, state->client_ssh_public_keyfile);
+    if (state->client_ssh_private_keyfile)
+        xcurl_easy_setopt_ptr(handle, CURLOPT_SSH_PRIVATE_KEYFILE, state->client_ssh_private_keyfile);
+
     if (data_size != POST_DATA_FROMFILE_PUT && data_size != POST_DATA_GET)
     {
         // Do a HTTP POST. This also makes curl use

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -87,7 +87,8 @@ dist_events_DATA = $(reporters_events) \
     report_EmergencyAnalysis.xml
 
 dist_eventsconf_DATA = $(reporters_events_conf) \
-    report_Logger.conf
+    report_Logger.conf \
+    report_Uploader.conf
 
 @INTLTOOL_XML_RULE@
 

--- a/src/plugins/report_Uploader.conf
+++ b/src/plugins/report_Uploader.conf
@@ -1,0 +1,23 @@
+# The URL where should be the tarball uploaded
+#Upload_URL =
+
+# User name for the upload URL
+#Upload_Username =
+
+# Password for the upload URL
+#Upload_Password =
+
+# Path to SSH public key file
+#Upload_SSHPublicKey =
+
+# Path to SSH private key file
+#Upload_SSHPrivateKey =
+
+# The proxy server to use for HTTP
+#http_proxy =
+
+# The proxy server to use for HTTPS
+#HTTPS_PROXY =
+
+# The proxy server to use for FTP
+#FTP_PROXY =

--- a/src/plugins/report_Uploader.xml.in
+++ b/src/plugins/report_Uploader.xml.in
@@ -45,6 +45,16 @@
                 <allow-empty>yes</allow-empty>
                 <_note-html>Sets the proxy server to use for FTP</_note-html>
             </option>
+            <option type="text" name="Upload_SSHPublicKey">
+                <_label>SSH Public key file</_label>
+                <allow-empty>yes</allow-empty>
+                <_note-html>Use this field to specify SSH public keyfile</_note-html>
+            </option>
+            <option type="text" name="Upload_SSHPrivateKey">
+                <_label>SSH Private key file</_label>
+                <allow-empty>yes</allow-empty>
+                <_note-html>Use this field to specify SSH private keyfile</_note-html>
+            </option>
         </advanced-options>
     </options>
 </event>

--- a/src/plugins/report_Uploader.xml.in
+++ b/src/plugins/report_Uploader.xml.in
@@ -19,17 +19,17 @@
             <_note-html>Examples:&#xA;ftp://[user[:pass]@]host/dir/[file.tar.gz]&#xA;scp://[user[:pass]@]host/dir/[file.tar.gz]&#xA;file:///dir/[file.tar.gz]</_note-html>
             <default-value></default-value>
         </option>
-        <option type="text" name="Upload_Username">
-            <_label>User name</_label>
-            <allow-empty>yes</allow-empty>
-            <_description>Use this field if you do not want to have user name in URL</_description>
-        </option>
-        <option type="password" name="Upload_Password">
-            <_label>Password</_label>
-            <allow-empty>yes</allow-empty>
-            <_description>Use this field if you do not want to have password in URL</_description>
-        </option>
         <advanced-options>
+            <option type="text" name="Upload_Username">
+                <_label>User name</_label>
+                <allow-empty>yes</allow-empty>
+                <_description>Use this field if you do not want to have user name in URL</_description>
+            </option>
+            <option type="password" name="Upload_Password">
+                <_label>Password</_label>
+                <allow-empty>yes</allow-empty>
+                <_description>Use this field if you do not want to have password in URL</_description>
+            </option>
             <option type="text" name="http_proxy">
                 <_label>HTTP Proxy</_label>
                 <allow-empty>yes</allow-empty>

--- a/src/plugins/report_Uploader.xml.in
+++ b/src/plugins/report_Uploader.xml.in
@@ -21,12 +21,12 @@
         </option>
         <option type="text" name="Upload_Username">
             <_label>User name</_label>
-            <allow-empty>no</allow-empty>
+            <allow-empty>yes</allow-empty>
             <_description>Use this field if you do not want to have user name in URL</_description>
         </option>
         <option type="password" name="Upload_Password">
             <_label>Password</_label>
-            <allow-empty>no</allow-empty>
+            <allow-empty>yes</allow-empty>
             <_description>Use this field if you do not want to have password in URL</_description>
         </option>
         <advanced-options>

--- a/src/plugins/upload.conf
+++ b/src/plugins/upload.conf
@@ -4,3 +4,9 @@
 #URL = scp://USERNAME:PASSWORD@SERVERNAME/var/spool/abrt-upload/
 #URL = ftp://USERNAME:PASSWORD@SERVERNAME/var/spool/abrt-upload/
 #URL = file:///var/spool/abrt-upload/
+
+# Specify SSH public key
+#SSHPublicKey =
+
+# Specify SSH private key
+#SSHPrivateKey =


### PR DESCRIPTION
The SSH key files can be set by command line arguments -u (public key) and -r
(private key) or in configuration file upload.conf or in environment variables.

Related to rhbz#1261120