### PR TITLE
client: add support for $releasever to debuginfo

### DIFF
--- a/src/client-python/reportclient/dnfdebuginfo.py
+++ b/src/client-python/reportclient/dnfdebuginfo.py
@@ -65,12 +65,15 @@ class DNFProgress(dnf.callback.DownloadProgress):
 class DNFDebugInfoDownload(DebugInfoDownload):
 
     def __init__(self, cache, tmp, repo_pattern="*debug*", keep_rpms=False,
-                 noninteractive=True):
+                 noninteractive=True, releasever=None):
         super(DNFDebugInfoDownload, self).__init__(cache, tmp, repo_pattern, keep_rpms, noninteractive)
 
         self.progress = None
 
         self.base = dnf.Base()
+        if not releasever is None:
+            self.base.conf.substitutions['releasever'] = releasever
+
         # bug resurfaces in different forms. if it appears again try uncommenting
         ######   dnf pre API enforced
         # self.base.logging.presetup()

--- a/src/client-python/reportclient/yumdebuginfo.py
+++ b/src/client-python/reportclient/yumdebuginfo.py
@@ -73,10 +73,12 @@ def downloadErrorCallback(callBackObj):
 class YumDebugInfoDownload(DebugInfoDownload):
 
     def __init__(self, cache, tmp, repo_pattern="*debug*", keep_rpms=False,
-                 noninteractive=True):
+                 noninteractive=True, releasever=None):
         super(YumDebugInfoDownload, self).__init__(cache, tmp, repo_pattern, keep_rpms, noninteractive)
 
         self.base = YumBase()
+        if not releasever is None:
+            self.base.conf.substitutions['releasever'] = releasever
 
     def initialize_progress(self, updater):
         self.progress = YumDownloadCallback(updater)


### PR DESCRIPTION
ABRT needs to overwrite $releasever when analyzing a problem that
occurred in a container or a changed root environment.

Signed-off-by: Jakub Filak <jfilak@redhat.com>