### PR TITLE
gui: Ellipsize warning text when the window is shrinked

### DIFF
--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -2217,7 +2217,7 @@ static void add_warning(const char *warning)
     gtk_widget_set_valign (warning_lbl, GTK_ALIGN_END);
 
     gtk_label_set_justify(GTK_LABEL(warning_lbl), GTK_JUSTIFY_LEFT);
-    gtk_label_set_line_wrap(GTK_LABEL(warning_lbl), TRUE);
+    gtk_label_set_ellipsize(GTK_LABEL(warning_lbl), PANGO_ELLIPSIZE_END);
 
     add_widget_to_warning_area(warning_lbl);
 }


### PR DESCRIPTION
The current behaviour word-wraps warning messages when the reporting window is
horizontaly shrinked. Word-wrapping elongates the window verticaly and causes problems
in lower desktop resolutions.

This PR changes the word-wrapping behaviour with ellipsizing (replace text with '...').

Related: rhbz#1220158, rhbz#1327813

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>