### PR TITLE
debuginfo: dnf API logging workarounds list

### DIFF
--- a/src/client-python/reportclient/dnfdebuginfo.py
+++ b/src/client-python/reportclient/dnfdebuginfo.py
@@ -71,7 +71,13 @@ class DNFDebugInfoDownload(DebugInfoDownload):
         self.progress = None
 
         self.base = dnf.Base()
-        self.base.logging.presetup()
+        # bug resurfaces in different forms. if it appears again try uncommenting
+        ######   dnf pre API enforced
+        # self.base.logging.presetup()
+        ######   dnf 1.9 API enforced
+        # self.base._logging.presetup()
+        ######   dnf 2.0
+        # self.base._logging._presetup()
 
     def prepare(self):
         try:


### PR DESCRIPTION
Internal presetup() used to workaround logging error.
Later introduced warning by API enforcement.

Fixes #438