### PR TITLE
augeas: trim spaces on eol, around value separator

### DIFF
--- a/augeas/libreport.aug
+++ b/augeas/libreport.aug
@@ -2,19 +2,24 @@ module Libreport =
     autoload xfm
 
     (* Define useful primitives *)
-    let value_sep    = del / ?= ?/ " = "
-    let value_to_eol = store /([^ \t\n].*[^ \t\n]|[^ \t\n]?)/
-    let eol          = del /\n/ "\n"
-    let ident        = /[a-zA-Z][a-zA-Z_]+/
+    let val_sep        = del /[ \t]*=[ \t]*/ " = "
+    let val            = store /([^ \t\n].*[^ \t\n]|[^ \t\n])/
+    let eol            = del /\n/ "\n"
+    let whitespace_eol = del /[ \t]*\n/ "\n"
+    let ident          = /[a-zA-Z][a-zA-Z_]+/
 
     (* Define comment *)
-    let comment = [ label "#comment" . del /#[ \t]*/ "# " . value_to_eol . eol ]
+    let commented_line = [ label "#comment" . del /#[ \t]*/ "# " . val . eol ]
+    let empty_comment  = [ label "#comment" . value "" . del /#[ \t]*/ "# " . eol ]
+    let comment        = commented_line | empty_comment
 
     (* Define empty *)
-    let empty = [ del /[ \t]*\n/ "\n" ]
+    let empty          = [ del /[ \t]*\n/ "\n" ]
 
     (* Define option *)
-    let option = [ del /[ \t]*/ "" . key ident . value_sep . value_to_eol . eol ]
+    let option_val     = [ del /[ \t]*/ "" . key ident . val_sep . val . whitespace_eol ]
+    let option_no_val  = [ value "" . del /[ \t]*/ "" . key ident . val_sep . eol ]
+    let option         = option_val | option_no_val
 
     (* Define lens *)
     let lns = ( comment | empty | option )*

--- a/augeas/test_libreport.aug
+++ b/augeas/test_libreport.aug
@@ -16,6 +16,8 @@ Password =
 # bugs in selinux-policy component.
 # (If you need to add more, the syntax is: \"component[,component...]\")
 #
+#       
+#		
 DontMatchComponents = selinux-policy
 
 # for more info about these settings see: https://github.com/abrt/abrt/wiki/FAQ#creating-private-bugzilla-tickets
@@ -25,6 +27,14 @@ PrivateGroups=private
   Whitespace_two=start
 	Whitespace_three =start
 	 Whitespace_four= start
+
+AssignmentWhitespace_a   =what
+     AssignmentWhitespace_b   =    an
+AssignmentWhitespace_c=   		 original
+  AssignmentWhitespace_d =      idea
+
+EOLWhitespace_a = nice      
+EOLWhitespace_b = nice 		 
 "
 
     test Libreport.lns get conf =
@@ -44,6 +54,8 @@ PrivateGroups=private
         { "#comment" = "bugs in selinux-policy component." }
         { "#comment" = "(If you need to add more, the syntax is: \"component[,component...]\")" }
         { "#comment" = "" }
+        { "#comment" = "" }
+        { "#comment" = "" }
         { "DontMatchComponents" = "selinux-policy" }
         {}
         { "#comment" = "for more info about these settings see: https://github.com/abrt/abrt/wiki/FAQ#creating-private-bugzilla-tickets" }
@@ -53,3 +65,11 @@ PrivateGroups=private
         { "Whitespace_two" = "start" }
         { "Whitespace_three" = "start" }
         { "Whitespace_four" = "start" }
+        {}
+        { "AssignmentWhitespace_a" = "what" }
+        { "AssignmentWhitespace_b" = "an" }
+        { "AssignmentWhitespace_c" = "original" }
+        { "AssignmentWhitespace_d" = "idea" }
+        {}
+        { "EOLWhitespace_a" = "nice" }
+        { "EOLWhitespace_b" = "nice" }


### PR DESCRIPTION
Lens were rewritten to handle whitespaces on EOL and also around value separator.
Tests updated.

Resolves abrt/libreport#474
Related to rhbz#1434414