### PR TITLE
bugzilla: stop including package details

### DIFF
--- a/src/plugins/bugzilla_format.conf
+++ b/src/plugins/bugzilla_format.conf
@@ -46,7 +46,7 @@ Version-Release number of selected component:: %bare_package
 
 Additional info:: \
 	-pkg_arch,-pkg_epoch,-pkg_name,-pkg_release,-pkg_version,\
-	-component,-architecture,-extra-cc,\
+	-pkg_vendor,-pkg_fingerprint,-component,-architecture,-extra-cc,\
 	-analyzer,-count,-duphash,-uuid,-abrt_version,\
 	-username,-hostname,-os_release,-os_info,\
 	-time,-pid,-pwd,-last_occurrence,-ureports_counter,-tid,\

--- a/src/plugins/bugzilla_format_anaconda.conf
+++ b/src/plugins/bugzilla_format_anaconda.conf
@@ -48,7 +48,7 @@ Version-Release number of selected component:: %bare_package
 
 Additional info:: \
 	reporter,-pkg_arch,-pkg_epoch,-pkg_name,-pkg_release,-pkg_version,\
-		-component,-architecture,-extra-cc,\
+	-pkg_vendor,-pkg_fingerprint,-component,-architecture,-extra-cc,\
 	-analyzer,-count,-duphash,-uuid,-abrt_version,\
 	-username,-hostname,-os_release,-last_occurrence,-ureports_counter,\
 	-time,-pid,-pwd,-backtrace,-core_backtrace,-ifcfg.log,-packaging.log,-tid,\

--- a/src/plugins/bugzilla_format_analyzer_libreport.conf
+++ b/src/plugins/bugzilla_format_analyzer_libreport.conf
@@ -46,7 +46,7 @@ Version-Release number of selected component:: %bare_package
 
 Additional info:: \
 	-pkg_arch,-pkg_epoch,-pkg_name,-pkg_release,-pkg_version,\
-		-component,-architecture,-extra-cc,\
+	-pkg_vendor,-pkg_fingerprint,component,-architecture,-extra-cc,\
 	-analyzer,-count,-duphash,-uuid,-abrt_version,\
 	-username,-hostname,-os_release,-os_info,\
 	-time,-pid,-pwd,-last_occurrence,-ureports_counter,-tid,\

--- a/src/plugins/bugzilla_formatdup.conf
+++ b/src/plugins/bugzilla_formatdup.conf
@@ -56,7 +56,7 @@ Similar problem has been detected:
 # we exclude it from message so that dup message elimination has more chances to work
 :: \
 	-pkg_arch,-pkg_epoch,-pkg_name,-pkg_release,-pkg_version,\
-		-component,-architecture,-extra-cc,\
+	-pkg_vendor,-pkg_fingerprint,-component,-architecture,-extra-cc,\
 	-analyzer,-count,-duphash,-uuid,-abrt_version,\
 	-username,-hostname,-os_release,-os_info,\
 	-time,-pid,-pwd,-last_occurrence,-ureports_counter,\

--- a/src/plugins/bugzilla_formatdup_anaconda.conf
+++ b/src/plugins/bugzilla_formatdup_anaconda.conf
@@ -56,7 +56,7 @@ Similar problem has been detected:
 # we exclude it from message so that dup message elimination has more chances to work
 :: \
 	reporter,-pkg_arch,-pkg_epoch,-pkg_name,-pkg_release,-pkg_version,\
-		-component,-architecture,-extra-cc,\
+	-pkg_vendor,-pkg_fingerprint,-component,-architecture,-extra-cc,\
 	-analyzer,-count,-duphash,-uuid,-abrt_version,\
 	-username,-hostname,-os_release,-last_occurrence,-ureports_counter,\
 	-time,-pid,-pwd,\


### PR DESCRIPTION
The latest version of ABRT generate pkg_vendor and pkg_fingerprint
problem elements in dump directories. These elements have only a little
use in Bugzilla bug description.

Signed-off-by: Jakub Filak <jfilak@redhat.com>