### PR TITLE
lib: Explicitly do not use DST

### DIFF
--- a/src/lib/iso_date_string.c
+++ b/src/lib/iso_date_string.c
@@ -61,6 +61,9 @@ int iso_date_string_parse(const char *date, time_t *pt)
         return -EINVAL;
     }
 
+    // daylight saving time not in use
+    local.tm_isdst = 0;
+
     *pt = mktime(&local);
     return 0;
 }


### PR DESCRIPTION
DST = Daylight Saving Time
Value of this field is not set up by strptime and therefore value
of `tm_isdst` field is undefined. Bacause of this reason, output of
`mktime` may differ +-1 hour.

@mkutlak this should fix tests 26 and 97 on rawhide, can you verify please?