### PR TITLE
Improve backtrace generation

### DIFF
--- a/src/lib/event_config.c
+++ b/src/lib/event_config.c
@@ -533,7 +533,7 @@ bool check_problem_rating_usability(const event_config_t *cfg,
     }
     else if (rating < minimal_rating)
     {
-        tmp_desc = xstrdup(_("Reporting disabled because the backtrace is unusable."));
+        tmp_desc = xstrdup(_("Reporting is disabled because the generated backtrace has low informational value."));
 
         const char *package = problem_data_get_content_or_NULL(pd, FILENAME_PACKAGE);
         if (package && package[0])


### PR DESCRIPTION
The current solution finds packages for given build-ids and then
downloads them. The problem is that some debuginfo packages require
other packages and if they are not available the generated backtrace
becomes unusable.

This commit adds a query for required packages and downloads them together
with the main packages.

And also modify the error message when the backtrace is unusable.

Related: rhbz#1515265
