### PR TITLE
rhbz: Only pull ids when looking for similar bzs

### DIFF
--- a/src/plugins/rhbz.c
+++ b/src/plugins/rhbz.c
@@ -863,7 +863,7 @@ xmlrpc_value *rhbz_search_duphash(struct abrt_xmlrpc *ax,
 
     char *s = strbuf_free_nobuf(query);
     log_debug("search for '%s'", s);
-    xmlrpc_value *search = abrt_xmlrpc_call(ax, "Bug.search", "{s:s}", "quicksearch", s);
+    xmlrpc_value *search = abrt_xmlrpc_call(ax, "Bug.search", "{s:s,s:(s)}", "quicksearch", s, "include_fields", "id");
 
     free(s);
     xmlrpc_value *bugs = rhbz_get_member("bugs", search);


### PR DESCRIPTION
When we are looking for similar bugzillas we only need their IDs. Before
this commit we pulled all information for all bugs, which could cause
that we pulled a lot of data.

Fixes BZ#1660227

Able to reproduce with abrt_hash:6a21339bb55077deb37b421ad0c7601c59a27656


Signed-off-by: Matej Marusak <mmarusak@redhat.com>