### PR TITLE
lib: replace hash table with list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ in libreport configs.
 - Update glib minimal version dependency, this bug caused update problems when
 updating libreport and pre-2.28 glib was installed.
 - Fix missing newline when asking for password.
+- Fix a bug causing inconsistent order of username and password fields when
+reporting bugs.
 
 
 ## [2.9.1] - 2017-03-16

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -914,10 +914,10 @@ static gint find_by_button(gconstpointer a, gconstpointer button)
 
 static void check_event_config(const char *event_name)
 {
-    GHashTable *errors = validate_event(event_name);
+    GList *errors = get_options_with_err_msg(event_name);
     if (errors != NULL)
     {
-        g_hash_table_unref(errors);
+        g_list_free_full(errors, (GDestroyNotify)free_invalid_options);
         show_event_config_dialog(event_name, GTK_WINDOW(g_top_most_window));
         update_private_ticket_creation_warning_for_selected_event();
     }

--- a/src/include/event_config.h
+++ b/src/include/event_config.h
@@ -63,6 +63,17 @@ typedef struct
     bool is_advanced;
 } event_option_t;
 
+/*
+ * struct holds
+ *   invopt_name = name of the option with invalid value
+ *   invopt_error = string of the error message
+ */
+typedef struct
+{
+    char *invopt_name;
+    char *invopt_error;
+} invalid_option_t;
+
 event_option_t *new_event_option(void);
 void free_event_option(event_option_t *p);
 
@@ -108,6 +119,8 @@ bool ec_restricted_access_enabled(event_config_t *ec);
 
 void free_event_config(event_config_t *p);
 
+invalid_option_t *new_invalid_option(void);
+void free_invalid_options(invalid_option_t* p);
 
 void load_event_description_from_file(event_config_t *event_config, const char* filename);
 
@@ -126,7 +139,7 @@ extern GHashTable *g_event_config_list;   // for iterating through entire list o
 GList *export_event_config(const char *event_name);
 void unexport_event_config(GList *env_list);
 
-GHashTable *validate_event(const char *event_name);
+GList *get_options_with_err_msg(const char *event_name);
 
 /*
  * Checks usability of problem's backtrace rating against required rating level

--- a/tests/event_config.at
+++ b/tests/event_config.at
@@ -58,3 +58,106 @@ TS_MAIN
 }
 TS_RETURN_MAIN
 ]])
+
+## ------------------------ ##
+## get_options_with_err_msg ##
+## ------------------------ ##
+
+AT_TESTFUN([get_options_with_err_msg], [[
+#include "testsuite.h"
+#include "internal_libreport.h"
+
+event_option_t* create_new_option(const char *n, const char *v, option_type_t t, int ae)
+{
+    event_option_t *op = new_event_option();
+    op->eo_name = xstrdup(n);
+    op->eo_value = NULL;
+    if(v != NULL)
+        op->eo_value = xstrdup(v);
+
+    op->eo_type = t;
+    op->eo_allow_empty = ae;
+
+    return op;
+}
+
+TS_MAIN
+{
+    GList *errors = NULL, *iter = NULL;
+    invalid_option_t *e_op;
+
+    if (!g_event_config_list)
+        g_event_config_list = g_hash_table_new_full(
+            g_str_hash, g_str_equal, free, (GDestroyNotify) free_event_config
+        );
+
+    {
+        event_config_t *evnt = new_event_config("Bugster0");
+        event_option_t *opt_login = create_new_option("Bugtest_Login", NULL, OPTION_TYPE_TEXT, 0);
+        event_option_t *opt_passwd = create_new_option("Bugtest_Password", NULL, OPTION_TYPE_PASSWORD, 0);
+        event_option_t *opt_url = create_new_option("Bugtest_URL", "bug.test", OPTION_TYPE_TEXT, 0);
+
+        evnt->options = g_list_append(evnt->options, opt_login);
+        evnt->options = g_list_append(evnt->options, opt_passwd);
+        evnt->options = g_list_append(evnt->options, opt_url);
+        g_hash_table_insert(g_event_config_list, xstrdup("Bugster0"), evnt);
+
+        errors = get_options_with_err_msg("Bugster0");
+        e_op = (invalid_option_t *)errors->data;
+
+        TS_ASSERT_STRING_EQ(e_op->invopt_name, "Bugtest_Login", "Show login first");
+
+        iter = g_list_next(errors);
+        e_op = (invalid_option_t *)iter->data;
+
+        TS_ASSERT_STRING_EQ(e_op->invopt_name, "Bugtest_Password", "Show password second");
+        TS_ASSERT_PTR_IS_NULL(g_list_next(iter));
+
+        g_list_free_full(errors, (GDestroyNotify)free_invalid_options);
+    }
+
+    {
+        event_config_t *evnt = new_event_config("Bugster1");
+        event_option_t *opt_login = create_new_option("Bugtest_Login", NULL, OPTION_TYPE_TEXT, 0);
+        event_option_t *opt_passwd = create_new_option("Bugtest_Password", NULL, OPTION_TYPE_PASSWORD, 0);
+        event_option_t *opt_url = create_new_option("Bugtest_URL", "bug.test", OPTION_TYPE_TEXT, 0);
+
+        evnt->options = g_list_append(evnt->options, opt_passwd);
+        evnt->options = g_list_append(evnt->options, opt_login);
+        evnt->options = g_list_append(evnt->options, opt_url);
+        g_hash_table_insert(g_event_config_list, xstrdup("Bugster1"), evnt);
+
+        errors = get_options_with_err_msg("Bugster1");
+        e_op = (invalid_option_t *)errors->data;
+
+        TS_ASSERT_STRING_EQ(e_op->invopt_name, "Bugtest_Password", "Show password first");
+
+        iter = g_list_next(errors);
+        e_op = (invalid_option_t *)iter->data;
+
+        TS_ASSERT_STRING_EQ(e_op->invopt_name, "Bugtest_Login", "Show login second");
+        TS_ASSERT_PTR_IS_NULL(g_list_next(iter));
+
+        g_list_free_full(errors, (GDestroyNotify)free_invalid_options);
+    }
+
+    {
+        event_config_t *evnt = new_event_config("Bugster2");
+        event_option_t *opt_login = create_new_option("Bugtest_Login", "login", OPTION_TYPE_TEXT, 0);
+        event_option_t *opt_passwd = create_new_option("Bugtest_Password", "password", OPTION_TYPE_PASSWORD, 0);
+        event_option_t *opt_url = create_new_option("Bugtest_URL", "bug.test", OPTION_TYPE_TEXT, 0);
+
+        evnt->options = g_list_append(evnt->options, opt_login);
+        evnt->options = g_list_append(evnt->options, opt_passwd);
+        evnt->options = g_list_append(evnt->options, opt_url);
+        g_hash_table_insert(g_event_config_list, xstrdup("Bugster2"), evnt);
+
+        errors = get_options_with_err_msg("Bugster2");
+
+        TS_ASSERT_PTR_IS_NULL(errors);
+    }
+
+    free_event_config_data();
+}
+TS_RETURN_MAIN
+]])


### PR DESCRIPTION
Order of login credentials wasn't guaranteed, because event options with missing
values were inserted into hash table and then extracted from it.

I renamed function validate_event as its name was a little bit confusing. The function
returns options that are missing input values and error message should be displayed.

This fixes abrt/abrt#1231

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>