### PR TITLE
doc: fix obsolete doxygen tags & complains

### DIFF
--- a/apidoc/Doxyfile.in
+++ b/apidoc/Doxyfile.in
@@ -6,7 +6,6 @@
 PROJECT_BRIEF          = "A tool to inform users about various problems on the running system"
 PROJECT_NAME           = @PACKAGE@
 PROJECT_NUMBER         = @VERSION@
-PROJECT_LOGO           = "@top_srcdir@/icons/hicolor_apps_48x48_abrt.png"
 DOXYFILE_ENCODING      = UTF-8
 OUTPUT_DIRECTORY       = @top_srcdir@/apidoc/
 CREATE_SUBDIRS         = NO
@@ -173,8 +172,6 @@ MAN_LINKS              = NO
 #---------------------------------------------------------------------------
 GENERATE_XML           = NO
 XML_OUTPUT             = xml
-XML_SCHEMA             =
-XML_DTD                =
 XML_PROGRAMLISTING     = YES
 #---------------------------------------------------------------------------
 # configuration options for the AutoGen Definitions output


### PR DESCRIPTION
Removes doxygen tags XML_SCHEMA and XML_DTD in apidoc, which became
obsolete and produces warnings while doxygen documentation generation.
Also removes PROJECT_LOGO tag, which caused error because of
non-existing icon image.