### PR TITLE
xml parser: be more verbose in case xml file cannot be opened

### DIFF
--- a/src/lib/event_xml_parser.c
+++ b/src/lib/event_xml_parser.c
@@ -577,6 +577,8 @@ void load_event_description_from_file(event_config_t *event_config, const char* 
         }
         fclose(fin);
     }
+    else
+        perror_msg("cannot load event description from file : '%s'", filename);
 
     g_markup_parse_context_free(context);
 


### PR DESCRIPTION
In a case a file cannot be openned by function
load_event_description_from_file(), no error messages was printed.

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>