### PR TITLE
Add workflow for adding data to existing RH customer case

### DIFF
--- a/doc/reporter-rhtsupport.txt
+++ b/doc/reporter-rhtsupport.txt
@@ -28,7 +28,8 @@ If not specified, CONFFILE defaults to /etc/libreport/plugins/rhtsupport.conf.
 
 Option -t uploads FILEs to the already created case on RHTSupport site.
 The case ID is retrieved from directory specified by -d DIR.
-If problem data in DIR was never reported to RHTSupport, upload will fail.
+If problem data in DIR was never reported to RHTSupport, you will be asked
+to enter case ID to which you want to upload the FILEs.
 
 Option -tCASE uploads FILEs to the case CASE on RHTSupport site.
 -d DIR is ignored.

--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -409,7 +409,16 @@ rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELBugzillaXorg.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELBugzillaLibreport.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELBugzillaJava.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELBugzillaJavaScript.xml
+rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataCCpp.xml
+rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataKerneloops.xml
+rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataPython.xml
+rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDatavmcore.xml
+rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataxorg.xml
+rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataLibreport.xml
+rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataJava.xml
+rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataJavaScript.xml
 rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_rhel.conf
+rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_rhel_add_data.conf
 rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_uReport.conf
 rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_rhel_bugzilla.conf
 rm -f %{buildroot}%{_mandir}/man5/report_rhel.conf.5
@@ -653,6 +662,7 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %config(noreplace) %{_sysconfdir}/libreport/plugins/rhtsupport.conf
 %{_datadir}/%{name}/conf.d/plugins/rhtsupport.conf
 %{_datadir}/%{name}/events/report_RHTSupport.xml
+%{_datadir}/%{name}/events/report_RHTSupport_AddData.xml
 %{_datadir}/dbus-1/interfaces/com.redhat.problems.configuration.rhtsupport.xml
 %config(noreplace) %{_sysconfdir}/libreport/events.d/rhtsupport_event.conf
 %{_mandir}/man1/reporter-rhtsupport.1.gz
@@ -707,8 +717,17 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{_datadir}/%{name}/workflows/workflow_RHELLibreport.xml
 %{_datadir}/%{name}/workflows/workflow_RHELJava.xml
 %{_datadir}/%{name}/workflows/workflow_RHELJavaScript.xml
+%{_datadir}/%{name}/workflows/workflow_RHELAddDataCCpp.xml
+%{_datadir}/%{name}/workflows/workflow_RHELAddDataJava.xml
+%{_datadir}/%{name}/workflows/workflow_RHELAddDataKerneloops.xml
+%{_datadir}/%{name}/workflows/workflow_RHELAddDataLibreport.xml
+%{_datadir}/%{name}/workflows/workflow_RHELAddDataPython.xml
+%{_datadir}/%{name}/workflows/workflow_RHELAddDatavmcore.xml
+%{_datadir}/%{name}/workflows/workflow_RHELAddDataxorg.xml
+%{_datadir}/%{name}/workflows/workflow_RHELAddDataJavaScript.xml
 %{_datadir}/%{name}/workflows/workflow_uReport.xml
 %config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_rhel.conf
+%config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_rhel_add_data.conf
 %config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_uReport.conf
 %{_mandir}/man5/report_rhel.conf.5.*
 %{_mandir}/man5/report_uReport.conf.5.*

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -50,6 +50,7 @@ src/plugins/report_Kerneloops.xml.in
 src/plugins/report_Logger.xml.in
 src/plugins/report_Mailx.xml.in
 src/plugins/report_RHTSupport.xml.in
+src/plugins/report_RHTSupport_AddData.xml.in
 src/plugins/report_Uploader.xml.in
 src/plugins/report_uReport.xml.in
 src/plugins/report_EmergencyAnalysis.xml.in
@@ -95,6 +96,14 @@ src/workflows/workflow_RHELxorg.xml.in
 src/workflows/workflow_RHELLibreport.xml.in
 src/workflows/workflow_RHELJava.xml.in
 src/workflows/workflow_RHELJavaScript.xml.in
+src/workflows/workflow_RHELAddDataCCpp.xml.in
+src/workflows/workflow_RHELAddDataJava.xml.in
+src/workflows/workflow_RHELAddDataKerneloops.xml.in
+src/workflows/workflow_RHELAddDataLibreport.xml.in
+src/workflows/workflow_RHELAddDataPython.xml.in
+src/workflows/workflow_RHELAddDatavmcore.xml.in
+src/workflows/workflow_RHELAddDataxorg.xml.in
+src/workflows/workflow_RHELAddDataJavaScript.xml.in
 src/workflows/workflow_RHELBugzillaCCpp.xml.in
 src/workflows/workflow_RHELBugzillaKerneloops.xml.in
 src/workflows/workflow_RHELBugzillaPython.xml.in

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -83,6 +83,7 @@ dist_events_DATA = $(reporters_events) \
     report_Logger.xml \
     report_Mailx.xml \
     report_RHTSupport.xml \
