### PR TITLE
Deprecated dtk 3 functions issue #488

### DIFF
--- a/src/gtk-helpers/autowrapped_label.c
+++ b/src/gtk-helpers/autowrapped_label.c
@@ -62,7 +62,8 @@ void make_label_autowrap_on_resize(GtkLabel *label)
 {
     // So far, only tested to work on labels which were set up as:
     //gtk_label_set_justify(label, GTK_JUSTIFY_LEFT);
-    //gtk_misc_set_alignment(GTK_MISC(label), /*x,yalign:*/ 0.0, 0.0);
+	    //gtk_widget_set_halign (label, GTK_ALIGN_START);
+    // gtk_widget_set_valign (label, GTK_ALIGN_END);
     // yalign != 0 definitely breaks things!
     // also, <property name="ypad">NONZERO</property> would be bad
 

--- a/src/gtk-helpers/config_dialog.c
+++ b/src/gtk-helpers/config_dialog.c
@@ -382,13 +382,9 @@ GtkWindow *create_config_list_window(GHashTable *configs, GtkWindow *parent)
     g_signal_connect(close_btn, "clicked", (GCallback)on_close_cb, window);
 
     gtk_box_pack_start(GTK_BOX(btn_box), close_btn, 0, 0, 5);
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION < 5))
-    GtkWidget *align = gtk_alignment_new(0, 0, 0, 0);
-    gtk_box_pack_start(GTK_BOX(btn_box), align, true, true, 5);
-    gtk_box_pack_start(GTK_BOX(btn_box), configure_btn, 0, 0, 5);
-#else
+
     gtk_box_pack_end(GTK_BOX(btn_box), configure_btn, 0, 0, 5);
-#endif
+
 
 
     gtk_box_pack_start(GTK_BOX(main_vbox), btn_box, 0, 0, 0);

--- a/src/gtk-helpers/config_dialog.c
+++ b/src/gtk-helpers/config_dialog.c
@@ -271,12 +271,6 @@ GtkWidget *create_config_tab_content(const char *column_label,
     gtk_tree_view_column_set_sort_column_id(column, COLUMN_NAME);
     gtk_tree_view_append_column(GTK_TREE_VIEW(tv), column);
 
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION < 6))
-    /* https://bugzilla.gnome.org/show_bug.cgi?id=733312 */
-    /* "Please draw rows in alternating colors": */
-    gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(tv), TRUE);
-#endif
-
     // TODO: gtk_tree_view_set_headers_visible(FALSE)? We have only one column anyway...
     GtkTreeModel *model = gtk_tree_model_filter_new(GTK_TREE_MODEL(store), NULL);
     gtk_tree_model_filter_set_visible_func(GTK_TREE_MODEL_FILTER(model), config_filter_func, NULL, NULL);

--- a/src/gtk-helpers/event_config_dialog.c
+++ b/src/gtk-helpers/event_config_dialog.c
@@ -35,16 +35,12 @@ static GtkWidget *gtk_label_new_justify_left(const gchar *label_str)
 {
     GtkWidget *label = gtk_label_new(label_str);
     gtk_label_set_justify(GTK_LABEL(label), GTK_JUSTIFY_LEFT);
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION < 5))
-    gtk_misc_set_alignment(GTK_MISC(label), /*xalign:*/ 0, /*yalign:*/ 0.5);
-    /* Make some space between label and input field to the right of it: */
-    gtk_misc_set_padding(GTK_MISC(label), /*xpad:*/ 5, /*ypad:*/ 0);
-#else
+
     gtk_widget_set_halign (label, GTK_ALIGN_START);
     /* Make some space between label and input field to the right of it: */
     gtk_widget_set_margin_start(label, 5);
     gtk_widget_set_margin_end(label, 5);
-#endif
+
     return label;
 }
 
@@ -153,12 +149,10 @@ static void add_option_to_table(gpointer data, gpointer user_data)
         case OPTION_TYPE_HINT_HTML:
             label = gtk_label_new(option_label);
             gtk_label_set_use_markup(GTK_LABEL(label), TRUE);
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION < 5))
-            gtk_misc_set_alignment(GTK_MISC(label), /*x,yalign:*/ 0.0, 0.0);
-#else
+
             gtk_widget_set_halign(label, GTK_ALIGN_START);
             gtk_widget_set_valign(label, GTK_ALIGN_START);
