### PR TITLE
reporter-mailx: Remove double quotes from config

### DIFF
--- a/src/plugins/mailx.conf
+++ b/src/plugins/mailx.conf
@@ -4,9 +4,9 @@
 # and you don't want to specify parameters in every tool invocation.
 #
 # String parameters:
-Subject="[abrt] a crash has been detected"
-EmailFrom="ABRT Daemon <DoNotReply>"
-EmailTo="root@localhost"
+Subject = [abrt] a crash has been detected
+EmailFrom = ABRT Daemon <DoNotReply>
+EmailTo = root@localhost
 
 # Boolean parameter:
 # SendBinaryData=yes/no


### PR DESCRIPTION
In 1394000e the default configuration file for reporter-mailx was changed
and it included double quoting the values. However we do not support quoted
values in configuration files and so the the parsed values then included
quotes.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>