### PR TITLE
lib: Don't warn if a configuration key is missing

### DIFF
--- a/src/lib/abrt_types.c
+++ b/src/lib/abrt_types.c
@@ -73,7 +73,7 @@ void set_map_string_item_from_bool(map_string_t *ms, const char *key, int value)
     const char *const val_name = get_map_string_item_or_NULL(conf, item_name); \
     if (val_name == NULL) \
     { \
-        log_warning("Option '%s' is not configured", item_name); \
+        log_debug("Configuration option '%s' not found in loaded settings", item_name); \
         return 0; \
     }
 


### PR DESCRIPTION
Drop warning if a key cannot be found in the supplied configuration map
in the `try_get_map_string_item_as_*` family of functions.

Related: [abrt#1405](https://github.com/abrt/abrt/pull/1405#discussion_r318605702)