### PR TITLE
reporter-s-journal: add count to default logs

### DIFF
--- a/src/plugins/reporter-systemd-journal.c
+++ b/src/plugins/reporter-systemd-journal.c
@@ -126,6 +126,7 @@ static const char *const fields_default[] = {
     DUMPDIR_PATH                ,
     FILENAME_UUID               ,
     FILENAME_DUPHASH            ,
+    FILENAME_COUNT              ,
     NULL
 };
 


### PR DESCRIPTION
Field count is available only in FULL dump. There are however two good
reasons why to include this in NONE dump.

1. It is quite useful to know if this problem occurred first time or is it
problem that happens a lot.

2. We need it for cockpit integration. If the problem happened more times it
will have multiple logs. By comparing count in the log and real count, we can
know, if this is the last log of the problem. (timestamps do not work ideally
for this, since the time of problem does not equal to the time of the
log - there is some delay)

Signed-off-by: Matej Marusak <mmarusak@redhat.com>