### PR TITLE
plugins: bugzilla: Add format file for libreport duplicates

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -39,6 +39,7 @@ MAN5_TXT += bugzilla_formatdup_anaconda.conf.txt
 MAN5_TXT += bugzilla_formatdup.conf.txt
 MAN5_TXT += bugzilla_format_kernel.conf.txt
 MAN5_TXT += bugzilla_format_analyzer_libreport.conf.txt
+MAN5_TXT += bugzilla_formatdup_analyzer_libreport.conf.txt
 MAN5_TXT += mantisbt.conf.txt
 MAN5_TXT += mantisbt_format.conf.txt
 MAN5_TXT += mantisbt_formatdup.conf.txt

--- a/doc/bugzilla_formatdup_analyzer_libreport.conf.txt
+++ b/doc/bugzilla_formatdup_analyzer_libreport.conf.txt
@@ -1,0 +1,18 @@
+bugzilla_formatdup_analyzer_libreport.conf(5)
+=============================================
+
+NAME
+----
+bugzilla_formatdup_analyzer_libreport.conf - configuration file for libreport.
+
+DESCRIPTION
+-----------
+This configuration file provides definition of general formatting for duplicate Bugzilla issues.
+
+SEE ALSO
+--------
+reporter-bugzilla(1)
+
+AUTHOR
+------
+* ABRT Team

--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -586,6 +586,7 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %config(noreplace) %{_sysconfdir}/libreport/plugins/bugzilla_format.conf
 %config(noreplace) %{_sysconfdir}/libreport/plugins/bugzilla_formatdup.conf
 %config(noreplace) %{_sysconfdir}/libreport/plugins/bugzilla_format_analyzer_libreport.conf
+%config(noreplace) %{_sysconfdir}/libreport/plugins/bugzilla_formatdup_analyzer_libreport.conf
 %config(noreplace) %{_sysconfdir}/libreport/plugins/bugzilla_format_kernel.conf
 %{_datadir}/%{name}/events/report_Bugzilla.xml
 %{_datadir}/%{name}/events/watch_Bugzilla.xml
@@ -600,6 +601,7 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{_mandir}/man5/bugzilla_format.conf.5.*
 %{_mandir}/man5/bugzilla_formatdup.conf.5.*
 %{_mandir}/man5/bugzilla_format_analyzer_libreport.conf.5.*
+%{_mandir}/man5/bugzilla_formatdup_analyzer_libreport.conf.5.*
 %{_mandir}/man5/bugzilla_format_kernel.conf.5.*
 %{_bindir}/reporter-bugzilla
 %endif

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -41,6 +41,7 @@ reporters_plugin_conf += bugzilla.conf
 reporters_plugin_format_conf += bugzilla_format.conf \
     bugzilla_formatdup.conf \
     bugzilla_format_analyzer_libreport.conf \
+    bugzilla_formatdup_analyzer_libreport.conf \
     bugzilla_format_kernel.conf \
     bugzilla_format_anaconda.conf \
     bugzilla_formatdup_anaconda.conf

--- a/src/plugins/bugzilla_event.conf
+++ b/src/plugins/bugzilla_event.conf
@@ -1,5 +1,6 @@
 EVENT=report_Bugzilla analyzer=libreport
 	reporter-bugzilla -b \
+		-A /etc/libreport/plugins/bugzilla_formatdup_analyzer_libreport.conf \
 		-F /etc/libreport/plugins/bugzilla_format_analyzer_libreport.conf
 
 EVENT=watch_Bugzilla reported_to~=Bugzilla

--- a/src/plugins/bugzilla_formatdup_analyzer_libreport.conf
+++ b/src/plugins/bugzilla_formatdup_analyzer_libreport.conf
@@ -1,0 +1,56 @@
+# Lines starting with # are ignored.
+# Lines can be continued on the next line using trailing backslash.
+#
+# Format:
+# %summary:: summary format
+# section:: element1[,element2]...
+# The literal text line to be added to Bugzilla comment. Can be empty.
+# (IOW: empty lines are NOT ignored!)
+#
+# Summary format is a line of text, where %element% is replaced by
+# text element's content, and [[...%element%...]] block is used only if
+# %element% exists. [[...]] blocks can nest.
+#
+# Sections can be:
+# - %summary: bug summary format string.
+# - %attach: a list of elements to attach.
+# - text, double colon (::) and the list of comma-separated elements.
+#   Text can be empty (":: elem1, elem2, elem3" works),
+#   in this case "Text:" header line will be omitted.
+#
+# Elements can be:
+# - problem directory element names, which get formatted as
+#   <element_name>: <contents>
+#   or
+#   <element_name>:
+#   :<contents>
+#   :<contents>
+#   :<contents>
+# - problem directory element names prefixed by "%bare_",
+#   which is formatted as-is, without "<element_name>:" and colons
+# - %oneline, %multiline, %text wildcards, which select all corresponding
+#   elements for output or attachment
+# - %binary wildcard, valid only for %attach section, instructs to attach
+#   binary elements
+# - problem directory element names prefixed by "-",
+#   which excludes given element from all wildcards
+#
+#   Nonexistent elements are silently ignored.
+#   If none of elements exists, the section will not be created.
+
+Similar problem has been detected:
+
+# If user filled out comment field, show it:
+:: %bare_comment
+
+# var_log_messages has too much variance (time/date),
+# we exclude it from message so that dup message elimination has more chances to work
+:: \
+    -pkg_arch,-pkg_epoch,-pkg_name,-pkg_release,-pkg_version,\
+        -component,-architecture,\
+    -analyzer,-count,-duphash,-uuid,-abrt_version,\
+    -username,-hostname,-os_release,-os_info,\
+    -time,-pid,-pwd,-last_occurrence,-ureports_counter,\
+    -var_log_messages,-tid\
+    %reporter,\
+    %oneline


### PR DESCRIPTION
Since we don’t have a duplicate formatting file for libreport-analyzed
problems, reporting things like SELinux AVC denials might result in a
nonexistent file being referenced (e.g. pkg_name, which doesn’t quite
make sense in this case).

Fixes https://github.com/abrt/libreport/issues/445
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1752006

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>