### PR TITLE
logging: rename log() to log_warning()

### DIFF
--- a/src/client-python/reportclient/__init__.py
+++ b/src/client-python/reportclient/__init__.py
@@ -69,7 +69,7 @@ def set_verbosity(verbosity):
     os.environ["ABRT_VERBOSE"] = str(verbose)
 
 
-def log(fmt, *args):
+def log_warning(fmt, *args):
     sys.stderr.write("%s\n" % (fmt % args))
 
 

--- a/src/gtk-helpers/config_dialog.c
+++ b/src/gtk-helpers/config_dialog.c
@@ -88,7 +88,7 @@ int cdialog_run(config_dialog_t *cdialog, const char *name)
 {
     if (cdialog == NULL || cdialog->dialog == NULL)
     {
-        log("There is no configurable option for: '%s'", name);
+        log_warning("There is no configurable option for: '%s'", name);
         return GTK_RESPONSE_REJECT;
     }
 
@@ -146,7 +146,7 @@ static void save_value_from_widget(gpointer data, gpointer user_data)
             val = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ow->widget)) ? "yes" : "no";
             break;
         default:
-            log("unsupported option type");
+            log_warning("unsupported option type");
     }
 
     /* gtk_entry_get_text() returns empty string for empty text value */

--- a/src/gtk-helpers/event_config_dialog.c
+++ b/src/gtk-helpers/event_config_dialog.c
@@ -175,7 +175,7 @@ static void add_option_to_table(gpointer data, gpointer user_data)
 
         default:
             //option_input = gtk_label_new_justify_left("WTF?");
-            log("unsupported option type");
+            log_warning("unsupported option type");
             free(option_label);
             return;
     }

--- a/src/gtk-helpers/problem_details_widget.c
+++ b/src/gtk-helpers/problem_details_widget.c
@@ -194,7 +194,7 @@ problem_details_widget_add_binary(ProblemDetailsWidget *self, const char *label,
 
     if (stat(path, &statbuf) != 0)
     {
-        log("File '%s' does not exist", path);
+        log_warning("File '%s' does not exist", path);
         return;
     }
 
@@ -235,7 +235,7 @@ problem_details_widget_add_problem_item(ProblemDetailsWidget *self, const char *
     else if (item->flags & CD_FLAG_BIN)
         problem_details_widget_add_binary(self, name, item->content);
     else
-        log("Unsupported file type");
+        log_warning("Unsupported file type");
 }
 
 /* Callback for GHashTable */

--- a/src/gtk-helpers/secrets.c
+++ b/src/gtk-helpers/secrets.c
@@ -305,7 +305,7 @@ static enum secrets_service_state secrets_service_connect(void)
 
     if (!g_connection)
     {
-        log("Failed to open connection to D-Bus session bus: %s", error->message);
+        log_warning("Failed to open connection to D-Bus session bus: %s", error->message);
         g_error_free(error);
         return SBS_UNAVAILABLE;
     }

--- a/src/gui-wizard-gtk/main.c
+++ b/src/gui-wizard-gtk/main.c
@@ -66,7 +66,7 @@ void problem_data_reload_from_dump_dir(void)
             new_item->default_by_reporter = 0;
             new_item->required_by_reporter = 0;
         }
-        //log("%s: was ->selected_by_user=%d", __func__, new_item->selected_by_user);
+        //log_warning("%s: was ->selected_by_user=%d", __func__, new_item->selected_by_user);
     }
     problem_data_free(g_cd);
     g_cd = new_cd;

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -322,7 +322,7 @@ static void label_wrapper(GtkWidget *widget, gpointer data_unused)
         GtkLabel *label = (GtkLabel*)widget;
         gtk_label_set_line_wrap(label, 1);
         //const char *txt = gtk_label_get_label(label);
-        //log("label '%s' set to wrap", txt);
+        //log_warning("label '%s' set to wrap", txt);
     }
 }
 
@@ -347,7 +347,7 @@ static void wrap_fixer(GtkWidget *widget, gpointer data_unused)
           && (gtk_widget_get_margin_top(widget) == 0)
           && (gtk_widget_get_margin_bottom(widget) == 0)
         ) {
-            //log("label '%s' set to autowrap", txt);
+            //log_warning("label '%s' set to autowrap", txt);
             make_label_autowrap_on_resize(label);
             return;
         }
@@ -867,7 +867,7 @@ static void g_tv_details_checkbox_toggled(
                         gchar    *tree_path,
                         gpointer  user_data_UNUSED)
 {
-    //log("%s: path:'%s'", __func__, tree_path);
+    //log_warning("%s: path:'%s'", __func__, tree_path);
     GtkTreeIter iter;
     if (!gtk_tree_model_get_iter_from_string(GTK_TREE_MODEL(g_ls_details), &iter, tree_path))
         return;
@@ -888,7 +888,7 @@ static void g_tv_details_checkbox_toggled(
         cur_value = item->default_by_reporter;
     else
         cur_value = !!(item->selected_by_user + 1); /* map -1,1 to 0,1 */
-    //log("%s: allowed:%d reqd:%d def:%d user:%d cur:%d", __func__,
+    //log_warning("%s: allowed:%d reqd:%d def:%d user:%d cur:%d", __func__,
     //            item->allowed_by_reporter,
     //            item->required_by_reporter,
     //            item->default_by_reporter,
@@ -899,7 +899,7 @@ static void g_tv_details_checkbox_toggled(
     {
         cur_value = !cur_value;
         item->selected_by_user = cur_value * 2 - 1; /* map 0,1 to -1,1 */
-        //log("%s: now ->selected_by_user=%d", __func__, item->selected_by_user);
+        //log_warning("%s: now ->selected_by_user=%d", __func__, item->selected_by_user);
         gtk_list_store_set(g_ls_details, &iter,
                 DETAIL_COLUMN_CHECKBOX, cur_value,
                 -1);
@@ -1321,7 +1321,7 @@ static void append_item_to_ls_details(gpointer name, gpointer value, gpointer da
 static void update_ls_details_checkboxes(const char *event_name)
 {
     event_config_t *cfg = get_event_config(event_name);
-    //log("%s: event:'%s', cfg:'%p'", __func__, g_event_selected, cfg);
+    //log_warning("%s: event:'%s', cfg:'%p'", __func__, g_event_selected, cfg);
     GHashTableIter iter;
     char *name;
     struct problem_item *item;
@@ -1364,7 +1364,7 @@ static void update_ls_details_checkboxes(const char *event_name)
         else
             cur_value = !!(item->selected_by_user + 1); /* map -1,1 to 0,1 */
 
-        //log("%s: '%s' allowed:%d reqd:%d def:%d user:%d", __func__, name,
+        //log_warning("%s: '%s' allowed:%d reqd:%d def:%d user:%d", __func__, name,
         //    item->allowed_by_reporter,
         //    item->required_by_reporter,
         //    item->default_by_reporter,
@@ -1389,7 +1389,7 @@ static void update_ls_details_checkboxes(const char *event_name)
                 gtk_list_store_set(g_ls_details, &iter,
                         DETAIL_COLUMN_CHECKBOX, cur_value,
                         -1);
-                //log("%s: changed gtk_list_store_set to %d", __func__, (item->allowed_by_reporter && item->selected_by_user >= 0));
+                //log_warning("%s: changed gtk_list_store_set to %d", __func__, (item->allowed_by_reporter && item->selected_by_user >= 0));
                 break;
             } while (gtk_tree_model_iter_next(GTK_TREE_MODEL(g_ls_details), &iter));
         }
@@ -1538,7 +1538,7 @@ static void set_excluded_envvar(void)
         } while (gtk_tree_model_iter_next(GTK_TREE_MODEL(g_ls_details), &iter));
     }
     char *var = strbuf_free_nobuf(item_list);
-    //log("EXCLUDE_FROM_REPORT='%s'", var);
+    //log_warning("EXCLUDE_FROM_REPORT='%s'", var);
     if (var)
     {
         xsetenv("EXCLUDE_FROM_REPORT", var);
@@ -2340,7 +2340,7 @@ static void toggle_eb_comment(void)
         switch(reproducible)
         {
             case -1:
-                VERB1 log("Uninitialized 'How reproducible' combobox");
+                VERB1 log_warning("Uninitialized 'How reproducible' combobox");
                 break;
 
             case PROBLEM_REPRODUCIBLE_UNKNOWN:
@@ -2409,7 +2409,7 @@ static void log_ready_state(void)
         buf[i] = ch;
     }
     buf[NUM_PAGES] = 0;
-    log("Completeness:[%s]", buf);
+    log_warning("Completeness:[%s]", buf);
 }
 #endif
 
@@ -3083,7 +3083,7 @@ static gint select_next_page_no(gint current_page_no, gpointer data)
                 }
                 else
                 {
-                    log("%s", msg);
+                    log_warning("%s", msg);
                     free(msg);
                 }
             }
