### PR TITLE
Move uReport workflow to ureport plugin

### DIFF
--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -307,6 +307,7 @@ install this package and you're done.
 %package rhel
 Summary: Default configuration for reporting bugs via Red Hat infrastructure
 Requires: %{name} = %{version}-%{release}
+Requires: %{name}-plugin-ureport
 
 %description rhel
 Default configuration for reporting bugs via Red Hat infrastructure
@@ -429,7 +430,6 @@ rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELxorg.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELLibreport.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELJava.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELJavaScript.xml
-rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_uReport.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_AnacondaRHEL.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_AnacondaRHELBugzilla.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELBugzillaCCpp.xml
@@ -450,10 +450,8 @@ rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataJava.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataJavaScript.xml
 rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_rhel.conf
 rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_rhel_add_data.conf
-rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_uReport.conf
 rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_rhel_bugzilla.conf
 rm -f %{buildroot}%{_mandir}/man5/report_rhel.conf.5
-rm -f %{buildroot}%{_mandir}/man5/report_uReport.conf.5
 rm -f %{buildroot}%{_mandir}/man5/report_rhel_bugzilla.conf.5
 %endif
 
@@ -625,12 +623,15 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 
 %files plugin-ureport
 %config(noreplace) %{_sysconfdir}/libreport/plugins/ureport.conf
+%config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_uReport.conf
 %{_datadir}/%{name}/conf.d/plugins/ureport.conf
+%{_datadir}/%{name}/events/report_uReport.xml
+%{_datadir}/%{name}/workflows/workflow_uReport.xml
+%{_datadir}/dbus-1/interfaces/com.redhat.problems.configuration.ureport.xml
 %{_bindir}/reporter-ureport
 %{_mandir}/man1/reporter-ureport.1.gz
 %{_mandir}/man5/ureport.conf.5.gz
-%{_datadir}/%{name}/events/report_uReport.xml
-%{_datadir}/dbus-1/interfaces/com.redhat.problems.configuration.ureport.xml
+%{_mandir}/man5/report_uReport.conf.5.*
 
 %if %{with bugzilla}
 %files plugin-bugzilla
@@ -761,12 +762,9 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{_datadir}/%{name}/workflows/workflow_RHELAddDatavmcore.xml
 %{_datadir}/%{name}/workflows/workflow_RHELAddDataxorg.xml
 %{_datadir}/%{name}/workflows/workflow_RHELAddDataJavaScript.xml
-%{_datadir}/%{name}/workflows/workflow_uReport.xml
 %config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_rhel.conf
 %config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_rhel_add_data.conf
-%config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_uReport.conf
 %{_mandir}/man5/report_rhel.conf.5.*
-%{_mandir}/man5/report_uReport.conf.5.*
 
 %files rhel-bugzilla
 %{_datadir}/%{name}/workflows/workflow_RHELBugzillaCCpp.xml

--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -430,6 +430,7 @@ rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELxorg.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELLibreport.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELJava.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELJavaScript.xml
+rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_uReport.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_AnacondaRHEL.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_AnacondaRHELBugzilla.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELBugzillaCCpp.xml
@@ -450,8 +451,10 @@ rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataJava.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELAddDataJavaScript.xml
 rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_rhel.conf
 rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_rhel_add_data.conf
+rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_uReport.conf
 rm -f %{buildroot}/%{_sysconfdir}/libreport/workflows.d/report_rhel_bugzilla.conf
 rm -f %{buildroot}%{_mandir}/man5/report_rhel.conf.5
+rm -f %{buildroot}%{_mandir}/man5/report_uReport.conf.5
 rm -f %{buildroot}%{_mandir}/man5/report_rhel_bugzilla.conf.5
 %endif
 
@@ -623,15 +626,17 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 
 %files plugin-ureport
 %config(noreplace) %{_sysconfdir}/libreport/plugins/ureport.conf
-%config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_uReport.conf
 %{_datadir}/%{name}/conf.d/plugins/ureport.conf
 %{_datadir}/%{name}/events/report_uReport.xml
-%{_datadir}/%{name}/workflows/workflow_uReport.xml
 %{_datadir}/dbus-1/interfaces/com.redhat.problems.configuration.ureport.xml
 %{_bindir}/reporter-ureport
 %{_mandir}/man1/reporter-ureport.1.gz
 %{_mandir}/man5/ureport.conf.5.gz
+%if 0%{?rhel}
+%config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_uReport.conf
+%{_datadir}/%{name}/workflows/workflow_uReport.xml
 %{_mandir}/man5/report_uReport.conf.5.*
+%endif
 
 %if %{with bugzilla}
 %files plugin-bugzilla


### PR DESCRIPTION
This moves the ureport workflow over to the ureport-plugin so that it isn't dependent on the rht-support plugin.