### PR TITLE
reporter-{bugzilla,mantisbt,rhtsupport}: fix free

### DIFF
--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -359,12 +359,12 @@ int main(int argc, char **argv)
     }
 
     {
+        char *local_conf = NULL;
         if (!conf_file)
         {
             conf_file = g_list_append(conf_file, (char*) CONF_DIR"/plugins/bugzilla.conf");
-            char *local_conf = xasprintf("%s"USER_HOME_CONFIG_PATH"/bugzilla.conf", getenv("HOME"));
+            local_conf = xasprintf("%s"USER_HOME_CONFIG_PATH"/bugzilla.conf", getenv("HOME"));
             conf_file = g_list_append(conf_file, local_conf);
-            free(local_conf);
         }
         while (conf_file)
         {
@@ -374,6 +374,8 @@ int main(int argc, char **argv)
             log_debug("Loaded '%s'", fn);
             conf_file = g_list_delete_link(conf_file, conf_file);
         }
+        free(local_conf);
+
         set_settings(&rhbz, settings);
         /* WRONG! set_settings() does not copy the strings, it merely sets up pointers
          * to settings[] dictionary:

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -301,12 +301,12 @@ int main(int argc, char **argv)
     map_string_t *settings = new_map_string();
 
     {
+        char *local_conf = NULL;
         if (!conf_file)
         {
             conf_file = g_list_append(conf_file, (char*) CONF_DIR"/plugins/mantisbt.conf");
-            char *local_conf = xasprintf("%s"USER_HOME_CONFIG_PATH"/mantisbt.conf", getenv("HOME"));
+            local_conf = xasprintf("%s"USER_HOME_CONFIG_PATH"/mantisbt.conf", getenv("HOME"));
             conf_file = g_list_append(conf_file, local_conf);
-            free(local_conf);
         }
         while (conf_file)
         {
@@ -316,6 +316,7 @@ int main(int argc, char **argv)
             log_debug("Loaded '%s'", fn);
             conf_file = g_list_delete_link(conf_file, conf_file);
         }
+        free(local_conf);
 
         struct dump_dir *dd = NULL;
         if (abrt_hash == NULL)

--- a/src/plugins/reporter-rhtsupport.c
+++ b/src/plugins/reporter-rhtsupport.c
@@ -560,12 +560,12 @@ int main(int argc, char **argv)
 
     /* Parse config, extract necessary params */
     map_string_t *settings = new_map_string();
+    char *local_conf = NULL;
     if (!conf_file)
     {
         conf_file = g_list_append(conf_file, (char*) CONF_DIR"/plugins/rhtsupport.conf");
-        char *local_conf = xasprintf("%s"USER_HOME_CONFIG_PATH"/rhtsupport.conf", getenv("HOME"));
+        local_conf = xasprintf("%s"USER_HOME_CONFIG_PATH"/rhtsupport.conf", getenv("HOME"));
         conf_file = g_list_append(conf_file, local_conf);
-        free(local_conf);
 
     }
     while (conf_file)
@@ -576,6 +576,8 @@ int main(int argc, char **argv)
         log_debug("Loaded '%s'", fn);
         conf_file = g_list_remove(conf_file, fn);
     }
+    free(local_conf);
+
     char *url      = get_param_string("URL"       , settings, "https://api.access.redhat.com/rs");
     char *login    = get_param_string("Login"     , settings, "");
     char *password = get_param_string("Password"  , settings, "");


### PR DESCRIPTION
There was an incorrect free of string local_conf right after addition to
the list conf_file, which caused that presence of the pointed string in
the memory was undeterministic. As a result, local config was sometimes
used and sometimes not.