@@ -3254,7 +3254,7 @@ static void save_edited_one_liner(GtkCellRendererText *renderer,
                 gchar *new_text,
                 gpointer user_data)
 {
-    //log("path:'%s' new_text:'%s'", tree_path, new_text);
+    //log_warning("path:'%s' new_text:'%s'", tree_path, new_text);
 
     GtkTreeIter iter;
     if (!gtk_tree_model_get_iter_from_string(GTK_TREE_MODEL(g_ls_details), &iter, tree_path))

--- a/src/include/internal_libreport.h
+++ b/src/include/internal_libreport.h
@@ -539,11 +539,11 @@ void set_xfunc_diemode(enum libreport_diemode mode);
 /* Verbosity level */
 #define g_verbose libreport_g_verbose
 extern int g_verbose;
-/* VERB1 log("what you sometimes want to see, even on a production box") */
+/* VERB1 log_warning("what you sometimes want to see, even on a production box") */
 #define VERB1 if (g_verbose >= 1)
-/* VERB2 log("debug message, not going into insanely small details") */
+/* VERB2 log_warning("debug message, not going into insanely small details") */
 #define VERB2 if (g_verbose >= 2)
-/* VERB3 log("lots and lots of details") */
+/* VERB3 log_warning("lots and lots of details") */
 #define VERB3 if (g_verbose >= 3)
 /* there is no level > 3 */
 
@@ -554,9 +554,9 @@ void xfunc_die(void) NORETURN;
 #define die_out_of_memory libreport_die_out_of_memory
 void die_out_of_memory(void) NORETURN;
 
-/* It's a macro, not function, since it collides with log() from math.h */
+/* It's a macro, not function, since it collides with log_warning() from math.h */
 #undef log
-#define log(...)         log_standard(LOG_WARNING, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#define log_warning(...)         log_standard(LOG_WARNING, __FILE__, __LINE__, __func__, __VA_ARGS__)
 #define log_debug(...)   log_standard(LOG_DEBUG,   __FILE__, __LINE__, __func__, __VA_ARGS__)
 #define log_info(...)    log_standard(LOG_INFO,    __FILE__, __LINE__, __func__, __VA_ARGS__)
 #define log_notice(...)  log_standard(LOG_NOTICE,  __FILE__, __LINE__, __func__, __VA_ARGS__)

--- a/src/lib/abrt_dbus.c
+++ b/src/lib/abrt_dbus.c
@@ -134,7 +134,7 @@ int load_charp(DBusMessageIter* iter, const char** val)
         return -1;
     }
     dbus_message_iter_get_basic(iter, val);
-//log("load_charp:'%s'", *val);
+//log_warning("load_charp:'%s'", *val);
     return dbus_message_iter_next(iter);
 }
 
@@ -294,7 +294,7 @@ void attach_dbus_conn_to_glib_main_loop(DBusConnection* conn,
     g_dbus_conn = conn;
 
 //do we need this? why?
-//log("dbus_connection_set_dispatch_status_function");
+//log_warning("dbus_connection_set_dispatch_status_function");
 //    dbus_connection_set_dispatch_status_function(conn,
 //                dispatch, /* void dispatch(DBusConnection *conn, DBusDispatchStatus new_status, void* data) */
 //                NULL, /* data */

--- a/src/lib/copy_file_recursive.c
+++ b/src/lib/copy_file_recursive.c
@@ -143,7 +143,7 @@ int copy_file_recursive(const char *source, const char *dest)
 	/* Neither dir not regular file: skip */
 
  skip:
-	log("Skipping '%s'", source);
+	log_warning("Skipping '%s'", source);
  ret:
 	return retval;
 }