+    report_RHTSupport_AddData.xml \
     report_Kerneloops.xml \
     report_Uploader.xml \
     report_EmergencyAnalysis.xml
@@ -123,6 +124,7 @@ EXTRA_DIST = $(reporters_extra_dist) \
     report_Logger.xml.in \
     report_Mailx.xml.in \
     report_RHTSupport.xml.in \
+    report_RHTSupport_AddData.xml.in \
     report_Kerneloops.xml.in \
     report_Uploader.xml.in \
     report_EmergencyAnalysis.xml.in

--- a/src/plugins/report_RHTSupport_AddData.xml.in
+++ b/src/plugins/report_RHTSupport_AddData.xml.in
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<event>
+    <_name>Red Hat Customer Support</_name>
+    <_description>Attach the data to existing Red Hat support case</_description>
+
+    <requires-items>package</requires-items>
+    <requires-details>yes</requires-details>
+    <exclude-items-by-default>event_log</exclude-items-by-default>
+    <exclude-items-always></exclude-items-always>
+    <exclude-binary-items>no</exclude-binary-items>
+    <include-items-by-default></include-items-by-default>
+    <minimal-rating>0</minimal-rating>
+    <gui-review-elements>yes</gui-review-elements>
+
+    <import-event-options event="report_RHTSupport"/>
+
+</event>

--- a/src/plugins/rhtsupport_event.conf
+++ b/src/plugins/rhtsupport_event.conf
@@ -1,1 +1,7 @@
-EVENT=report_RHTSupport      reporter-rhtsupport
+EVENT=report_RHTSupport
+    # Submit an uReport and create a case in Red Hat Customer Portal
+    reporter-rhtsupport -u
+
+EVENT=report_RHTSupport_AddData
+    # Attach data to a case in Red Hat Customer Portal
+    reporter-rhtsupport -t

--- a/src/workflows/Makefile.am
+++ b/src/workflows/Makefile.am
@@ -18,6 +18,14 @@ dist_workflows_DATA = \
     workflow_RHELLibreport.xml \
     workflow_RHELJava.xml \
     workflow_RHELJavaScript.xml \
+    workflow_RHELAddDataCCpp.xml \
+    workflow_RHELAddDataJava.xml \
+    workflow_RHELAddDataKerneloops.xml \
+    workflow_RHELAddDataLibreport.xml \
+    workflow_RHELAddDataPython.xml \
+    workflow_RHELAddDatavmcore.xml \
+    workflow_RHELAddDataxorg.xml \
+    workflow_RHELAddDataJavaScript.xml \
     workflow_uReport.xml \
     workflow_Mailx.xml \
     workflow_MailxCCpp.xml \
@@ -60,6 +68,7 @@ workflowsdefdir = $(WORKFLOWS_DEFINITION_DIR)
 dist_workflowsdef_DATA =\
     report_fedora.conf \
     report_rhel.conf \
+    report_rhel_add_data.conf \
     report_uReport.conf \
     report_mailx.conf \
     report_logger.conf \
@@ -92,6 +101,14 @@ EXTRA_DIST = \
     workflow_RHELLibreport.xml.in \
     workflow_RHELJava.xml.in \
     workflow_RHELJavaScript.xml.in \
+    workflow_RHELAddDataCCpp.xml.in \
+    workflow_RHELAddDataJava.xml.in \
+    workflow_RHELAddDataJavaScript.xml.in \
+    workflow_RHELAddDataKerneloops.xml.in \
+    workflow_RHELAddDataLibreport.xml.in \
+    workflow_RHELAddDataPython.xml.in \
+    workflow_RHELAddDatavmcore.xml.in \
+    workflow_RHELAddDataxorg.xml.in \
     workflow_uReport.xml.in \
     workflow_Mailx.xml.in \
     workflow_MailxCCpp.xml.in \

--- a/src/workflows/report_rhel_add_data.conf
+++ b/src/workflows/report_rhel_add_data.conf
@@ -1,0 +1,27 @@
+EVENT=workflow_RHELAddDataLibreport analyzer=libreport
+# this is just a meta event which consists of other events
+# the list is defined in the xml file
+
+EVENT=workflow_RHELAddDataCCpp type=CCpp
+# this is just a meta event which consists of other events
+# the list is defined in the xml file
+
+EVENT=workflow_RHELAddDataPython type=Python component!=anaconda
+# this is just a meta event which consists of other events
+# the list is defined in the xml file
+
+EVENT=workflow_RHELAddDataKerneloops type=Kerneloops
+# this is just a meta event which consists of other events
+# the list is defined in the xml file
+
+EVENT=workflow_RHELAddDatavmcore type=vmcore
+# this is just a meta event which consists of other events
+# the list is defined in the xml file
+
+EVENT=workflow_RHELAddDataxorg type=xorg
+# this is just a meta event which consists of other events
+# the list is defined in the xml file
+
+EVENT=workflow_RHELAddDataJava type=Java
+# this is just a meta event which consists of other events
+# the list is defined in the xml file

