### PR TITLE
Wildcards in event specifications for workflows

### DIFF
--- a/src/cli/cli-report.c
+++ b/src/cli/cli-report.c
@@ -817,25 +817,6 @@ static int run_event_chain_real(struct run_event_state *run_state,
     return retval;
 }
 
-/**
- * Expand '*' wildcards in an event chain.
- *
- * Returns the expanded list of event names.
- */
-static GList *expand_event_chain_wildcards(GList *chain)
-{
-    GList *list = NULL;
-
-    for (GList *item = chain; item; item = g_list_next(item))
-    {
-        const char *event_name = (const char *)item->data;
-        GList *expanded = expand_event_wildcard(event_name, strlen(event_name));
-        list = g_list_concat(list, expanded);
-    }
-
-    return list;
-}
-
 /*
  * Run events from a chain. Perform the following steps for each event:
  * 1. Terminate the chain run if the backtrace is not usable.

--- a/src/cli/cli-report.c
+++ b/src/cli/cli-report.c
@@ -813,6 +813,25 @@ static int run_event_chain_real(struct run_event_state *run_state,
     return retval;
 }
 
+/**
+ * Expand '*' wildcards in an event chain.
+ *
+ * Returns the expanded list of event names.
+ */
+static GList *expand_event_chain_wildcards(GList *chain)
+{
+    GList *list = NULL;
+
+    for (GList *item = chain; item; item = g_list_next(item))
+    {
+        const char *event_name = (const char *)item->data;
+        GList *expanded = expand_event_wildcard(event_name, strlen(event_name));
+        list = g_list_concat(list, expanded);
+    }
+
+    return list;
+}
+
 /*
  * Run events from a chain. Perform the following steps for each event:
  * 1. Terminate the chain run if the backtrace is not usable.
@@ -826,12 +845,14 @@ static int run_event_chain_real(struct run_event_state *run_state,
  */
 int run_event_chain(const char *dump_dir_name, GList *chain, int interactive)
 {
+    /* Expand *-wildcards in the names of events in the chain. */
+    GList *expanded_chain = expand_event_chain_wildcards(chain);
     struct run_event_state *run_state = new_run_event_state();
-    int retval;
 
-    retval = run_event_chain_real(run_state, dump_dir_name, chain, interactive);
+    int retval = run_event_chain_real(run_state, dump_dir_name, expanded_chain, interactive);
 
     free_run_event_state(run_state);
+    g_list_free_full(expanded_chain, free);
 
     return retval;
 }

--- a/src/cli/cli-report.c
+++ b/src/cli/cli-report.c
@@ -796,8 +796,12 @@ static int run_event_chain_real(struct run_event_state *run_state,
             break;
         if (retval == 0 && run_state->children_count == 0)
         {
-            printf("Error: no processing is specified for event '%s'\n", event_name);
-            retval = 1;
+            /* Continue running the chain even if no actions were executed for
+             * this event.
+             */
+            log_warning("no actions matching this problem found for event '%s'",
+                    event_name);
+            continue;
         }
         else if (retval != 0 || !l_state.output_was_produced)
         {

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -179,14 +179,13 @@ int main(int argc, char** argv)
         }
         case OPT_workflow:
         {
-            load_workflow_config_data(WORKFLOWS_DIR);
-
-            /* list of workflows applicable to the currently processed problem */
+            /* list the workflows which can be applied to the current problem */
+            GList *possible_names = list_possible_events_glist(dump_dir_name, "workflow");
             GHashTable *possible_workflows = load_workflow_config_data_from_list(
-                                    list_possible_events_glist(dump_dir_name, "workflow"),
-                                                    WORKFLOWS_DIR);
+                            possible_names, WORKFLOWS_DIR);
+            g_list_free_full(possible_names, free);
 
-            /* this may still directory even if no workflow will be run */
+            /* this may steal the directory even if no workflow is run */
             dump_dir_name = steal_directory_if_needed(dump_dir_name);
             exitcode = select_and_run_workflow(dump_dir_name, possible_workflows, !(opts & OPT_y));
             break;

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -2158,7 +2158,6 @@ static void start_event_run(const char *event_name)
  no_cmds:
         /* No commands needed?! (This is untypical) */
         free_run_event_state(state);
-//TODO: better msg?
         char *msg = xasprintf(_("No processing for event '%s' is defined"), event_name);
         append_to_textview(g_tv_event_log, msg);
         free(msg);
@@ -2778,14 +2777,14 @@ static char *get_next_processed_event(GList **events_list)
 
         free(expanded_events);
 
-        /* It's OK we can safely compare address even if them were previously freed */
+        /* It's OK, we can safely compare addresses even if they were previously freed */
         if (event_name != expanded_events)
             /* the last expanded event name is stored in event_name */
             *events_list = g_list_concat(expanded_list, *events_list);
         else
         {
             log_info("No event was expanded, will continue with the next one.");
-            /* no expanded event try the next event */
+            /* No expanded event, try the next one */
             return get_next_processed_event(events_list);
         }
     }

--- a/src/include/event_config.h
+++ b/src/include/event_config.h
@@ -162,6 +162,15 @@ bool check_problem_rating_usability(const event_config_t *cfg,
                                     char                 **description,
                                     char                 **detail);
 
