### PR TITLE
augeas: Use generic augeas modules

### DIFF
--- a/augeas/test_libreport.aug
+++ b/augeas/test_libreport.aug
@@ -53,9 +53,9 @@ EOLWhitespace_b = nice
         { "#comment" = "component match when it searches for duplicates of" }
         { "#comment" = "bugs in selinux-policy component." }
         { "#comment" = "(If you need to add more, the syntax is: \"component[,component...]\")" }
-        { "#comment" = "" }
-        { "#comment" = "" }
-        { "#comment" = "" }
+        {}
+        {}
+        {}
         { "DontMatchComponents" = "selinux-policy" }
         {}
         { "#comment" = "for more info about these settings see: https://github.com/abrt/abrt/wiki/FAQ#creating-private-bugzilla-tickets" }


### PR DESCRIPTION
Most of the changes are just replacement of current regexps with in-build modules
from augeas. The changes do not make any major changes in the behaviour of the lenses.

The only thing that is different is that Util.empty [1] module ignores empty comments.
This means that empty commented lines in the configuration files do not show up in
augeas tree and because of that they can't be changed using the augeas.

The goal of this PR is to simplify the augeas lenses but it should also fix the linked
bugzilla bug.

[1] http://augeas.net/docs/references/1.4.0/lenses/files/util-aug.html#Util.empty

Related: rhbz#1649742

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>