--- a/src/workflows/workflow_RHELAddDataCCpp.xml.in
+++ b/src/workflows/workflow_RHELAddDataCCpp.xml.in
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<workflow>
+    <_name>Attach crash data to an existing Red Hat support case</_name>
+    <_description>Provide Red Hat Support with crash details</_description>
+    <priority>99</priority>
+
+    <events>
+        <event>collect_*</event>
+        <event>report_RHTSupport_AddData</event>
+    </events>
+</workflow>

--- a/src/workflows/workflow_RHELAddDataJava.xml.in
+++ b/src/workflows/workflow_RHELAddDataJava.xml.in
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<workflow>
+    <_name>Attach crash data to an existing Red Hat support case</_name>
+    <_description>Provide Red Hat Support with crash details</_description>
+    <priority>99</priority>
+
+    <events>
+        <event>collect_*</event>
+        <event>report_RHTSupport_AddData</event>
+    </events>
+</workflow>

--- a/src/workflows/workflow_RHELAddDataJavaScript.xml.in
+++ b/src/workflows/workflow_RHELAddDataJavaScript.xml.in
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<workflow>
+    <_name>Attach crash data to an existing Red Hat support case</_name>
+    <_description>Provide Red Hat Support with crash details</_description>
+    <priority>99</priority>
+
+    <events>
+        <event>collect_*</event>
+        <event>report_RHTSupport_AddData</event>
+    </events>
+</workflow>

--- a/src/workflows/workflow_RHELAddDataKerneloops.xml.in
+++ b/src/workflows/workflow_RHELAddDataKerneloops.xml.in
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<workflow>
+    <_name>Attach crash data to an existing Red Hat support case</_name>
+    <_description>Provide Red Hat Support with crash details</_description>
+    <priority>99</priority>
+
+    <events>
+        <event>collect_*</event>
+        <event>report_RHTSupport_AddData</event>
+    </events>
+</workflow>

--- a/src/workflows/workflow_RHELAddDataLibreport.xml.in
+++ b/src/workflows/workflow_RHELAddDataLibreport.xml.in
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<workflow>
+    <_name>Attach crash data to an existing Red Hat support case</_name>
+    <_description>Provide Red Hat Support with crash details</_description>
+    <priority>99</priority>
+
+    <events>
+        <event>report_RHTSupport_AddData</event>
+    </events>
+</workflow>

--- a/src/workflows/workflow_RHELAddDataPython.xml.in
+++ b/src/workflows/workflow_RHELAddDataPython.xml.in
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<workflow>
+    <_name>Attach crash data to an existing Red Hat support case</_name>
+    <_description>Provide Red Hat Support with crash details</_description>
+    <priority>99</priority>
+
+    <events>
+        <event>collect_*</event>
+        <event>report_RHTSupport_AddData</event>
+    </events>
+</workflow>

--- a/src/workflows/workflow_RHELAddDatavmcore.xml.in
+++ b/src/workflows/workflow_RHELAddDatavmcore.xml.in
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<workflow>
+    <_name>Attach crash data to an existing Red Hat support case</_name>
+    <_description>Provide Red Hat Support with crash details</_description>
+    <priority>99</priority>
+
+    <events>
+        <event>collect_*</event>
+        <event>analyze_VMcore</event>
+        <event>report_RHTSupport_AddData</event>
+    </events>
+</workflow>

--- a/src/workflows/workflow_RHELAddDataxorg.xml.in
+++ b/src/workflows/workflow_RHELAddDataxorg.xml.in
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<workflow>
+    <_name>Attach crash data to an existing Red Hat support case</_name>
+    <_description>Provide Red Hat Support with crash details</_description>
+    <priority>99</priority>
+
+    <events>
+        <event>report_RHTSupport_AddData</event>
+    </events>
+</workflow>

--- a/src/workflows/workflow_RHELJavaScript.xml.in
+++ b/src/workflows/workflow_RHELJavaScript.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <workflow>
-    <_name>Report to Fedora</_name>
+    <_name>Ask Red Hat Support for help</_name>
     <_description>Create new Red Hat Support case - I would like to be contacted by Red Hat Support</_description>
 
     <events>


### PR DESCRIPTION
Change behavior of -t parameter in reporter-rhtsupport.
    
    If option -t without support case ID is used and problem data in DIR was never
    reported to RHTSupport, you will ask to enter case ID to which you want to
    upload the FILEs. If the data in DIR was reported, the case ID is obtained from
    'reported_to' element in problem dir. In this case, you will be asked if you
    want to attach the data to the support case or you want to change the support
    case ID.
    
    Related to #1395285