### PR TITLE
gtk: Memory management redux

### DIFF
--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -2714,6 +2714,7 @@ static char *get_next_processed_event(GList **events_list)
         return NULL;
 
     char *event_name = (char *)(*events_list)->data;
+    *events_list = g_list_delete_link(*events_list, *events_list);
 
     clear_warnings();
 
@@ -2738,7 +2739,6 @@ static char *get_next_processed_event(GList **events_list)
         return NULL;
     }
 
-    *events_list = g_list_next(*events_list);
     return event_name;
 }
 

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -1676,7 +1676,7 @@ static void on_btn_cancel_event(GtkButton *button)
 
 static bool is_processing_finished()
 {
-    return !g_expert_mode && !g_auto_event_list;
+    return !g_expert_mode && g_auto_event_list == NULL;
 }
 
 static void hide_next_step_button()
@@ -2116,7 +2116,7 @@ static void start_event_run(const char *event_name)
 
     if (prepare_commands(state) == 0)
     {
-        /* Strangely, no commands at all were fond for processing the crashdump.
+        /* Strangely, no commands at all were found for processing the crashdump.
          * Let the user know and terminate processing.
          */
         free_run_event_state(state);
@@ -2882,9 +2882,9 @@ static void on_page_prepare(GtkNotebook *assistant, GtkWidget *page, gpointer us
         }
     }
 
-    if(pages[PAGENO_EVENT_SELECTOR].page_widget == page)
+    if (pages[PAGENO_EVENT_SELECTOR].page_widget == page)
     {
-        if (!g_expert_mode && !g_auto_event_list)
+        if (is_processing_finished())
             hide_next_step_button();
     }
 }
@@ -2969,11 +2969,11 @@ static char *setup_next_processed_event(GList **events_list)
     char *event = get_next_processed_event(events_list);
     if (!event)
     {
-        /* No next event, go to progress page and finish */
+        /* No next event, go to progress page and finish. */
         gtk_label_set_text(g_lbl_event_log, _("Processing finished."));
-        /* we don't know the result of the previous event here
-         * so at least hide the spinner, because we're obviously finished
-        */
+        /* We don't know the result of the previous event here
+         * so at least hide the spinner, because we're obviously finished.
+         */
         gtk_widget_hide(GTK_WIDGET(g_spinner_event_log));
         hide_next_step_button();
         return NULL;
@@ -3010,7 +3010,7 @@ static gint select_next_page_no(gint current_page_no, gpointer data)
 
     if (pages[PAGENO_EVENT_SELECTOR].page_widget == page)
     {
-        if (!g_expert_mode && (g_auto_event_list == NULL))
+        if (is_processing_finished())
         {
             return current_page_no; //stay here and let user select the workflow
         }
@@ -3059,13 +3059,11 @@ static gint select_next_page_no(gint current_page_no, gpointer data)
 
             g_event_selected = event;
 
-            /* Notify a user that some configuration options miss values, but */
-            /* don't force him to provide them. */
+            /* Notify the user that some configuration options miss values, but don't
+             * force him to provide them.
+             */
             check_event_config(g_event_selected);
 
-            /* >>> and this but this is clearer
-             * because it does exactly the same thing
-             * but I'm pretty scared to touch it */
             current_page_no = pages[PAGENO_EVENT_SELECTOR].page_no + 1;
             goto event_was_selected;
         }

--- a/src/lib/workflow.c
+++ b/src/lib/workflow.c
@@ -170,13 +170,17 @@ GList *wf_get_event_names(workflow_t *w)
 {
     GList *wf_event_list = wf_get_event_list(w);
     GList *event_names = NULL;
-    while(wf_event_list)
+
+    while (wf_event_list)
     {
-        event_names = g_list_append(event_names, xstrdup(ec_get_name(wf_event_list->data)));
+        /* Since appending is inefficient for GLib doubly-linked lists, we prepend
+         * here and reverse the list just before returning.
+         */
+        event_names = g_list_prepend(event_names, xstrdup(ec_get_name(wf_event_list->data)));
         wf_event_list = g_list_next(wf_event_list);
     }
 
-    return event_names;
+    return g_list_reverse(event_names);
 }
 
 const char *wf_get_name(workflow_t *w)


### PR DESCRIPTION
In light of recently (re)discovered ghastly double-frees, and for very practical reasons as well, I've taken up the task of cleaning up the wizard GUI code. I've started by flushing most of the manual memory management, which seems to be a long-time source of painful problems.

This is but a humble beginning attempting to patch the most glaring holes. There's still a lot left to do to make this into a shiny cathedral.