### PR TITLE
Refactoring conditional directives that break parts of statements.

### DIFF
--- a/src/lib/dump_dir.c
+++ b/src/lib/dump_dir.c
@@ -2061,6 +2061,7 @@ static bool uid_in_group(uid_t uid, gid_t gid)
 int dd_stat_for_uid(struct dump_dir *dd, uid_t uid)
 {
     int ddstat = 0;
+    bool uid_test;
 
     if (uid == dd_g_super_user_uid)
     {
@@ -2106,10 +2107,11 @@ fsattributes:
     }
 
 #if DUMP_DIR_OWNED_BY_USER > 0
-    if (uid == dd->dd_uid)
+    uid_test = uid == dd->dd_uid;
 #else
-    if (uid_in_group(uid, dd->dd_gid))
+    uid_test = uid_in_group(uid, dd->dd_gid);
 #endif
+    if (uid_test)
     {
         log_debug("fs attributes: %ld uid owns directory", (long)uid);
         ddstat |= DD_OWNER_FLAGS;


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.