### PR TITLE
rhbz: Replace nomail flag with minor_update

### DIFF
--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -35,7 +35,7 @@ int attach_text_item(struct abrt_xmlrpc *ax, const char *bug_id,
     log_debug("attaching '%s' as text", item_name);
     int r = rhbz_attach_blob(ax, bug_id,
                 item_name, item->content, strlen(item->content),
-                RHBZ_NOMAIL_NOTIFY
+                RHBZ_MINOR_UPDATE
     );
     return (r == 0);
 }
@@ -63,7 +63,7 @@ int attach_file_item(struct abrt_xmlrpc *ax, const char *bug_id,
         return 0;
     }
     log_debug("attaching '%s' as file", item_name);
-    int flag = RHBZ_NOMAIL_NOTIFY;
+    int flag = RHBZ_MINOR_UPDATE;
     if (!(item->flags & CD_FLAG_BIGTXT))
         flag |= RHBZ_BINARY_ATTACHMENT;
     int r = rhbz_attach_fd(ax, bug_id, item_name, fd, flag);
@@ -793,7 +793,7 @@ int main(int argc, char **argv)
                 if (reported_to && reported_to->url)
                 {
                     log_warning(_("Adding External URL to bug %i"), new_id);
-                    rhbz_set_url(client, new_id, reported_to->url, RHBZ_NOMAIL_NOTIFY);
+                    rhbz_set_url(client, new_id, reported_to->url, RHBZ_MINOR_UPDATE);
                     free_report_result(reported_to);
                 }
             }
@@ -821,7 +821,7 @@ int main(int argc, char **argv)
             if (existing_id >= 0)
             {
                 log_warning(_("Closing bug %i as duplicate of bug %i"), new_id, existing_id);
-                rhbz_close_as_duplicate(client, new_id, existing_id, RHBZ_NOMAIL_NOTIFY);
+                rhbz_close_as_duplicate(client, new_id, existing_id, RHBZ_MINOR_UPDATE);
             }
 
             goto log_out;
@@ -876,7 +876,7 @@ int main(int argc, char **argv)
      && !g_list_find_custom(bz->bi_cc_list, rhbz.b_login, (GCompareFunc)g_strcmp0)
     ) {
         log_warning(_("Adding %s to CC list"), rhbz.b_login);
-        rhbz_mail_to_cc(client, bz->bi_id, rhbz.b_login, RHBZ_NOMAIL_NOTIFY);
+        rhbz_mail_to_cc(client, bz->bi_id, rhbz.b_login, RHBZ_MINOR_UPDATE);
     }
 
     /* Add comment and bt */
@@ -911,7 +911,7 @@ int main(int argc, char **argv)
                 sprintf(bug_id_str, "%i", bz->bi_id);
                 log_warning(_("Attaching better backtrace"));
                 rhbz_attach_blob(client, bug_id_str, FILENAME_BACKTRACE, bt, strlen(bt),
-                                 RHBZ_NOMAIL_NOTIFY);
+                                 RHBZ_MINOR_UPDATE);
             }
         }
         else

--- a/src/plugins/rhbz.h
+++ b/src/plugins/rhbz.h
@@ -36,7 +36,7 @@ enum {
     RHBZ_MANDATORY_MEMB      = (1 << 0),
     RHBZ_READ_STR            = (1 << 1),
     RHBZ_READ_INT            = (1 << 2),
-    RHBZ_NOMAIL_NOTIFY       = (1 << 3),
+    RHBZ_MINOR_UPDATE        = (1 << 3),
     RHBZ_PRIVATE             = (1 << 4),
     RHBZ_BINARY_ATTACHMENT   = (1 << 5),
 };
@@ -44,7 +44,7 @@ enum {
 #define IS_MANDATORY(flags) ((flags) & RHBZ_MANDATORY_MEMB)
 #define IS_READ_STR(flags) ((flags) & RHBZ_READ_STR)
 #define IS_READ_INT(flags) ((flags) & RHBZ_READ_INT)
-#define IS_NOMAIL_NOTIFY(flags) ((flags) & RHBZ_NOMAIL_NOTIFY)
+#define IS_MINOR_UPDATE(flags) ((flags) & RHBZ_MINOR_UPDATE)
 #define IS_PRIVATE(flags) ((flags) & RHBZ_PRIVATE)
 
 struct bug_info {


### PR DESCRIPTION
In Bugzilla v5.0 nomail flag is replaced with minor_update. [1]
Because we still use the old nomail flag emails are being sent for every added attachment/comment.

Related: rhbz#1660157
Closes: abrt/abrt#1346

See also:
- https://partner-bugzilla.redhat.com/docs/en/html/integrating/api/Bugzilla/WebService/Bug.html?highlight=minor_update

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1655829

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>