### PR TITLE
RHEL7: lib: allow report SELinux denial from sealert under common user

### DIFF
--- a/src/lib/create_dump_dir.c
+++ b/src/lib/create_dump_dir.c
@@ -48,9 +48,6 @@ struct dump_dir *create_dump_dir_from_problem_data_ext(problem_data_t *problem_d
         return NULL;
     }
 
-    if (uid == (uid_t)-1L)
-        uid = 0;
-
     struct timeval tv;
     if (gettimeofday(&tv, NULL) < 0)
     {

--- a/tests/report_python.at
+++ b/tests/report_python.at
@@ -100,3 +100,40 @@ if report.getVersion_fromOSRELEASE() != report.getVersion():
 
 sys.exit(exit_code)
 ]])
+
+## ---------------------------------- ##
+## create_dump_dir_uid_does_not_exist ##
+## ---------------------------------- ##
+
+AT_PYTESTFUN([create_dump_dir_uid_does_not_exist],
+[[import sys
+
+sys.path.insert(0, "../../../src/report-python")
+sys.path.insert(0, "../../../src/report-python/.libs")
+
+report = __import__("report-python", globals(), locals(), [], -1)
+sys.modules["report"] = report
+
+import os
+
+cd = report.problem_data()
+cd.add_basics()
+dd = cd.create_dump_dir("/tmp/")
+print "dumpdir name:", dd.name
+
+stat_info = os.stat(dd.name)
+uid = stat_info.st_uid
+gid = stat_info.st_gid
+print "user uid", os.getuid()
+print "user gid", os.getgid()
+print "dumpdir uid: ", uid," gid: ",  gid
+
+exit_code = 0
+if os.getuid() != uid:
+    exit_code += 1
+
+if os.getgid() != gid:
+    exit_code += 1
+
+sys.exit(exit_code)
+]])


### PR DESCRIPTION
The main purpose of the removed lines in this commit were preventing from
creating non-root dump dir's sub-directrories in the case an uid element
doesn't exist in time of creating the dump dir.

The removed lines are moved to the function problem_data_save() in abrt
src/lib/hooklib.c.

Related to rhbz#1264921

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>