### PR TITLE
rhtsupport: fix a double free of config at exit

### DIFF
--- a/src/plugins/reporter-rhtsupport.c
+++ b/src/plugins/reporter-rhtsupport.c
@@ -810,12 +810,7 @@ int main(int argc, char **argv)
             /* Check for hints and show them if we have something */
             log(_("Checking for hints"));
             if (check_for_hints(base_api_url, &login, &password, ssl_verify, tempfile))
-            {
-                ureport_server_config_destroy(&urconf);
-                free_map_string(ursettings);
-                free(bthash);
                 goto ret;
-            }
         }
 
         log(_("Creating a new case"));


### PR DESCRIPTION
Introduced in commit 028b35b where I forgot on the code added in commit
5ff7f36.

Related: rhbz#1373094