### PR TITLE
anaconda: run log-capture if available

### DIFF
--- a/src/plugins/bugzilla_anaconda_event.conf
+++ b/src/plugins/bugzilla_anaconda_event.conf
@@ -7,6 +7,9 @@ EVENT=report_Bugzilla component=anaconda
 			sed 's/^.*rootpw.*$/<auto-removed line containing rootpw>/' -i $sf
 		fi
 	done
+	if [ -x /usr/libexec/anaconda/log-capture ]; then
+		/usr/libexec/anaconda/log-capture "$DUMP_DIR/log-capture.tar.bz2"
+	fi
 	# file a bug in Bugzilla
 	reporter-bugzilla -b \
 		-F /etc/libreport/plugins/bugzilla_format_anaconda.conf \


### PR DESCRIPTION
Newer anaconda releases provide a tool to capture anaconda logs.  This may be handy for automatic reporting in order to understand why an install crashed.

The attached patch conditionally runs the script if it exists.  The first arg to log-capture is where to store the output.