### PR TITLE
configure.ac: Remove nss dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -228,7 +228,6 @@ PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.21])
 PKG_CHECK_MODULES([GOBJECT], [gobject-2.0])
 PKG_CHECK_MODULES([DBUS], [dbus-1])
 PKG_CHECK_MODULES([LIBXML], [libxml-2.0])
-PKG_CHECK_MODULES([NSS], [nss])
 PKG_CHECK_MODULES([CURL], [libcurl])
 PKG_CHECK_MODULES([PROXY], [libproxy-1.0], [
     AC_DEFINE([HAVE_PROXY], [1], [Use libproxy])

--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -5,13 +5,11 @@
   %bcond_with bugzilla
 
   %define dbus_devel dbus-1-devel
-  %define nss_devel mozilla-nss-devel
   %define libjson_devel libjson-devel
 %else
   %bcond_without bugzilla
 
   %define dbus_devel dbus-devel
-  %define nss_devel nss-devel
   %define libjson_devel json-c-devel
 %endif
 
@@ -33,7 +31,6 @@ BuildRequires: libxml2-devel
 BuildRequires: libtar-devel
 BuildRequires: intltool
 BuildRequires: libtool
-BuildRequires: %{nss_devel}
 BuildRequires: texinfo
 BuildRequires: asciidoc
 BuildRequires: xmlto


### PR DESCRIPTION
This does not seem to be referenced anywhere.

I might be missing something, but I cannot find where this is used. If it is not needed, can you please merge? If it is still needed, I am sorry for the churn and would like to know what it is used for.