### PR TITLE
client-python,report-python: Allow python to be optional at build time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,18 +56,6 @@ IT_PROG_INTLTOOL([0.35.0])
 
 dnl ****** END ****************************************
 
-AM_PATH_PYTHON
-if test -z "$PYTHON"; then
-    echo "*** Essential program python not found" 1>&2
-    exit 1
-fi
-
-AC_PATH_PROG([PYTHON3], [python3], [no])
-if test -z "$PYTHON3"; then
-    echo "*** Essential program python3 not found" 1>&2
-    exit 1
-fi
-
 AC_PATH_PROG([ASCIIDOC], [asciidoc], [no])
 [if test "$ASCIIDOC" = "no"]
 [then]
@@ -184,11 +172,58 @@ do
 done
 fi dnl end NO_MANTISBT
 
+AC_ARG_WITH(python2,
+AS_HELP_STRING([--with-python2],[use python2 (default is YES)]),
+LIBREPORT_PARSE_WITH([python2]))
+if test -z "$NO_PYTHON2"; then
+AM_CONDITIONAL(BUILD_PYTHON2, true)
+AC_PATH_PROG([PYTHON], [python], [no])
+[if test "$PYTHON" = "no"]
+[then]
+    [echo "The python program was not found in the search path. Please ensure"]
+    [echo "that it is installed and its directory is included in the search path or"]
+    [echo "pass --without-python2 to ./configure."]
+    [echo "Then run configure again before attempting to build libreport."]
+    [exit 1]
+[fi]
+
 AC_PATH_PROG([PYTHON_CONFIG], [python-config], [no])
 [if test "$PYTHON_CONFIG" = "no"]
 [then]
     [echo "The python-config program was not found in the search path. Please ensure"]
-    [echo "that it is installed and its directory is included in the search path."]
+    [echo "that it is installed and its directory is included in the search path or"]
+    [echo "pass --without-python2 to ./configure."]
+    [echo "Then run configure again before attempting to build libreport."]
+    [exit 1]
+[fi]
+
+PYTHON_CFLAGS=`python-config --cflags 2> /dev/null`
+PYTHON_LIBS=`python-config --libs 2> /dev/null`
+
+AC_SUBST(PYTHON_CFLAGS)
+AC_SUBST(PYTHON_LIBS)
+
+AC_SUBST([PYTHON2_EXEC_PREFIX], ['${exec_prefix}'])
+
+PYTHON2_EXECDIR=`$PYTHON -c "import distutils.sysconfig; \
+    print(distutils.sysconfig.get_python_lib(1,0,prefix='$PYTHON2_EXEC_PREFIX'))"`
+
+AC_SUBST(pyexecdir, $PYTHON2_EXECDIR)
+else
+AM_CONDITIONAL(BUILD_PYTHON2, false)
+fi dnl end NO_PYTHON2
+
+AC_ARG_WITH(python3,
+AS_HELP_STRING([--with-python3],[use python3 (default is YES)]),
+LIBREPORT_PARSE_WITH([python3]))
+if test -z "$NO_PYTHON3"; then
+AM_CONDITIONAL(BUILD_PYTHON3, true)
+AC_PATH_PROG([PYTHON3], [python3], [no])
+[if test "$PYTHON3" = "no"]
+[then]
+    [echo "The python3 program was not found in the search path. Please ensure"]
+    [echo "that it is installed and its directory is included in the search path or"]
+    [echo "pass --without-python3 to ./configure."]
     [echo "Then run configure again before attempting to build libreport."]
     [exit 1]
 [fi]
@@ -197,16 +232,17 @@ AC_PATH_PROG([PYTHON3_CONFIG], [python3-config], [no])
 [if test "$PYTHON3_CONFIG" = "no"]
 [then]
     [echo "The python3-config program was not found in the search path. Please ensure"]
-    [echo "that it is installed and its directory is included in the search path."]
+    [echo "that it is installed and its directory is included in the search path or"]
+    [echo "pass --without-python3 to ./configure."]
     [echo "Then run configure again before attempting to build libreport."]
     [exit 1]
 [fi]
 
-PYTHON_CFLAGS=`python-config --cflags 2> /dev/null`
-PYTHON_LIBS=`python-config --libs 2> /dev/null`
-
 PYTHON3_CFLAGS=`python3-config --cflags 2> /dev/null`
 PYTHON3_LIBS=`python3-config --libs 2> /dev/null`
+
+AC_SUBST(PYTHON3_CFLAGS)
+AC_SUBST(PYTHON3_LIBS)
 
 AC_SUBST([PYTHON3_PREFIX], ['${prefix}'])
 AC_SUBST([PYTHON3_EXEC_PREFIX], ['${exec_prefix}'])
