### PR TITLE
reporter-mailx: rely on configured email

### DIFF
--- a/src/plugins/mailx.conf
+++ b/src/plugins/mailx.conf
@@ -4,9 +4,9 @@
 # and you don't want to specify parameters in every tool invocation.
 #
 # String parameters:
-# Subject=
-# EmailFrom=
-# EmailTo=
-#
+Subject="[abrt] a crash has been detected"
+EmailFrom="ABRT Daemon <DoNotReply>"
+EmailTo="root@localhost"
+
 # Boolean parameter:
 # SendBinaryData=yes/no

--- a/src/plugins/mailx_event.conf
+++ b/src/plugins/mailx_event.conf
@@ -1,15 +1,7 @@
 EVENT=notify
-    # do not rely on the default config nor on the config file
-    Mailx_Subject="[abrt] a crash has been detected" \
-    Mailx_EmailFrom="ABRT Daemon <DoNotReply>" \
-    Mailx_EmailTo="root@localhost" \
     reporter-mailx --notify-only
 
 EVENT=notify-dup
-    # do not rely on the default config nor on the config file
-    Mailx_Subject="[abrt] a crash has been detected again" \
-    Mailx_EmailFrom="ABRT Daemon <DoNotReply>" \
-    Mailx_EmailTo="root@localhost" \
     reporter-mailx --notify-only
 
 EVENT=report_Mailx      reporter-mailx

--- a/src/plugins/reporter-mailx.c
+++ b/src/plugins/reporter-mailx.c
@@ -112,7 +112,7 @@ static void create_and_send_email(
 
     char* env;
     env = getenv("Mailx_EmailFrom");
-    char *email_from = (env ? xstrdup(env) : xstrdup(get_map_string_item_or_NULL(settings, "EmailFrom")) ? : ask_email_address("sender", "user@localhost"));
+    char *email_from = (env ? xstrdup(env) : xstrdup(get_map_string_item_or_NULL(settings, "EmailFrom")) ? : ask_email_address("sender", "ABRT Daemon <DoNotReply>"));
     env = getenv("Mailx_EmailTo");
     char *email_to = (env ? xstrdup(env) : xstrdup(get_map_string_item_or_NULL(settings, "EmailTo")) ? : ask_email_address("receiver", "root@localhost"));
     env = getenv("Mailx_SendBinaryData");


### PR DESCRIPTION
As a side effect of the fix of rhbz#1093375, the users loosed the control
over their reporter-mailx via configuration file:
/etc/libreport/plugins/mailx.conf

This fix retains this option for the user, but still solves
rhbz#1093375.

Related to rhbz#1523689, rhbz#1093375.