### PR TITLE
ureport: remove json-c is_error() usage

### DIFF
--- a/src/lib/ureport.c
+++ b/src/lib/ureport.c
@@ -613,7 +613,7 @@ ureport_server_response_from_reply(post_state_t *post_state,
 
     json_object *const json = json_tokener_parse(post_state->body);
 
-    if (is_error(json))
+    if (json == NULL)
     {
         error_msg(_("Unable to parse response from ureport server at '%s'"), config->ur_url);
         log_notice("%s", post_state->body);


### PR DESCRIPTION
This macro has been deprecated and removed from json-c/bits.h.