-#endif
+
             make_label_autowrap_on_resize(GTK_LABEL(label));
 
             last_row = add_one_row_to_grid(option_table);
@@ -190,12 +184,10 @@ static void add_option_to_table(gpointer data, gpointer user_data)
     {
         label = gtk_label_new(option->eo_note_html);
         gtk_label_set_use_markup(GTK_LABEL(label), TRUE);
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION < 5))
-        gtk_misc_set_alignment(GTK_MISC(label), /*x,yalign:*/ 0.0, 0.0);
-#else
+
         gtk_widget_set_halign(label, GTK_ALIGN_START);
         gtk_widget_set_valign(label, GTK_ALIGN_START);
-#endif
+
         make_label_autowrap_on_resize(GTK_LABEL(label));
 
         last_row = add_one_row_to_grid(option_table);

--- a/src/gtk-helpers/event_config_dialog.c
+++ b/src/gtk-helpers/event_config_dialog.c
@@ -203,13 +203,9 @@ static GtkWidget *create_event_config_grid()
 {
     GtkWidget *option_table = gtk_grid_new();
 
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 11) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 11 && GTK_MICRO_VERSION < 2))
-    gtk_widget_set_margin_left(option_table, 5);
-    gtk_widget_set_margin_right(option_table, 5);
-#else
     gtk_widget_set_margin_start(option_table, 5);
     gtk_widget_set_margin_end(option_table, 5);
-#endif
+
     gtk_widget_set_margin_top(option_table, 5);
     gtk_widget_set_margin_bottom(option_table, 5);
 

--- a/src/gtk-helpers/problem_details_widget.c
+++ b/src/gtk-helpers/problem_details_widget.c
@@ -119,17 +119,10 @@ problem_details_widget_add_single_line(ProblemDetailsWidget *self, const char *n
     gtk_widget_set_hexpand(value, TRUE);
     gtk_widget_override_font(GTK_WIDGET(value), self->priv->font);
 
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 11) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 11 && GTK_MICRO_VERSION < 2))
-    gtk_widget_set_margin_left(label, 20);
-    gtk_widget_set_margin_right(label, 20);
-
-    gtk_widget_set_margin_left(value, 5);
-#else
     gtk_widget_set_margin_start(label, 20);
     gtk_widget_set_margin_end(label, 20);
 
     gtk_widget_set_margin_start(value, 5);
-#endif
 
     const gulong row = problem_details_widget_append_row(self);
 

--- a/src/gtk-helpers/workflow_config_dialog.c
+++ b/src/gtk-helpers/workflow_config_dialog.c
@@ -37,13 +37,9 @@ static void create_event_config_dialog_content_cb(event_config_t *ec, gpointer n
     GtkWidget *ev_lbl = gtk_label_new(ec_get_screen_name(ec));
 
     GtkWidget *content = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 11) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 11 && GTK_MICRO_VERSION < 2))
-    gtk_widget_set_margin_left(content, 10);
-    gtk_widget_set_margin_right(content, 10);
-#else
     gtk_widget_set_margin_start(content, 10);
     gtk_widget_set_margin_end(content, 10);
-#endif
+
     gtk_widget_set_margin_top(content, 5);
     gtk_widget_set_margin_bottom(content, 10);
 

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -3717,16 +3717,11 @@ void create_assistant(GtkApplication *app, bool expert_mode)
     gtk_box_pack_start(g_box_buttons, g_btn_onfail, false, false, 5);
     gtk_box_pack_start(g_box_buttons, g_btn_repeat, false, false, 5);
     /* Btns above are to the left, the rest are to the right: */
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION < 5))
-    GtkWidget *w = gtk_alignment_new(0.0, 0.0, 1.0, 1.0);
-    gtk_box_pack_start(g_box_buttons, w, true, true, 5);
-    gtk_box_pack_start(g_box_buttons, g_btn_detail, false, false, 5);
-    gtk_box_pack_start(g_box_buttons, g_btn_next, false, false, 5);
-#else
+
     gtk_widget_set_valign(GTK_WIDGET(g_btn_next), GTK_ALIGN_END);
     gtk_box_pack_end(g_box_buttons, g_btn_next, false, false, 5);
     gtk_box_pack_end(g_box_buttons, g_btn_detail, false, false, 5);