--- a/src/lib/curl.c
+++ b/src/lib/curl.c
@@ -224,7 +224,7 @@ static size_t fread_with_reporting(void *ptr, size_t size, size_t nmemb, void *u
         last_t = t;
         report_interval *= 2;
         off_t sz = fstat_st_size_or_die(fileno(fp));
-        log(_("Uploaded: %llu of %llu kbytes"),
+        log_warning(_("Uploaded: %llu of %llu kbytes"),
                 (unsigned long long)cur_pos / 1024,
                 (unsigned long long)sz / 1024);
     }
@@ -267,25 +267,25 @@ static int curl_debug(CURL *handle, curl_infotype it, char *buf, size_t bufsize,
     switch (it) {
     case CURLINFO_TEXT: /* The data is informational text. */
         /* Here eol is always "^J" or "", not printing it */
-        log("curl: %.*s", (int) bufsize, buf);
+        log_warning("curl: %.*s", (int) bufsize, buf);
         break;
     case CURLINFO_HEADER_IN: /* The data is header (or header-like) data received from the peer. */
-        log("curl rcvd header: '%.*s%s'", (int) bufsize, buf, eol);
+        log_warning("curl rcvd header: '%.*s%s'", (int) bufsize, buf, eol);
         break;
     case CURLINFO_HEADER_OUT: /* The data is header (or header-like) data sent to the peer. */
-        log("curl sent header: '%.*s%s'", (int) bufsize, buf, eol);
+        log_warning("curl sent header: '%.*s%s'", (int) bufsize, buf, eol);
         break;
     case CURLINFO_DATA_IN: /* The data is protocol data received from the peer. */
         if (g_verbose >= 3)
-            log("curl rcvd data: '%.*s%s'", (int) bufsize, buf, eol);
+            log_warning("curl rcvd data: '%.*s%s'", (int) bufsize, buf, eol);
         else
-            log("curl rcvd data %u bytes", orig_bufsize);
+            log_warning("curl rcvd data %u bytes", orig_bufsize);
         break;
     case CURLINFO_DATA_OUT: /* The data is protocol data sent to the peer. */
         if (g_verbose >= 3)
-            log("curl sent data: '%.*s%s'", (int) bufsize, buf, eol);
+            log_warning("curl sent data: '%.*s%s'", (int) bufsize, buf, eol);
         else
-            log("curl sent data %u bytes", orig_bufsize);
+            log_warning("curl sent data %u bytes", orig_bufsize);
         break;
     default:
         break;
@@ -663,7 +663,7 @@ char *upload_file_ext(post_state_t *state, const char *url, const char *filename
 
     /* Do not include the path part of the URL as it can contain sensitive data
      * in case of typos */
-    log(_("Sending %s to %s//%s"), filename, scheme, hostname);
+    log_warning(_("Sending %s to %s//%s"), filename, scheme, hostname);
     post(state,
                 whole_url,
                 /*content_type:*/ "application/octet-stream",
@@ -716,7 +716,7 @@ char *upload_file_ext(post_state_t *state, const char *url, const char *filename
     else
     {
         /* This ends up a "reporting status message" in abrtd */
-        log(_("Successfully created %s"), whole_url);
+        log_warning(_("Successfully created %s"), whole_url);
     }
 
     close(stdin_bck);

--- a/src/lib/dump_dir.c
+++ b/src/lib/dump_dir.c
@@ -358,7 +358,7 @@ int create_symlink_lockfile_at(int dir_fd, const char* lock_file, const char* pi
 
         if (strcmp(pid_buf, pid) == 0)
         {
-            log("Lock file '%s' is already locked by us", lock_file);
+            log_warning("Lock file '%s' is already locked by us", lock_file);
             errno = EALREADY;
             return 0;
         }
@@ -368,10 +368,10 @@ int create_symlink_lockfile_at(int dir_fd, const char* lock_file, const char* pi
             snprintf(pid_str, sizeof(pid_str), "/proc/%s", pid_buf);
             if (access(pid_str, F_OK) == 0)
             {
-                log("Lock file '%s' is locked by process %s", lock_file, pid_buf);
+                log_warning("Lock file '%s' is locked by process %s", lock_file, pid_buf);
                 return 0;
             }
-            log("Lock file '%s' was locked by process %s, but it crashed?", lock_file, pid_buf);
+            log_warning("Lock file '%s' was locked by process %s, but it crashed?", lock_file, pid_buf);
         }
         /* The file may be deleted by now by other process. Ignore ENOENT */
         if (unlinkat(dir_fd, lock_file, /*only files*/0) != 0 && errno != ENOENT)

--- a/src/lib/event_config.c
+++ b/src/lib/event_config.c
@@ -212,12 +212,12 @@ static void load_config_files(const char *dir_path)
             if (elem)
             {
                 opt = elem->data;
-                // log("conf: replacing '%s' value:'%s'->'%s'", name, opt->value, value);
+                // log_warning("conf: replacing '%s' value:'%s'->'%s'", name, opt->value, value);
                 free(opt->eo_value);
             }
             else
             {
-                // log("conf: new value %s='%s'", name, value);
+                // log_warning("conf: new value %s='%s'", name, value);
                 opt = new_event_option();
                 opt->eo_name = xstrdup(name);
             }

--- a/src/lib/event_xml_parser.c
+++ b/src/lib/event_xml_parser.c
@@ -154,13 +154,13 @@ static void consume_cur_option(struct my_parse_data *parse_data)
             opt->eo_value = old_opt->eo_value;
             old_opt->eo_value = NULL;
         }
-        //log("xml: replacing '%s' value:'%s'->'%s'", opt->eo_name, old_opt->eo_value, opt->eo_value);
+        //log_warning("xml: replacing '%s' value:'%s'->'%s'", opt->eo_name, old_opt->eo_value, opt->eo_value);
         free_event_option(old_opt);
         elem->data = opt;
     }
     else
     {
-        //log("xml: new value %s='%s'", opt->eo_name, opt->eo_value);
+        //log_warning("xml: new value %s='%s'", opt->eo_name, opt->eo_value);
         event_config->values->options = g_list_append(event_config->values->options, opt);
     }
 }
@@ -173,7 +173,7 @@ static void start_element(GMarkupParseContext *context,
                   gpointer user_data,
                   GError **error)
 {
-    //log("start: %s", element_name);
+    //log_warning("start: %s", element_name);
 
     struct my_parse_data *parse_data = user_data;
     if (strcmp(element_name, ADV_OPTIONS_ELEMENT) == 0)
@@ -494,7 +494,7 @@ static void text(GMarkupParseContext *context,
             ui->ec_minimal_rating = strtol(text_copy, &endptr, 10);
             if (errno != 0 || endptr == text_copy || *endptr != '\0')
             {
-                log("invalid minimal-rating number '%s', set to default 4", text_copy);
+                log_warning("invalid minimal-rating number '%s', set to default 4", text_copy);
                 ui->ec_minimal_rating = 4;
             }
         }

--- a/src/lib/glib_support.c
+++ b/src/lib/glib_support.c
@@ -48,7 +48,7 @@ void glib_init(void)
                                                            GLIB_MINOR_VERSION,
                                                            GLIB_MICRO_VERSION);
         if (version_mismatch != NULL)
-            log("Running GLib incompatible version: %s", version_mismatch);
+            log_warning("Running GLib incompatible version: %s", version_mismatch);
     }
 }
 

--- a/src/lib/parse_options.c
+++ b/src/lib/parse_options.c
@@ -180,7 +180,7 @@ unsigned parse_opts(int argc, char **argv, const struct options *opt,
             case OPTION_END:
                 break;
         }
-        //log("curopt[%d].name:'%s' .has_arg:%d .flag:%p .val:%d", (int)(curopt-longopts),
+        //log_warning("curopt[%d].name:'%s' .has_arg:%d .flag:%p .val:%d", (int)(curopt-longopts),
         //      curopt->name, curopt->has_arg, curopt->flag, curopt->val);
         /*
          * getopt_long() thinks that NULL name marks the end of longopts.

--- a/src/lib/problem_data.c
+++ b/src/lib/problem_data.c
@@ -504,14 +504,14 @@ void problem_data_load_from_dump_dir(problem_data_t *problem_data, struct dump_d
     {
         if (excluding && is_in_string_list(short_name, (const char *const *)excluding))
         {
-            //log("Excluded:'%s'", short_name);
+            //log_warning("Excluded:'%s'", short_name);
             goto next;
         }
 
         if (short_name[0] == '#'
          || (short_name[0] && short_name[strlen(short_name) - 1] == '~')
         ) {
-            //log("Excluded (editor backup file):'%s'", short_name);
+            //log_warning("Excluded (editor backup file):'%s'", short_name);
             goto next;
         }
 
@@ -592,7 +592,7 @@ void log_problem_data(problem_data_t *problem_data, const char *pfx)
     g_hash_table_iter_init(&iter, problem_data);
     while (g_hash_table_iter_next(&iter, (void**)&name, (void**)&value))
     {
-        log("%s[%s]:'%s' 0x%x",
+        log_warning("%s[%s]:'%s' 0x%x",
                 pfx, name,
                 value->content,
                 value->flags

--- a/src/lib/problem_report.c
+++ b/src/lib/problem_report.c
@@ -483,7 +483,7 @@ append_short_backtrace(struct strbuf *result, problem_data_t *problem_data, bool
 
         if (!backtrace)
         {
-            log(_("Can't parse backtrace: %s"), error_msg);
+            log_warning(_("Can't parse backtrace: %s"), error_msg);
             free(error_msg);
             return 0;
         }
@@ -498,7 +498,7 @@ append_short_backtrace(struct strbuf *result, problem_data_t *problem_data, bool
 
         if (!truncated)
         {
-            log(_("Can't generate stacktrace description (no crash thread?)"));
+            log_warning(_("Can't generate stacktrace description (no crash thread?)"));
             return 0;
         }
     }
@@ -555,7 +555,7 @@ append_item(struct strbuf *result, const char *item_name, problem_data_t *pd, GL
     bool text      = (strcmp(item_name+1, "text"     ) == 0);
     if (!oneline && !multiline && !text)
     {
-        log("Unknown or unsupported element specifier '%s'", item_name);
+        log_warning("Unknown or unsupported element specifier '%s'", item_name);
         return 0; /* "I did not print anything" */
     }
 
@@ -665,7 +665,7 @@ get_special_items(const char *item_name, problem_data_t *pd, GList *comment_fmt_
     bool binary    = (strcmp(item_name+1, "binary"   ) == 0);
     if (!oneline && !multiline && !text && !binary)
     {
-        log("Unknown or unsupported element specifier '%s'", item_name);
+        log_warning("Unknown or unsupported element specifier '%s'", item_name);
         return NULL;
     }
 

--- a/src/lib/run_event.c
+++ b/src/lib/run_event.c
@@ -250,9 +250,9 @@ GList *load_rule_list(GList *rule_list,
             }
             else if (g_verbose >= 3)
             {
-                log("Adding '%s'\nwith conditions:", p);
+                log_warning("Adding '%s'\nwith conditions:", p);
                 for (GList *c = cur_rule->conditions; c != NULL; c = g_list_next(c))
-                    log("| %s", (const char *)c->data);
+                    log_warning("| %s", (const char *)c->data);
             }
 
             cur_rule->command = xstrdup(p);
@@ -313,7 +313,7 @@ static int regcmp_lines(char *val, const char *regex)
 {
     regex_t rx;
     int r = regcomp(&rx, regex, REG_NOSUB); //TODO: and REG_EXTENDED?
-    //log("REGEX:'%s':%d", regex, r);
+    //log_warning("REGEX:'%s':%d", regex, r);
     if (r)
     {
         //char errbuf[256];
@@ -329,7 +329,7 @@ static int regcmp_lines(char *val, const char *regex)
         if (eol)
             *eol = '\0';
         r = regexec(&rx, val, 0, NULL, /*eflags:*/ 0);
-        //log("REGCMP:'%s':%d", val, r);
+        //log_warning("REGCMP:'%s':%d", val, r);
         if (eol)
             *eol = '\n';
         if (r == 0 || !eol)

--- a/src/lib/steal_directory.c
+++ b/src/lib/steal_directory.c
@@ -88,7 +88,7 @@ struct dump_dir *open_directory_for_writing(
     if (dd->locked)
         return dd;
 
-    log("'%s' is not writable", dump_dir_name);
+    log_warning("'%s' is not writable", dump_dir_name);
     dd_close(dd);
 
     char *spooldir = concat_path_file(g_get_user_cache_dir(), "abrt/spool");

--- a/src/lib/workflow_xml_parser.c
+++ b/src/lib/workflow_xml_parser.c
@@ -35,7 +35,7 @@ static void start_element(GMarkupParseContext *context,
                   gpointer user_data,
                   GError **error)
 {
-    //log("start: %s", element_name);
+    //log_warning("start: %s", element_name);
 
     struct my_parse_data *parse_data = user_data;
     if (strcmp(element_name, EVENTS_ELEMENT) == 0)

--- a/src/plugins/mantisbt.c
+++ b/src/plugins/mantisbt.c
@@ -122,7 +122,7 @@ mantisbt_find_origin_bug_closed_duplicate(mantisbt_settings_t *settings, mantisb
         if (ii == MAX_HOPS)
             error_msg_and_die(_("MantisBT couldn't find parent of issue %d"), info->mii_id);
 
-        log("Issue %d is a duplicate, using parent issue %d", info_tmp->mii_id, info_tmp->mii_dup_id);
+        log_warning("Issue %d is a duplicate, using parent issue %d", info_tmp->mii_id, info_tmp->mii_dup_id);
         int issue_id = info_tmp->mii_dup_id;
 
         mantisbt_issue_info_free(info_tmp);

--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -213,7 +213,7 @@ char *ask_bz_password(const char *message)
 static
 void login(struct abrt_xmlrpc *client, struct bugzilla_struct *rhbz)
 {
-    log(_("Logging into Bugzilla at %s"), rhbz->b_bugzilla_url);
+    log_warning(_("Logging into Bugzilla at %s"), rhbz->b_bugzilla_url);
     while (!rhbz_login(client, rhbz->b_login, rhbz->b_password))
     {
         free(rhbz->b_login);
@@ -382,7 +382,7 @@ int main(int argc, char **argv)
 
     if (abrt_hash)
     {
-        log(_("Looking for similar problems in bugzilla"));
+        log_warning(_("Looking for similar problems in bugzilla"));
         char *hash;
         if (prefixcmp(abrt_hash, "abrt_hash:"))
             hash = xasprintf("abrt_hash:%s", abrt_hash);
@@ -488,7 +488,7 @@ int main(int argc, char **argv)
 
             /* won't ever call free on it - it simplifies the code a lot */
             ticket_no = xstrdup(ticket_no + 1);
-            log(_("Using Bugzilla ID '%s'"), ticket_no);
+            log_warning(_("Using Bugzilla ID '%s'"), ticket_no);
         }
 
         login(client, &rhbz);
@@ -522,7 +522,7 @@ int main(int argc, char **argv)
             }
         }
 
-        log(_("Logging out"));
+        log_warning(_("Logging out"));
         rhbz_logout(client);
 
 #if 0  /* enable if you search for leaks (valgrind etc) */
@@ -631,7 +631,7 @@ int main(int argc, char **argv)
     struct bug_info *bz = NULL;
     if (!bug_id)
     {
-        log(_("Checking for duplicates"));
+        log_warning(_("Checking for duplicates"));
 
         int existing_id = -1;
         int crossver_id = -1;
@@ -707,7 +707,7 @@ int main(int argc, char **argv)
 
                 if (r == 0)
                 {
-                    log(_("Logging out"));
+                    log_warning(_("Logging out"));
                     rhbz_logout(client);
 
                     problem_formatter_free(pf);
@@ -723,7 +723,7 @@ int main(int argc, char **argv)
             }
 
             /* Create new bug */
-            log(_("Creating a new bug"));
+            log_warning(_("Creating a new bug"));
 
             if (existing_id < 0 && crossver_id >= 0)
                 problem_report_buffer_printf(
@@ -758,7 +758,7 @@ int main(int argc, char **argv)
                 if (extra != NULL) {
                     char *email = strtok(extra, "\n");
                     while (email != NULL) {
-                        log(_("Adding extra cc %s to bug report"), email);
+                        log_warning(_("Adding extra cc %s to bug report"), email);
                         rhbz_mail_to_cc(client, new_id, email, /* require mail notify */ 0);
                         email = strtok(NULL, "\n");
                     }
@@ -767,13 +767,13 @@ int main(int argc, char **argv)
 
                 if (reported_to && reported_to->url)
                 {
-                    log(_("Adding External URL to bug %i"), new_id);
+                    log_warning(_("Adding External URL to bug %i"), new_id);
                     rhbz_set_url(client, new_id, reported_to->url, RHBZ_NOMAIL_NOTIFY);
                     free_report_result(reported_to);
                 }
             }
 
-            log(_("Adding attachments to bug %i"), new_id);
+            log_warning(_("Adding attachments to bug %i"), new_id);
             char new_id_str[sizeof(int)*3 + 2];
             sprintf(new_id_str, "%i", new_id);
 
@@ -795,7 +795,7 @@ int main(int argc, char **argv)
 
             if (existing_id >= 0)
             {
-                log(_("Closing bug %i as duplicate of bug %i"), new_id, existing_id);
+                log_warning(_("Closing bug %i as duplicate of bug %i"), new_id, existing_id);
                 rhbz_close_as_duplicate(client, new_id, existing_id, RHBZ_NOMAIL_NOTIFY);
             }
 
@@ -807,7 +807,7 @@ int main(int argc, char **argv)
 
     bz = rhbz_bug_info(client, bug_id);
 
-    log(_("Bug is already reported: %i"), bz->bi_id);
+    log_warning(_("Bug is already reported: %i"), bz->bi_id);
 
     /* Follow duplicates */
     if ((strcmp(bz->bi_status, "CLOSED") == 0)
@@ -850,7 +850,7 @@ int main(int argc, char **argv)
     if (strcmp(bz->bi_reporter, rhbz.b_login) != 0
      && !g_list_find_custom(bz->bi_cc_list, rhbz.b_login, (GCompareFunc)g_strcmp0)
     ) {
-        log(_("Adding %s to CC list"), rhbz.b_login);
+        log_warning(_("Adding %s to CC list"), rhbz.b_login);
         rhbz_mail_to_cc(client, bz->bi_id, rhbz.b_login, RHBZ_NOMAIL_NOTIFY);
     }
 
@@ -871,7 +871,7 @@ int main(int argc, char **argv)
         int dup_comment = is_comment_dup(bz->bi_comments, bzcomment);
         if (!dup_comment)
         {
-            log(_("Adding new comment to bug %d"), bz->bi_id);
+            log_warning(_("Adding new comment to bug %d"), bz->bi_id);
             rhbz_add_comment(client, bz->bi_id, bzcomment, 0);
 
             const char *bt = problem_data_get_content_or_NULL(problem_data, FILENAME_BACKTRACE);
@@ -884,23 +884,23 @@ int main(int argc, char **argv)
             {
                 char bug_id_str[sizeof(int)*3 + 2];
                 sprintf(bug_id_str, "%i", bz->bi_id);
-                log(_("Attaching better backtrace"));
+                log_warning(_("Attaching better backtrace"));
                 rhbz_attach_blob(client, bug_id_str, FILENAME_BACKTRACE, bt, strlen(bt),
                                  RHBZ_NOMAIL_NOTIFY);
             }
         }
         else
-            log(_("Found the same comment in the bug history, not adding a new one"));
+            log_warning(_("Found the same comment in the bug history, not adding a new one"));
 
         problem_report_free(pr);
         problem_formatter_free(pf);
     }
 
  log_out:
-    log(_("Logging out"));
+    log_warning(_("Logging out"));
     rhbz_logout(client);
 
-    log(_("Status: %s%s%s %s/show_bug.cgi?id=%u"),
+    log_warning(_("Status: %s%s%s %s/show_bug.cgi?id=%u"),
                 bz->bi_status,
                 bz->bi_resolution ? " " : "",
                 bz->bi_resolution ? bz->bi_resolution : "",

--- a/src/plugins/reporter-kerneloops.c
+++ b/src/plugins/reporter-kerneloops.c
@@ -26,7 +26,7 @@ static size_t writefunction(void *ptr, size_t size, size_t nmemb, void *stream)
 /*
     char *c, *c1, *c2;
 
-    log("received: '%*.*s'", (int)size, (int)size, (char*)ptr);
+    log_warning("received: '%*.*s'", (int)size, (int)size, (char*)ptr);
     c = (char*)xzalloc(size + 1);
     memcpy(c, ptr, size);
     c1 = strstr(c, "201 ");
@@ -102,7 +102,7 @@ static void report_to_kerneloops(
     if (!submitURL[0])
         submitURL = "http://oops.kernel.org/submitoops.php";
 
-    log(_("Submitting oops report to %s"), submitURL);
+    log_warning(_("Submitting oops report to %s"), submitURL);
 
     CURLcode ret = http_post_to_kerneloops_site(submitURL, backtrace);
     if (ret != CURLE_OK)
@@ -124,7 +124,7 @@ static void report_to_kerneloops(
         dd_close(dd);
     }
 
-    log("Kernel oops report was uploaded");
+    log_warning("Kernel oops report was uploaded");
 }
 
 int main(int argc, char **argv)

--- a/src/plugins/reporter-mailx.c
+++ b/src/plugins/reporter-mailx.c
@@ -67,11 +67,11 @@ static void exec_and_feed_input(const char* text, char **args)
 
 static char** append_str_to_vector(char **vec, unsigned *size_p, const char *str)
 {
-    //log("old vec: %p", vec);
+    //log_warning("old vec: %p", vec);
     unsigned size = *size_p;
     vec = (char**) xrealloc(vec, (size+2) * sizeof(vec[0]));
     vec[size] = xstrdup(str);
-    //log("new vec: %p, added [%d] %p", vec, size, vec[size]);
+    //log_warning("new vec: %p, added [%d] %p", vec, size, vec[size]);
     size++;
     vec[size] = NULL;
     *size_p = size;
@@ -204,9 +204,9 @@ static void create_and_send_email(
     putenv((char*)"DEAD=/dev/null");
 
     if (flag & RM_FLAG_NOTIFY)
-        log(_("Sending a notification email to: %s"), email_to);
+        log_warning(_("Sending a notification email to: %s"), email_to);
     else
-        log(_("Sending an email..."));
+        log_warning(_("Sending an email..."));
 
     exec_and_feed_input(dsc, args);
 
@@ -231,7 +231,7 @@ static void create_and_send_email(
             free(rr.url);
             dd_close(dd);
         }
-        log(_("Email was sent to: %s"), email_to);
+        log_warning(_("Email was sent to: %s"), email_to);
     }
 
     free(email_to);

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -106,7 +106,7 @@ verify_credentials(mantisbt_settings_t *settings)
         {
             GList *ids = response_get_main_ids_list(result->mr_body);
             if (ids != NULL)
-                log("%s", (char *)ids->data);
+                log_warning("%s", (char *)ids->data);
             response_values_free(ids);
         }
 
@@ -337,7 +337,7 @@ int main(int argc, char **argv)
 
     if (abrt_hash)
     {
-        log(_("Looking for similar problems in MantisBT"));
+        log_warning(_("Looking for similar problems in MantisBT"));
         GList *ids = mantisbt_search_by_abrt_hash(&mbt_settings, abrt_hash);
         mantisbt_settings_free(&mbt_settings);
 
@@ -380,7 +380,7 @@ int main(int argc, char **argv)
 
             /* won't ever call free on it - it simplifies the code a lot */
             ticket_no = xstrdup(ticket_no + 1);
-            log(_("Using MantisBT ID '%s'"), ticket_no);
+            log_warning(_("Using MantisBT ID '%s'"), ticket_no);
         }
 
         /* Attach files to existing MantisBT issues */
@@ -388,7 +388,7 @@ int main(int argc, char **argv)
         {
             const char *path = *argv++;
             char *filename = basename(path);
-            log(_("Attaching file '%s' to issue %s"), filename, ticket_no);
+            log_warning(_("Attaching file '%s' to issue %s"), filename, ticket_no);
             mantisbt_attach_file(&mbt_settings, ticket_no, filename, path);
         }
 
@@ -483,7 +483,7 @@ int main(int argc, char **argv)
     mantisbt_issue_info_t *ii;
     if (!bug_id)
     {
-        log(_("Checking for duplicates"));
+        log_warning(_("Checking for duplicates"));
 
         int existing_id = -1;
         int crossver_id = -1;
@@ -522,7 +522,7 @@ int main(int argc, char **argv)
         if (existing_id < 0)
         {
             /* Create new issue */
-            log(_("Creating a new issue"));
+            log_warning(_("Creating a new issue"));
             problem_formatter_t *pf = problem_formatter_new();
             problem_formatter_add_section(pf, PR_SEC_ADDITIONAL_INFO, 0);
 
@@ -550,7 +550,7 @@ int main(int argc, char **argv)
 
                 if (reported_to && reported_to->url)
                 {
-                    log(_("Adding External URL to issue"));
+                    log_warning(_("Adding External URL to issue"));
                     tracker_url = xstrdup(reported_to->url);
                     free_report_result(reported_to);
                 }
@@ -563,7 +563,7 @@ int main(int argc, char **argv)
             if (new_id == -1)
                 return EXIT_FAILURE;
 
-            log(_("Adding attachments to issue %i"), new_id);
+            log_warning(_("Adding attachments to issue %i"), new_id);
             char *new_id_str = xasprintf("%u", new_id);
 
             for (GList *a = problem_report_get_attachments(pr); a != NULL; a = g_list_next(a))
@@ -592,7 +592,7 @@ int main(int argc, char **argv)
 
     ii = mantisbt_get_issue_info(&mbt_settings, bug_id);
 
-    log(_("Bug is already reported: %i"), ii->mii_id);
+    log_warning(_("Bug is already reported: %i"), ii->mii_id);
 
     /* Follow duplicates */
     if ((strcmp(ii->mii_status, "closed") == 0)
@@ -629,7 +629,7 @@ int main(int argc, char **argv)
         int dup_comment = is_comment_dup(ii->mii_notes, mbtcomment);
         if (!dup_comment)
         {
-            log(_("Adding new comment to issue %d"), ii->mii_id);
+            log_warning(_("Adding new comment to issue %d"), ii->mii_id);
             mantisbt_add_issue_note(&mbt_settings, ii->mii_id, mbtcomment);
 
             const char *bt = problem_data_get_content_or_NULL(problem_data, FILENAME_BACKTRACE);
@@ -642,7 +642,7 @@ int main(int argc, char **argv)
             {
                 char *bug_id_str = xasprintf("%i", ii->mii_id);
 
-                log(_("Attaching better backtrace"));
+                log_warning(_("Attaching better backtrace"));
 
                 // find unique filename of attachment
                 char *name = NULL;
@@ -665,14 +665,14 @@ int main(int argc, char **argv)
             }
         }
         else
-            log(_("Found the same comment in the issue history, not adding a new one"));
+            log_warning(_("Found the same comment in the issue history, not adding a new one"));
 
         problem_report_free(pr);
         problem_formatter_free(pf);
     }
 
 finish:
-    log(_("Status: %s%s%s %s/view.php?id=%u"),
+    log_warning(_("Status: %s%s%s %s/view.php?id=%u"),
                 ii->mii_status,
                 ii->mii_resolution ? " " : "",
                 ii->mii_resolution ? ii->mii_resolution : "",

--- a/src/plugins/reporter-print.c
+++ b/src/plugins/reporter-print.c
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
             }
         }
         const char *format = (open_mode[0] == 'a' ? _("The report was appended to %s") : _("The report was stored to %s"));
-        log(format, output_file);
+        log_warning(format, output_file);
         free(output_file);
     }
 

--- a/src/plugins/reporter-rhtsupport-parse.c
+++ b/src/plugins/reporter-rhtsupport-parse.c
@@ -39,7 +39,7 @@ static void start_element(
                 gpointer            user_data,
                 GError              **error)
 {
-    //log("start: %s", element_name);
+    //log_warning("start: %s", element_name);
 
     struct my_parse_data *parse_data = user_data;
 

--- a/src/plugins/reporter-rhtsupport.c
+++ b/src/plugins/reporter-rhtsupport.c
@@ -291,7 +291,7 @@ char *submit_ureport(const char *dump_dir_name, struct ureport_server_config *co
         ureport_server_response_save_in_dump_dir(resp, dump_dir_name, conf);
 
         if (resp->urr_message)
-            log("%s", resp->urr_message);
+            log_warning("%s", resp->urr_message);
     }
     else if (g_verbose > 2)
         error_msg(_("Server responded with an error: '%s'"), resp->urr_value);
@@ -321,9 +321,9 @@ bool check_for_hints(const char *url, char **login, char **password, bool ssl_ve
     );
 
 #if 0 /* testing */
-    log("ERR:%d", result->error);
-    log("MSG:'%s'", result->msg);
-    log("BODY:'%s'", result->body);
+    log_warning("ERR:%d", result->error);
+    log_warning("MSG:'%s'", result->msg);
+    log_warning("BODY:'%s'", result->body);
     result->error = 0;
     result->body = xstrdup(
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
@@ -595,8 +595,8 @@ int main(int argc, char **argv)
                 error_msg_and_die("Can't attach: problem data in '%s' "
                         "was not reported to RHTSupport and therefore has no URL",
                         dump_dir_name);
-            //log("URL:'%s'", reported_to->url);
-            //log("MSG:'%s'", reported_to->msg);
+            //log_warning("URL:'%s'", reported_to->url);
+            //log_warning("MSG:'%s'", reported_to->msg);
             free(url);
             url = reported_to->url;
             reported_to->url = NULL;
@@ -616,7 +616,7 @@ int main(int argc, char **argv)
             /* -t[CASE] FILE: just attach files and exit */
             while (*argv)
             {
-                log(_("Attaching '%s' to case '%s'"), *argv, url);
+                log_warning(_("Attaching '%s' to case '%s'"), *argv, url);
                 rhts_result_t *result = attach_file_to_case(url,
                     login,
                     password,
@@ -625,8 +625,8 @@ int main(int argc, char **argv)
                 );
                 if (result->error)
                     error_msg_and_die("%s", result->msg);
-                log("Attachment URL:%s", result->url);
-                log("File attached successfully");
+                log_warning("Attachment URL:%s", result->url);
+                log_warning("File attached successfully");
                 free_rhts_result(result);
                 argv++;
             }
@@ -653,7 +653,7 @@ int main(int argc, char **argv)
 
         if (submit_ur)
         {
-            log(_("Sending ABRT crash statistics data"));
+            log_warning(_("Sending ABRT crash statistics data"));
 
             bthash = submit_ureport(dump_dir_name, &urconf);
 
@@ -794,7 +794,7 @@ int main(int argc, char **argv)
     }
 
     /* Gzipping e.g. 0.5gig coredump takes a while. Let user know what we are doing */
-    log(_("Compressing data"));
+    log_warning(_("Compressing data"));
 
     struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
     if (!dd)
@@ -813,12 +813,12 @@ int main(int argc, char **argv)
         if (tempfile_size <= QUERY_HINTS_IF_SMALLER_THAN)
         {
             /* Check for hints and show them if we have something */
-            log(_("Checking for hints"));
+            log_warning(_("Checking for hints"));
             if (check_for_hints(base_api_url, &login, &password, ssl_verify, tempfile))
                 goto ret;
         }
 
-        log(_("Creating a new case"));
+        log_warning(_("Creating a new case"));
 
         char *product = NULL;
         char *version = NULL;
@@ -878,14 +878,14 @@ int main(int argc, char **argv)
             add_reported_to_entry(dd, &rr);
             dd_close(dd);
             if (result->msg)
-                log("%s", result->msg);
-            log("URL=%s", result->url);
+                log_warning("%s", result->msg);
+            log_warning("URL=%s", result->url);
         }
         /* else: error msg was already emitted by dd_opendir */
 
         if (bthash)
         {
-            log(_("Linking ABRT crash statistics record with the case"));
+            log_warning(_("Linking ABRT crash statistics record with the case"));
 
             /* Make sure we use the current credentials */
             ureport_server_config_set_basic_auth(&urconf, login, password);
@@ -898,7 +898,7 @@ int main(int argc, char **argv)
             UREPORT_OPTION_VALUE_FROM_CONF(ursettings, "ContactEmail", email, (const char *));
             if (email != NULL)
             {
-                log(_("Linking ABRT crash statistics record with contact email: '%s'"), email);
+                log_warning(_("Linking ABRT crash statistics record with contact email: '%s'"), email);
                 attach_to_ureport(&urconf, bthash, "email", email);
             }
 
@@ -917,12 +917,12 @@ int main(int argc, char **argv)
     if (bigsize != 0 && tempfile_size / (1024*1024) >= bigsize)
     {
         /* Upload tarball of -d DIR to "big file" FTP */
-        /* log(_("Uploading problem data to '%s'"), bigurl); - upload_file does this */
+        /* log_warning(_("Uploading problem data to '%s'"), bigurl); - upload_file does this */
         remote_filename = upload_file(bigurl, tempfile);
     }
     if (remote_filename)
     {
-        log(_("Adding comment to case '%s'"), url);
+        log_warning(_("Adding comment to case '%s'"), url);
         /*
          * Do not translate message below - it goes
          * to a server where *other people* will read it.
@@ -940,7 +940,7 @@ int main(int argc, char **argv)
     else
     {
         /* Attach the tarball of -d DIR */
-        log(_("Attaching problem data to case '%s'"), url);
+        log_warning(_("Attaching problem data to case '%s'"), url);
         INVALID_CREDENTIALS_LOOP(login, password,
                 result_atch, attach_file_to_case(url, login, password, ssl_verify, tempfile)
         );
@@ -952,11 +952,11 @@ int main(int argc, char **argv)
             /* Prepend "Case created" text to whatever error message there is,
              * so that user knows that case _was_ created despite error in attaching.
              */
-            log("Case created but failed to attach problem data: %s", result_atch->msg);
+            log_warning("Case created but failed to attach problem data: %s", result_atch->msg);
         }
         else
         {
-            log("Failed to attach problem data: %s", result_atch->msg);
+            log_warning("Failed to attach problem data: %s", result_atch->msg);
         }
     }
 

--- a/src/plugins/reporter-systemd-journal.c
+++ b/src/plugins/reporter-systemd-journal.c
@@ -334,7 +334,7 @@ int main(int argc, char **argv)
     /* Debug */
     if (opts & OPT_D)
     {
-        log("Message: %s\n"
+        log_warning("Message: %s\n"
                 "\n"
                 "%s"
                 "\n"

--- a/src/plugins/reporter-upload.c
+++ b/src/plugins/reporter-upload.c
@@ -100,7 +100,7 @@ static int create_and_upload_archive(
         xfunc_die(); /* error msg is already logged by dd_opendir */
 
     /* Compressing e.g. 0.5gig coredump takes a while. Let client know what we are doing */
-    log(_("Compressing data"));
+    log_warning(_("Compressing data"));
     if (dd_create_archive(dd, tempfile, (const_string_vector_const_ptr_t)exclude_from_report, 0) != 0)
     {
         log_error("Can't create temporary file in %s", LARGE_DATA_TMP_DIR);
@@ -117,7 +117,7 @@ static int create_and_upload_archive(
     else
     {
         result = 0; /* success */
-        log(_("Archive is created: '%s'"), tempfile);
+        log_warning(_("Archive is created: '%s'"), tempfile);
         *remote_name = tempfile;
         tempfile = NULL;
     }

--- a/src/plugins/reporter-ureport.c
+++ b/src/plugins/reporter-ureport.c
@@ -313,9 +313,9 @@ int main(int argc, char **argv)
         /* If a reported problem is not known then emit NEEDMORE */
         if (strcmp("true", response->urr_value) == 0)
         {
-            log(_("This problem has already been reported."));
+            log_warning(_("This problem has already been reported."));
             if (response->urr_message)
-                log("%s", response->urr_message);
+                log_warning("%s", response->urr_message);
 
             ret = EXIT_STOP_EVENT_RUN;
         }

--- a/src/plugins/rhbz.c
+++ b/src/plugins/rhbz.c
@@ -34,8 +34,8 @@
 
 //#define DEBUG
 #ifdef DEBUG
-#define func_entry() log("-- %s", __func__)
-#define func_entry_str(x) log("-- %s\t%s", __func__, (x))
+#define func_entry() log_warning("-- %s", __func__)
+#define func_entry_str(x) log_warning("-- %s\t%s", __func__, (x))
 #else
 #define func_entry()
 #define func_entry_str(x)
@@ -601,7 +601,7 @@ int rhbz_new_bug(struct abrt_xmlrpc *ax,
     int new_bug_id = *r;
     free(r);
 
-    log(_("New bug id: %i"), new_bug_id);
+    log_warning(_("New bug id: %i"), new_bug_id);
     return new_bug_id;
 }
 
@@ -723,7 +723,7 @@ struct bug_info *rhbz_find_origin_bug_closed_duplicate(struct abrt_xmlrpc *ax,
         if (ii == MAX_HOPS)
             error_msg_and_die(_("Bugzilla couldn't find parent of bug %d"), bi->bi_id);
 
-        log("Bug %d is a duplicate, using parent bug %d", bi_tmp->bi_id, bi_tmp->bi_dup_id);
+        log_warning("Bug %d is a duplicate, using parent bug %d", bi_tmp->bi_id, bi_tmp->bi_dup_id);
         int bug_id = bi_tmp->bi_dup_id;
 
         free_bug_info(bi_tmp);

--- a/tests/glib_helpers.at
+++ b/tests/glib_helpers.at
@@ -21,8 +21,8 @@ int test(const char *list, const char *delimiter, const char *strings[])
     int retval = 0;
 
     while(l != NULL) {
-        log("is: '%s'", (char *)l->data);
-        log("should be: '%s'", *tmp);
+        log_warning("is: '%s'", (char *)l->data);
+        log_warning("should be: '%s'", *tmp);
         retval |= strcmp((char *)l->data, *(tmp++)) != 0;
         if (retval)
             break; // no need to continue further
@@ -60,8 +60,8 @@ int test(const char *list, const char *strings[])
     int retval = 0;
 
     while(l != NULL) {
-        log("is: '%s'", (char *)l->data);
-        log("should be: '%s'", *tmp);
+        log_warning("is: '%s'", (char *)l->data);
+        log_warning("should be: '%s'", *tmp);
         retval |= strcmp((char *)l->data, *(tmp++)) != 0;
         if (retval)
             break; // no need to continue further

--- a/tests/osrelease.at
+++ b/tests/osrelease.at
@@ -16,12 +16,12 @@ int test(char ***input)
 {
     char * release_string = **input;
     int retcode = 1;
-    log("release: >>%s<<\n", release_string);
+    log_warning("release: >>%s<<\n", release_string);
     char *product = NULL;
     char *version = NULL;
     parse_release_for_bz(release_string, &product, &version);
-    log("version: >>%s<<\n", version);
-    log("product: >>%s<<\n", product);
+    log_warning("version: >>%s<<\n", version);
+    log_warning("product: >>%s<<\n", product);
 
     if(version == NULL || (strlen(version) == 0))
     {
@@ -30,17 +30,17 @@ int test(char ***input)
     }
 
     (*input)++; //expected product is +1 in the array
-    log("'%s' == '%s'", product, **input);
+    log_warning("'%s' == '%s'", product, **input);
     if (strcmp(product, **input) != 0)
         goto ret;
 
     (*input)++; //expected version is +2 in the array
-    log("'%s' == '%s'", version, **input);
+    log_warning("'%s' == '%s'", version, **input);
     if (strcmp(version, **input) == 0)
         retcode = 0;
 
 ret:
-    log("retcode %i\n", retcode);
+    log_warning("retcode %i\n", retcode);
     return retcode;
 }
 
@@ -84,12 +84,12 @@ int test(char ***input)
 {
     char * release_string = **input;
     int retcode = 1;
-    log("release: >>%s<<\n", release_string);
+    log_warning("release: >>%s<<\n", release_string);
     char *product = NULL;
     char *version = NULL;
     parse_release_for_rhts(release_string, &product, &version);
-    log("version: >>%s<<\n", version);
-    log("product: >>%s<<\n", product);
+    log_warning("version: >>%s<<\n", version);
+    log_warning("product: >>%s<<\n", product);
 
     if(version == NULL || (strlen(version) == 0))
     {
@@ -98,17 +98,17 @@ int test(char ***input)
     }
 
     (*input)++; //expected product is +1 in the array
-    log("'%s' == '%s'", product, **input);
+    log_warning("'%s' == '%s'", product, **input);
     if (strcmp(product, **input) != 0)
         goto ret;
 
     (*input)++; //expected version is +2 in the array
-    log("'%s' == '%s'", version, **input);
+    log_warning("'%s' == '%s'", version, **input);
     if (strcmp(version, **input) == 0)
         retcode = 0;
 
 ret:
-    log("retcode %i\n", retcode);
+    log_warning("retcode %i\n", retcode);
     return retcode;
 }
 


### PR DESCRIPTION
Renaming log() logging function to log_warning() because
of conflict with log() function from math.h.

Related to #1481205

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>