### PR TITLE
lib: correct test for own root

### DIFF
--- a/src/include/internal_libreport.h
+++ b/src/include/internal_libreport.h
@@ -754,10 +754,15 @@ struct ns_ids {
 int get_ns_ids_at(int pid_proc_fd, struct ns_ids *ids);
 #define get_ns_ids libreport_get_ns_ids
 int get_ns_ids(pid_t pid, struct ns_ids *ids);
+
+/* These functions require a privileged user and does not work correctly in
+ * processes running in own PID namespace
+ */
 #define process_has_own_root_at libreport_process_has_own_root_at
 int process_has_own_root_at(int proc_pid_fd);
 #define process_has_own_root libreport_process_has_own_root
 int process_has_own_root(pid_t pid);
+
 #define get_pid_of_container_at libreport_get_pid_of_container_at
 int get_pid_of_container_at(int pid_proc_fd, pid_t *init_pid);
 #define get_pid_of_container libreport_get_pid_of_container

--- a/src/lib/get_cmdline.c
+++ b/src/lib/get_cmdline.c
@@ -865,9 +865,9 @@ int process_has_own_root_at(int pid_proc_fd)
     }
 
     struct stat root_buf;
-    if (stat("/", &root_buf) < 0)
+    if (stat("/proc/1/root", &root_buf) < 0)
     {
-        perror_msg("Failed to get stat for '/'");
+        perror_msg("Failed to get stat for '/proc/1/root'");
         return -1;
     }
 

--- a/tests/proc_helpers.at
+++ b/tests/proc_helpers.at
@@ -875,23 +875,3 @@ TS_MAIN
 }
 TS_RETURN_MAIN
 ]])
-
-
-## -------------------- ##
-## process_has_own_root ##
-## -------------------- ##
-
-AT_TESTFUN([process_has_own_root], [[
-#include "testsuite.h"
-#include <err.h>
-
-TS_MAIN
-{
-    TS_ASSERT_SIGNED_EQ(process_has_own_root(getpid()), 0);
-
-    const int pid_proc_fd = open_proc_pid_dir(getpid());
-    TS_ASSERT_SIGNED_EQ(process_has_own_root_at(pid_proc_fd), 0);
-    TS_ASSERT_FUNCTION(close(pid_proc_fd));
-}
-TS_RETURN_MAIN
-]])


### PR DESCRIPTION
Compare /proc/[pid]/root to /proc/1/root to ensure that process running
in container will correctly recognize that the tested process is running
on the host.

This would fail with own PID namespace.

Disabling the test because regular users are not allowed to access
/proc/1/root.

Signed-off-by: Jakub Filak <jfilak@redhat.com>