@@ -216,13 +252,11 @@ PYTHON3_DIR=`$PYTHON3 -c "import distutils.sysconfig; \
 PYTHON3_EXECDIR=`$PYTHON3 -c "import distutils.sysconfig; \
     print(distutils.sysconfig.get_python_lib(1,0,prefix='$PYTHON3_EXEC_PREFIX'))"`
 
-AC_SUBST(PYTHON_CFLAGS)
-AC_SUBST(PYTHON_LIBS)
-
-AC_SUBST(PYTHON3_CFLAGS)
-AC_SUBST(PYTHON3_LIBS)
 AC_SUBST(python3dir, $PYTHON3_DIR)
 AC_SUBST(py3execdir, $PYTHON3_EXECDIR)
+else
+AM_CONDITIONAL(BUILD_PYTHON3, false)
+fi dnl end NO_PYTHON3
 
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.43])
 PKG_CHECK_MODULES([GOBJECT], [gobject-2.0])

--- a/src/client-python/reportclient/Makefile.am
+++ b/src/client-python/reportclient/Makefile.am
@@ -4,15 +4,6 @@ PYFILES = \
     dnfdebuginfo.py \
     yumdebuginfo.py
 
-py2clientdir = $(pyexecdir)/reportclient
-py3clientdir = $(py3execdir)/reportclient
-
-py2client_PYTHON = $(PYFILES)
-py3client_PYTHON = $(PYFILES)
-
-py2client_LTLIBRARIES = _reportclient.la
-py3client_LTLIBRARIES = _reportclient3.la
-
 PYEXTFILES = \
     clientmodule.c \
     client.c \
@@ -33,17 +24,31 @@ PYEXTLDFLAGS = \
     -avoid-version \
     -Wl,-z,relro -Wl,-z,now
 
+if BUILD_PYTHON2
+py2clientdir = $(pyexecdir)/reportclient
+
+py2client_PYTHON = $(PYFILES)
+py2client_LTLIBRARIES = _reportclient.la
+
 _reportclient_la_SOURCES = $(PYEXTFILES)
 _reportclient_la_CPPFLAGS = $(PYEXTCPPFLAGS) $(PYTHON_CFLAGS)
 _reportclient_la_LDFLAGS = $(PYEXTLDFLAGS) \
     -export-symbols-regex init_reportclient
 _reportclient_la_LIBADD = ../../lib/libreport.la
+endif
+
+if BUILD_PYTHON3
+py3clientdir = $(py3execdir)/reportclient
+
+py3client_PYTHON = $(PYFILES)
+py3client_LTLIBRARIES = _reportclient3.la
 
 _reportclient3_la_SOURCES = $(PYEXTFILES)
 _reportclient3_la_CPPFLAGS = $(PYEXTCPPFLAGS) $(PYTHON3_CFLAGS)
 _reportclient3_la_LDFLAGS = $(PYEXTLDFLAGS) \
     -export-symbols-regex PyInit__reportclient3
 _reportclient3_la_LIBADD = ../../lib/libreport.la
+endif
 
 _reportclient.so: $(clientexec_LTLIBRARIES)
 	ln -sf $(abs_builddir)/.libs/$@ ./

--- a/src/report-python/Makefile.am
+++ b/src/report-python/Makefile.am
@@ -1,14 +1,5 @@
 PYFILES = __init__.py accountmanager.py
 
-pyreportexecdir = $(pyexecdir)/report
-py3reportexecdir = $(py3execdir)/report
-
-pyreportexec_PYTHON = $(PYFILES)
-py3reportexec_PYTHON = $(PYFILES)
-
-pyreportexec_LTLIBRARIES = _pyreport.la
-py3reportexec_LTLIBRARIES = _py3report.la
-
 PYEXTFILES = \
     reportmodule.c \
     problem_data.c \
@@ -34,6 +25,12 @@ PYEXTLDFLAGS = \
     -avoid-version \
     -Wl,-z,relro -Wl,-z,now
 
+if BUILD_PYTHON2
+pyreportexecdir = $(pyexecdir)/report
+
+pyreportexec_PYTHON = $(PYFILES)
+pyreportexec_LTLIBRARIES = _pyreport.la
+
 _pyreport_la_SOURCES = $(PYEXTFILES)
 
 _pyreport_la_CPPFLAGS = \
@@ -47,6 +44,13 @@ _pyreport_la_LDFLAGS = \
 _pyreport_la_LIBADD = \
     ../lib/libreport.la \
     $(PYTHON2_LIBS)
+endif
+
+if BUILD_PYTHON3
+py3reportexecdir = $(py3execdir)/report
+
+py3reportexec_PYTHON = $(PYFILES)
+py3reportexec_LTLIBRARIES = _py3report.la
 
 _py3report_la_SOURCES = $(PYEXTFILES)
 
@@ -61,17 +65,21 @@ _py3report_la_LDFLAGS = \
 _py3report_la_LIBADD = \
     ../lib/libreport.la \
     $(PYTHON3_LIBS)
+endif
 
 # report compat:
-
-pyreportioexecdir = $(pyexecdir)/report/io
-py3reportioexecdir = $(py3execdir)/report/io
-
 PYIOFILES = \
     io/__init__.py \
     io/GTKIO.py \
     io/NewtIO.py \
     io/TextIO.py
 
+if BUILD_PYTHON2
+pyreportioexecdir = $(pyexecdir)/report/io
 pyreportioexec_PYTHON = $(PYIOFILES)
+endif
+
+if BUILD_PYTHON3
+py3reportioexecdir = $(py3execdir)/report/io
 py3reportioexec_PYTHON = $(PYIOFILES)
+endif


### PR DESCRIPTION
This allows python2 and python3 to be independently used for builds that
only require using one or the other.