### PR TITLE
makefile: fix make release

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,7 +74,7 @@ release:
 	maint/pull-translations; \
 	echo "* $$(LANG='en_US.UTF-8' date +'%a %b %d %Y') $$(git config --get user.name) <$$(git config --get user.email)> $$NEW_VER-1" | sort > /tmp/changelog.tmp; \
 	git log --oneline $$OLD_VER..HEAD | awk '{$$1=""; if (a[$$0]++ == 0) print "-" $$0} END {print ""}' | grep -v -e "- Merge" -e "- testsuite:" -e "- make:" >> /tmp/changelog.tmp; \
-	sed "$$(grep -n changelog libreport.spec.in | cut -f1 -d:)"'r /tmp/changelog.tmp' -i libreport.spec.in; \
+	sed "$$(grep -n %changelog libreport.spec.in | cut -f1 -d: | head -1)"'r /tmp/changelog.tmp' -i libreport.spec.in; \
 	sed -e "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$$NEW_VER] - $$(date +'%F')/" \
 	    -e "s/^\[Unreleased\]: \(https:\/\/.*\/compare\)\(\/.*\)\.\.\.HEAD/[Unreleased]: \1\/$$NEW_VER...HEAD\n[$$NEW_VER]: \1\2...$$NEW_VER/" \
 	    -i CHANGELOG.md; \


### PR DESCRIPTION
make release-* commands failed to update changelog in spec when it
contained more than one "changelog" string