### PR TITLE
gtk: Fix a double-free condition

### DIFF
--- a/src/gui-wizard-gtk/main.c
+++ b/src/gui-wizard-gtk/main.c
@@ -224,7 +224,6 @@ int main(int argc, char **argv)
     /* Enter main loop */
     g_application_run(G_APPLICATION(app), argc, argv);
     g_object_unref(app);
-    g_list_free_full(g_auto_event_list, free);
 
     if (opts & OPT_d)
         delete_dump_dir_possibly_using_abrtd(g_dump_dir_name);

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -2966,7 +2966,7 @@ static char *setup_next_processed_event(GList **events_list)
     free(g_event_selected);
     g_event_selected = NULL;
 
-    char *event = get_next_processed_event(&g_auto_event_list);
+    char *event = get_next_processed_event(events_list);
     if (!event)
     {
         /* No next event, go to progress page and finish */


### PR DESCRIPTION
This misbehaviour seems to have been introduced in 861e8d10b.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1761095