+/**
+ * Expand suffixed star wildcard in an event name.
+ *
+ * Returns the expanded list of event names matching the pattern. If no
+ * wildcard is present, returns the singleton list with the original event
+ * only. Returns NULL if no matching events could be found.
+ */
+GList *expand_event_wildcard(const gchar *event_name, gsize event_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/event_config.h
+++ b/src/include/event_config.h
@@ -171,6 +171,13 @@ bool check_problem_rating_usability(const event_config_t *cfg,
  */
 GList *expand_event_wildcard(const gchar *event_name, gsize event_len);
 
+/**
+ * Expand '*' wildcards in an event chain.
+ *
+ * Returns the expanded list of event names.
+ */
+GList *expand_event_chain_wildcards(GList *chain);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/run_event.h
+++ b/src/include/run_event.h
@@ -163,8 +163,9 @@ struct rule {
     char *command; /* never NULL */
 };
 
-/* Returns 0 if no commands found for this dump_dir_name+event, else >0 */
-int prepare_commands(struct run_event_state *state, const char *dump_dir_name, const char *event);
+/* Returns 0 if no commands at all are defined for event processing, otherwise
+ * returns 1. */
+int prepare_commands(struct run_event_state *state);
 /*
  * Returns -1 if no more commands needs to be executed,
  * else sets state->command_pid and state->command_out_fd and returns >=0.

--- a/src/lib/event_config.c
+++ b/src/lib/event_config.c
@@ -596,3 +596,17 @@ GList *expand_event_wildcard(const gchar *event_name, gsize event_len)
 
     return list;
 }
+
+GList *expand_event_chain_wildcards(GList *chain)
+{
+    GList *list = NULL;
+
+    for (GList *item = chain; item; item = g_list_next(item))
+    {
+        const char *event_name = (const char *)item->data;
+        GList *expanded = expand_event_wildcard(event_name, strlen(event_name));
+        list = g_list_concat(list, expanded);
+    }
+
+    return list;
+}

--- a/src/lib/event_xml_parser.c
+++ b/src/lib/event_xml_parser.c
@@ -546,11 +546,15 @@ static void error(GMarkupParseContext *context,
  * event_config_t contains list of options, which is malloced by hits function
  * and must be freed by the caller
  */
-
 void load_event_description_from_file(event_config_t *event_config, const char* filename)
 {
     log_info("loading event: '%s'", filename);
-    struct my_parse_data parse_data = { {event_config, false, false, false}, {NULL, false, false}, NULL, NULL };
+    struct my_parse_data parse_data = {
+        { event_config, false, false, false },
+        { NULL, false, false },
+        NULL,
+        NULL
+    };
     parse_data.cur_locale = xstrdup(setlocale(LC_ALL, NULL));
     strchrnul(parse_data.cur_locale, '.')[0] = '\0';
 
@@ -577,6 +581,8 @@ void load_event_description_from_file(event_config_t *event_config, const char* 
         }
         fclose(fin);
     }
+    else
+        perror_msg("cannot load event description from file: '%s'", filename);
 
     g_markup_parse_context_free(context);
 

--- a/src/lib/run_event.c
+++ b/src/lib/run_event.c
@@ -114,7 +114,7 @@ void make_run_event_state_forwarding(struct run_event_state *state)
  *
  * List of commands machinery is encapsulated in struct run_event_state,
  * and public async API:
- *      prepare_commands(state, dir, event);
+ *      prepare_commands(state);
  *      spawn_next_command(state, dir, event, 0);
  *      free_commands(state);
  * does not expose the way we select rules to execute.
@@ -471,10 +471,8 @@ void free_commands(struct run_event_state *state)
     state->command_pid = 0;
 }
 
-int prepare_commands(struct run_event_state *state,
-                const char *dump_dir_name,
-                const char *event
-) {
+int prepare_commands(struct run_event_state *state)
+{
     free_commands(state);
 
     state->children_count = 0;
@@ -720,7 +718,7 @@ int run_event_on_dir_name(struct run_event_state *state,
                 const char *dump_dir_name,
                 const char *event
 ) {
-    prepare_commands(state, dump_dir_name, event);
+    prepare_commands(state);
 
     /* Execute every command in shell */
 

--- a/src/lib/workflow.c
+++ b/src/lib/workflow.c
@@ -124,15 +124,12 @@ GHashTable *load_workflow_config_data(const char *path)
     if (g_workflow_list)
         return g_workflow_list;
 
-    if (g_workflow_list == NULL)
-    {
-        g_workflow_list = g_hash_table_new_full(
-                                        g_str_hash,
-                                        g_str_equal,
-                                        g_free,
-                                        (GDestroyNotify) free_workflow
-        );
-    }
+    g_workflow_list = g_hash_table_new_full(
+                                    g_str_hash,
+                                    g_str_equal,
+                                    g_free,
+                                    (GDestroyNotify) free_workflow
+    );
 
     if (path == NULL)
         path = WORKFLOWS_DIR;


### PR DESCRIPTION
This proposal repairs the workflow (no pun intended) for workflows that contain event wildcards. The two main changes so far are:

1. Expand wildcards in the workflow XML parser so that the expanded events are available to `report-cli` and `report-gtk` alike. (I'm not happy about doing anything but parsing in the parser, but a more reasonable architecture would likely require significant refactoring.)
2. Don't fail if no matching actions are found for an event. This is a natural thing to happen when using wildcards, since some actions might only make sense for specific problem types.

Fixes #421