### PR TITLE
autogen.sh tweaks and test “fix”

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -54,30 +54,11 @@ case "$1" in
             echo "Running gen-version"
             ./gen-version
 
-            mkdir -p m4
-            echo "Creating m4/aclocal.m4 ..."
-            test -r m4/aclocal.m4 || touch m4/aclocal.m4
-
-            echo "Running autopoint"
-            autopoint --force || exit 1
+            echo "Running autoreconf"
+            autoreconf -ifv || exit 1
 
             echo "Running intltoolize..."
             intltoolize --force --copy --automake || exit 1
-
-            echo "Running aclocal..."
-            aclocal || exit 1
-
-            echo "Running libtoolize..."
-            libtoolize || exit 1
-
-            echo "Running autoheader..."
-            autoheader || return 1
-
-            echo "Running autoconf..."
-            autoconf --force || exit 1
-
-            echo "Running automake..."
-            automake --add-missing --force --copy || exit 1
 
             if [ "$NOCONFIGURE" = "" ]; then
                 echo "Running configure ..."

--- a/autogen.sh
+++ b/autogen.sh
@@ -79,19 +79,23 @@ case "$1" in
             echo "Running automake..."
             automake --add-missing --force --copy || exit 1
 
-            echo "Running configure ..."
-            if [ 0 -eq $# ]; then
-                ./configure \
-                    --prefix=/usr \
-                    --sysconfdir=/etc \
-                    --localstatedir=/var \
-                    --sharedstatedir=/var/lib \
-                    --mandir=/usr/share/man \
-                    --infodir=/usr/share/info \
-                    --enable-debug
-                echo "Configured for local debugging ..."
+            if [ "$NOCONFIGURE" = "" ]; then
+                echo "Running configure ..."
+                if [ 0 -eq $# ]; then
+                    ./configure \
+                        --prefix=/usr \
+                        --sysconfdir=/etc \
+                        --localstatedir=/var \
+                        --sharedstatedir=/var/lib \
+                        --mandir=/usr/share/man \
+                        --infodir=/usr/share/info \
+                        --enable-debug
+                    echo "Configured for local debugging ..."
+                else
+                    ./configure "$@"
+                fi
             else
-                ./configure "$@"
+                echo "Skipping configure"
             fi
         ;;
 esac

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,6 +29,9 @@ libreport_include_helpers_HEADERS = \
 	helpers/testsuite.h \
 	helpers/testsuite_tools.h
 
+TESTSUITEFLAGS = \
+    CPPFLAGS='-DCONF_DIR="$(CONF_DIR)" $(CPPFLAGS)'
+
 TESTSUITE_AT = \
   local.at \
   testsuite.at \

--- a/tests/forbidden_words.at
+++ b/tests/forbidden_words.at
@@ -34,7 +34,7 @@ TS_MAIN
     {
         dynamic_words = load_words_from_file("test_ignored.conf");
     }
-    TS_ASSERT_STDERR_EQ_END("Can't open /etc/libreport/test_ignored.conf: No such file or directory\n", "User notified about errors!");
+    TS_ASSERT_STDERR_EQ_END("Can't open " CONF_DIR "/test_ignored.conf: No such file or directory\n", "User notified about errors!");
 
     TS_ASSERT_PTR_IS_NOT_NULL(dynamic_words);
 

--- a/tests/local.at
+++ b/tests/local.at
@@ -6,7 +6,7 @@
 # Compile SOURCES into OUTPUT.  If OUTPUT does not contain '.',
 # assume that we are linking too; this is a hack.
 m4_define([AT_COMPILE],
-[AT_CHECK([$LIBTOOL --mode=link $CC $CFLAGS m4_bmatch([$1], [[.]], [], [$LDFLAGS ])-o $1 m4_default([$2], [$1.c])[]m4_bmatch([$1], [[.]], [], [ $LIBS])],
+[AT_CHECK([$LIBTOOL --mode=link $CC $CFLAGS $CPPFLAGS m4_bmatch([$1], [[.]], [], [$LDFLAGS ])-o $1 m4_default([$2], [$1.c])[]m4_bmatch([$1], [[.]], [], [ $LIBS])],
           0, [ignore], [ignore])])
 
 # ------------------------


### PR DESCRIPTION
Was too lazy to split into separate PRs, but here goes.

The test I’m touching is giving me trouble when doing an `rpmbuild -ba`, as the sysconfdir includes the prefix (the spec file does not specify any of the dirs during the invocation of configure), and the expected output is hardcoded.

The changes in autogen.sh are mostly to make things easier when packaging.