-#endif
+
 
     {   /* Warnings area widget definition start */
         g_box_warning_labels = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
@@ -3743,23 +3738,15 @@ void create_assistant(GtkApplication *app, bool expert_mode)
         gtk_widget_set_visible(g_widget_warnings_area, FALSE);
         gtk_widget_set_no_show_all(g_widget_warnings_area, TRUE);
 
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION < 5))
-        GtkWidget *alignment_left = gtk_alignment_new(0.5,0.5,1,1);
-        gtk_widget_set_visible(alignment_left, TRUE);
-        gtk_box_pack_start(GTK_BOX(g_widget_warnings_area), alignment_left, true, false, 0);
-#else
+	
         gtk_widget_set_valign(GTK_WIDGET(image), GTK_ALIGN_CENTER);
         gtk_widget_set_valign(GTK_WIDGET(vbox), GTK_ALIGN_CENTER);
-#endif
+
 
         gtk_box_pack_start(GTK_BOX(g_widget_warnings_area), image, false, false, 5);
         gtk_box_pack_start(GTK_BOX(g_widget_warnings_area), GTK_WIDGET(vbox), false, false, 0);
 
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION < 5))
-        GtkWidget *alignment_right = gtk_alignment_new(0.5,0.5,1,1);
-        gtk_widget_set_visible(alignment_right, TRUE);
-        gtk_box_pack_start(GTK_BOX(g_widget_warnings_area), alignment_right, true, false, 0);
-#endif
+
     }   /* Warnings area widget definition end */
 
     g_box_assistant = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -1002,12 +1002,10 @@ static event_gui_data_t *add_event_buttons(GtkBox *box,
     if (!event_name || !event_name[0])
     {
         GtkWidget *lbl = gtk_label_new(_("No reporting targets are defined for this problem. Check configuration in /etc/libreport/*"));
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION < 5))
-        gtk_misc_set_alignment(GTK_MISC(lbl), /*x*/ 0.0, /*y*/ 0.0);
-#else
+
         gtk_widget_set_halign (lbl, GTK_ALIGN_START);
         gtk_widget_set_valign (lbl, GTK_ALIGN_END);
-#endif
+
         make_label_autowrap_on_resize(GTK_LABEL(lbl));
         gtk_box_pack_start(box, lbl, /*expand*/ true, /*fill*/ false, /*padding*/ 0);
         return NULL;
@@ -2217,12 +2215,10 @@ static void add_warning(const char *warning)
     /* should be safe to free it, gtk calls strdup() to copy it */
     free(label_str);
 
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION < 5))
-    gtk_misc_set_alignment(GTK_MISC(warning_lbl), 0.0, 0.0);
-#else
+
     gtk_widget_set_halign (warning_lbl, GTK_ALIGN_START);
     gtk_widget_set_valign (warning_lbl, GTK_ALIGN_END);
-#endif
+
     gtk_label_set_justify(GTK_LABEL(warning_lbl), GTK_JUSTIFY_LEFT);
     gtk_label_set_line_wrap(GTK_LABEL(warning_lbl), TRUE);
 

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -2984,11 +2984,8 @@ static void add_workflow_buttons(GtkBox *box, GHashTable *workflows, GCallback f
         gtk_label_set_use_markup(GTK_LABEL(label), true);
         gtk_widget_set_halign(label, GTK_ALIGN_START);
         gtk_widget_set_margin_top(label, 10);
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 11) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 11 && GTK_MICRO_VERSION < 2))
-        gtk_widget_set_margin_left(label, 40);
-#else
         gtk_widget_set_margin_start(label, 40);
-#endif
+
         gtk_widget_set_margin_bottom(label, 10);
         g_list_free(children);
         free(btn_label);


### PR DESCRIPTION
Old deprecated dtk-3 functions changed to new functions.

This one error from issue #488 is still  not solved in this work:
event_config_dialog.c:291:9: error: 'gtk_widget_override_color' is deprecated (declared at /usr/include/gtk-3.0/gtk/gtkwidget.h:1144) [-Werror=deprecated-declarations]
         gtk_widget_override_color(keyring_warn_lbl, GTK_STATE_FLAG_NORMAL, &red);
         ^

Created on internship in Redhat.