### PR TITLE
gtk-helpers: config_dialog: Hide tree view header

### DIFF
--- a/src/gtk-helpers/config_dialog.c
+++ b/src/gtk-helpers/config_dialog.c
@@ -268,10 +268,9 @@ GtkWidget *create_config_tab_content(const char *column_label,
     gtk_tree_view_column_set_resizable(column, TRUE);
     g_object_set(G_OBJECT(renderer), "wrap-mode", PANGO_WRAP_WORD, NULL);
     g_object_set(G_OBJECT(renderer), "wrap-width", 440, NULL);
-    gtk_tree_view_column_set_sort_column_id(column, COLUMN_NAME);
     gtk_tree_view_append_column(GTK_TREE_VIEW(tv), column);
+    gtk_tree_view_set_headers_visible (GTK_TREE_VIEW(tv), FALSE);
 
-    // TODO: gtk_tree_view_set_headers_visible(FALSE)? We have only one column anyway...
     GtkTreeModel *model = gtk_tree_model_filter_new(GTK_TREE_MODEL(store), NULL);
     gtk_tree_model_filter_set_visible_func(GTK_TREE_MODEL_FILTER(model), config_filter_func, NULL, NULL);
 


### PR DESCRIPTION
There’s only one column and the model used is not sortable, so it
should just be hidden.

Fixes https://github.com/abrt/gnome-abrt/issues/150

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>