### PR TITLE
dd: Update dd_get_owner to handle error return values

### DIFF
--- a/src/include/dump_dir.h
+++ b/src/include/dump_dir.h
@@ -347,7 +347,7 @@ int dd_set_no_owner(struct dump_dir *dd);
  * If meta-data misses owner, returns fs owner.
  * Can be used with DD_OPEN_FD_ONLY.
  */
-uid_t dd_get_owner(struct dump_dir *dd);
+uid_t dd_get_owner(struct dump_dir *dd, int *errorno);
 
 /* Returns UNIX time stamp of the first occurrence of the problem.
  *

--- a/tests/dump_dir.at
+++ b/tests/dump_dir.at
@@ -199,6 +199,7 @@ AT_TESTFUN([dd_create_open_delete],
 int main(int argc, char **argv)
 {
     g_verbose = 3;
+    int ret = 0;
 
     char template[] = "/tmp/XXXXXX/dump_dir";
 
@@ -234,7 +235,8 @@ int main(int argc, char **argv)
     struct stat owner_md_st;
     assert(fstatat(dd->dd_md_fd, "owner", &owner_md_st, 0) == 0);
     assert((dd_st.st_mode & 0666) == (owner_md_st.st_mode & 0666));
-    assert(geteuid() == dd_get_owner(dd));
+    assert(geteuid() == dd_get_owner(dd, &ret));
+    assert(ret == 0);
 
     dd_create_basic_files(dd, (uid_t)-1, NULL);
     dd_save_text(dd, FILENAME_TYPE, "attest");
@@ -375,6 +377,7 @@ AT_TESTFUN([dd_owner],
 int main(int argc, char **argv)
 {
     g_verbose = 3;
+    int ret = 0;
 
     char template[] = "/tmp/XXXXXX/dump_dir";
 
@@ -395,7 +398,8 @@ int main(int argc, char **argv)
         struct dump_dir *dd = dd_create(template, (uid_t)-1, 0640);
         assert(dd != NULL);
 
-        assert(geteuid() == dd_get_owner(dd));
+        assert(geteuid() == dd_get_owner(dd, &ret));
+        assert(ret == 0);
 
         assert(dd_delete(dd) == 0);
     }
@@ -406,7 +410,8 @@ int main(int argc, char **argv)
         assert(dd != NULL);
 
         dd_create_basic_files(dd, (uid_t)-1, NULL);
-        assert(geteuid() == dd_get_owner(dd));
+        assert(geteuid() == dd_get_owner(dd, &ret));
+        assert(ret == 0);
 
         assert(dd_delete(dd) == 0);
     }
@@ -417,7 +422,8 @@ int main(int argc, char **argv)
         assert(dd != NULL);
 
         dd_create_basic_files(dd, (geteuid() + 1), NULL);
-        assert((geteuid() + 1) == dd_get_owner(dd));
+        assert((geteuid() + 1) == dd_get_owner(dd, &ret));
+        assert(ret == 0);
 
         assert(dd_delete(dd) == 0);
     }
@@ -431,7 +437,8 @@ int main(int argc, char **argv)
 
         struct passwd *nobody_pw= getpwnam("nobody");
         assert(nobody_pw != NULL);
-        assert(nobody_pw->pw_uid == dd_get_owner(dd));
+        assert(nobody_pw->pw_uid == dd_get_owner(dd, &ret));
+        assert(ret == 0);
 
         assert(dd_delete(dd) == 0);
     }
@@ -442,7 +449,8 @@ int main(int argc, char **argv)
         assert(dd != NULL);
 
         dd_set_owner(dd, (geteuid() + 2));
-        assert((geteuid() + 2) == dd_get_owner(dd));
+        assert((geteuid() + 2) == dd_get_owner(dd, &ret));
+        assert(ret == 0);
 
         assert(dd_delete(dd) == 0);
     }
@@ -453,10 +461,12 @@ int main(int argc, char **argv)
         assert(dd != NULL);
 
         dd_set_no_owner(dd);
-        assert(geteuid() != dd_get_owner(dd));
+        assert(geteuid() != dd_get_owner(dd, &ret));
+        assert(ret == 0);
 
         dd_chown(dd, geteuid());
-        assert(geteuid() == dd_get_owner(dd));
+        assert(geteuid() == dd_get_owner(dd, &ret));
+        assert(ret == 0);
 
         assert(dd_delete(dd) == 0);
     }
@@ -480,6 +490,7 @@ AT_TESTFUN([dd_stat],
 int main(int argc, char **argv)
 {
     g_verbose = 3;
+    int ret = 0;
 
     char template[] = "/tmp/XXXXXX/dump_dir";
 
@@ -518,7 +529,8 @@ int main(int argc, char **argv)
     assert(dd != NULL || !"reopen for writing");
 
     assert(dd_set_owner(dd, geteuid() + 1) == 0);
-    assert(dd_get_owner(dd) == geteuid() + 1);
+    assert(dd_get_owner(dd, &ret) == geteuid() + 1);
+    assert(ret == 0);
 
     {
         const int scn_stat = dd_stat_for_uid(dd, geteuid() + 2);
@@ -533,7 +545,8 @@ int main(int argc, char **argv)
     }
 
     assert(dd_set_no_owner(dd) == 0);
-    assert(dd_get_owner(dd) != geteuid() + 3);
+    assert(dd_get_owner(dd, &ret) != geteuid() + 3);
+    assert(ret == 0);
 
     {
         const int frt_stat = dd_stat_for_uid(dd, geteuid() + 3);
@@ -761,6 +774,8 @@ TS_MAIN
 {
     char template[] = "/tmp/XXXXXX";
 
+    int ret = 0;
+
     if (mkdtemp(template) == NULL) {
         perror("mkdtemp()");
         return EXIT_FAILURE;
@@ -791,7 +806,8 @@ TS_MAIN
         fprintf(stderr, "=== NO UID - geteuid() ===\n");
         struct dump_dir *no_uid_dd_geteuid = create_dump_dir_from_problem_data_ext(pd, template, geteuid());
         assert(no_uid_dd_geteuid != NULL);
-        assert(dd_get_owner(no_uid_dd_geteuid) == geteuid());
+        assert(dd_get_owner(no_uid_dd_geteuid, &ret) == geteuid());
+        assert(ret == 0);
         assert(dd_delete(no_uid_dd_geteuid) == 0);
         fprintf(stderr, "=== NO UID - geteuid() ===\n");
     }
@@ -800,7 +816,8 @@ TS_MAIN
         fprintf(stderr, "=== NO UID - NO UID ===\n");
         struct dump_dir *no_uid_dd_nouid = create_dump_dir_from_problem_data_ext(pd, template, (uid_t)-1L);
         assert(no_uid_dd_nouid != NULL);
-        assert(dd_get_owner(no_uid_dd_nouid) == geteuid());
+        assert(dd_get_owner(no_uid_dd_nouid, &ret) == geteuid());
+        assert(ret == 0);
         assert(dd_delete(no_uid_dd_nouid) == 0);
         fprintf(stderr, "=== NO UID - NO UID ===\n");
     }
@@ -813,7 +830,8 @@ TS_MAIN
         fprintf(stderr, "=== UID - geteuid() ===\n");
         struct dump_dir *uid_dd_geteuid = create_dump_dir_from_problem_data_ext(pd, template, geteuid());
         assert(uid_dd_geteuid != NULL);
-        assert(dd_get_owner(uid_dd_geteuid) == (geteuid() + 1));
+        assert(dd_get_owner(uid_dd_geteuid, &ret) == (geteuid() + 1));
+        assert(ret == 0);
         assert(dd_delete(uid_dd_geteuid) == 0);
         fprintf(stderr, "=== UID - geteuid() ===\n");
     }
@@ -822,7 +840,8 @@ TS_MAIN
         fprintf(stderr, "=== UID - NO UID ===\n");
         struct dump_dir *uid_dd_nouid = create_dump_dir_from_problem_data_ext(pd, template, (uid_t)-1L);
         assert(uid_dd_nouid != NULL);
-        assert(dd_get_owner(uid_dd_nouid) == (geteuid() + 1));
+        assert(dd_get_owner(uid_dd_nouid, &ret) == (geteuid() + 1));
+        assert(ret == 0);
         assert(dd_delete(uid_dd_nouid) == 0);
         fprintf(stderr, "=== UID - NO UID ===\n");
     }


### PR DESCRIPTION
Update dd_get_owner prototype and implementation to properly handle the
possible error return values which can be negative.

As reference the link to the issue in abrt repo:
abrt/abrt#1345

Basically dd_get_owner() calls read_number_from_file_at() which returns negative numbers in case of error:
https://github.com/abrt/libreport/blob/5e0c2c3839f7205a90aedd6be7a1f54bc4306ebb/src/lib/dump_dir.c#L240

Thank you to original commiter - webera.
https://github.com/abrt/libreport/pull/546

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>