### PR TITLE
Enhance emergeny analyses output

### DIFF
--- a/src/plugins/emergencyanalysis_event.conf
+++ b/src/plugins/emergencyanalysis_event.conf
@@ -2,5 +2,6 @@ EVENT=report_EmergencyAnalysis
     rpm -q abrt > abrt_installed_version 2>/dev/null
     rpm -q libreport > libreport_version 2>/dev/null
     rpm -q satyr > satyr_version 2>/dev/null
+    echo -e "An archive will be created.\nThis archive is accessible only by ABRT developers.\nTherefore if you try to open the produced web location you will not be able to see it."
     EXCLUDE_FROM_REPORT="" reporter-upload 1>/dev/null
     rm -f abrt_installed_version libreport_version satyr_version

--- a/src/plugins/emergencyanalysis_event.conf
+++ b/src/plugins/emergencyanalysis_event.conf
@@ -2,5 +2,5 @@ EVENT=report_EmergencyAnalysis
     rpm -q abrt > abrt_installed_version 2>/dev/null
     rpm -q libreport > libreport_version 2>/dev/null
     rpm -q satyr > satyr_version 2>/dev/null
-    EXCLUDE_FROM_REPORT="" reporter-upload
+    EXCLUDE_FROM_REPORT="" reporter-upload 1>/dev/null
     rm -f abrt_installed_version libreport_version satyr_version


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1540500 and commit messages.

I am more than happy to discuss the message that should be printed. This was my first idea. We need to inform user that when click the URL, is not going to be able to see the archive. The url looks like this: https://retrace.fedoraproject.org/faf/dumpdirs/new/oops-2018-01-26-21:28:20-1347-0.tar.gz/