### PR TITLE
RHEL7: mailx: stop creating dead.letter on mailx failures

### DIFF
--- a/src/plugins/reporter-mailx.c
+++ b/src/plugins/reporter-mailx.c
@@ -197,6 +197,12 @@ static void create_and_send_email(
      */
     putenv((char*)"sendwait=1");
 
+    /* Prevent mailx from creating dead.letter if sending fails. The file is
+     * useless in our case and if the reporter is called from abrtd, SELinux
+     * complains a lot about mailx touching ABRT data.
+     */
+    putenv((char*)"DEAD=/dev/null");
+
     log(_("Sending an email..."));
 
     if (flag & RM_FLAG_NOTIFY)


### PR DESCRIPTION
SELinux does not like mailx creating the file and I do not see any
reason to create the file in a problem directory because the file
contains a copy of the email that could not be send.

Failures of EVENT=notify are discoverable in system logs and if you run
the reporter manually, you will see that mailx failed.

Resolves #1309317

Signed-off-by: Jakub Filak <jfilak@redhat.com>