### PR TITLE
dirsize: Skip dirs in which sosreport is being generated

### DIFF
--- a/src/lib/dirsize.c
+++ b/src/lib/dirsize.c
@@ -91,6 +91,11 @@ double get_dirsize_find_largest_dir(
         if (dot_or_dotdot(ep->d_name))
             continue;
         char *dname = concat_path_file(pPath, ep->d_name);
+        if (lstat(concat_path_file(dname, "sosreport.log"), &statbuf) == 0)
+        {
+            log_debug("Skipping %s': sosreport is being generated.", dname);
+            goto next;
+        }
         if (lstat(dname, &statbuf) != 0)
         {
             goto next;


### PR DESCRIPTION
With these changes ABRT will skip directories in which sosreport is running
and won't delete them when MaxCrashReportSize limit is exceeded.

I had a concern about the size of the logs that sosreport collects but
there is a limit set by sosreport for how big the individual logs can
be and the default value is 25MiB.

Fixes: rhbz#1671232

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>