### PR TITLE
potfiles: fix issue in POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -34,7 +34,7 @@ src/lib/reported_to.c
 src/lib/reporters.c
 src/lib/run_event.c
 src/plugins/abrt_rh_support.c
-src/plugins/report_Bugzilla.xml.in
+src/plugins/report_Bugzilla.xml.in.in
 src/plugins/report.c
 src/plugins/reporter-bugzilla.c
 src/plugins/reporter-kerneloops.c

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,3 +1,3 @@
 contrib/command-not-found/pk-tools-common.c
 build/
-src/plugins/report_Bugzilla.xml.in.in
+src/plugins/report_Bugzilla.xml.in


### PR DESCRIPTION
src/plugins/report_Bugzilla.xml.in doesn't exist anymore,
it was rename to src/plugins/report_Bugzilla.xml.in.in.
Actualize POTFILES files regarding to this change.

Related to #1449646

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>