### PR TITLE
gui-wizard-gtk: Get rid of advanced misfeatures

### DIFF
--- a/src/gui-wizard-gtk/main.c
+++ b/src/gui-wizard-gtk/main.c
@@ -23,7 +23,6 @@
 # include <locale.h>
 #endif
 
-char *g_glade_file = NULL;
 char *g_dump_dir_name = NULL;
 char *g_events = NULL;
 GList *g_auto_event_list = NULL;
@@ -167,7 +166,6 @@ int main(int argc, char **argv)
     /* Keep enum above and order of options below in sync! */
     struct options program_options[] = {
         OPT__VERBOSE(&g_verbose),
-        OPT_STRING('g', NULL, &g_glade_file, "FILE",          _("Alternate GUI file")),
         OPT_BOOL(  'p', NULL, NULL,                           _("Add program names to log")),
         OPT_BOOL(  'd', "delete", NULL,                       _("Remove PROBLEM_DIR after reporting")),
         OPT_LIST(  'e', "event", &user_event_list, "EVENT",   _("Run only these events")),

--- a/src/gui-wizard-gtk/main.c
+++ b/src/gui-wizard-gtk/main.c
@@ -116,13 +116,12 @@ static void
 activate_wizard(GApplication *app,
                 gpointer user_data)
 {
-    create_assistant(GTK_APPLICATION(app), *(int *)user_data);
+    create_assistant(GTK_APPLICATION(app));
     update_gui_state_from_problem_data(UPDATE_SELECTED_EVENT);
 }
 
 int main(int argc, char **argv)
 {
-    int expert_mode = 0;
     /* List of events specified on the command line. */
     GList *user_event_list = NULL;
     const char *prgname = "abrt";
@@ -169,7 +168,6 @@ int main(int argc, char **argv)
         OPT_BOOL(  'p', NULL, NULL,                           _("Add program names to log")),
         OPT_BOOL(  'd', "delete", NULL,                       _("Remove PROBLEM_DIR after reporting")),
         OPT_LIST(  'e', "event", &user_event_list, "EVENT",   _("Run only these events")),
-        OPT_BOOL(  'x', "expert", &expert_mode,               _("Expert mode")),
         OPT_END()
     };
     unsigned opts = parse_opts(argc, argv, program_options, program_usage_string);
@@ -198,7 +196,7 @@ int main(int argc, char **argv)
     g_list_free_full(possible_names, free);
 
     /* if we have only 1 workflow, we can use the events from it as default */
-    if (!expert_mode && g_auto_event_list == NULL && g_hash_table_size(possible_workflows) == 1)
+    if (g_auto_event_list == NULL && g_hash_table_size(possible_workflows) == 1)
     {
         GHashTableIter iter;
         gpointer key, value;
@@ -216,7 +214,7 @@ int main(int argc, char **argv)
 
     g_custom_logger = &show_error_as_msgbox;
     GtkApplication *app = gtk_application_new("org.freedesktop.libreport.report", G_APPLICATION_NON_UNIQUE);
-    g_signal_connect(app, "activate", G_CALLBACK(activate_wizard), (gpointer)&expert_mode);
+    g_signal_connect(app, "activate", G_CALLBACK(activate_wizard), NULL);
     g_signal_connect(app, "startup",  G_CALLBACK(startup_wizard),  NULL);
 
     /* Enter main loop */

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -268,33 +268,25 @@ static GtkBuilder *make_builder()
 {
     GError *error = NULL;
     GtkBuilder *builder = gtk_builder_new();
-    if (!g_glade_file)
+
+    /* load additional widgets from glade */
+    gtk_builder_add_objects_from_string(builder,
+            WIZARD_GLADE_CONTENTS, sizeof(WIZARD_GLADE_CONTENTS) - 1,
+            (gchar**)misc_widgets,
+            &error);
+    if (error != NULL)
     {
-        /* load additional widgets from glade */
-        gtk_builder_add_objects_from_string(builder,
-                WIZARD_GLADE_CONTENTS, sizeof(WIZARD_GLADE_CONTENTS) - 1,
-                (gchar**)misc_widgets,
-                &error);
-        if (error != NULL)
-            error_msg_and_die("Error loading glade data: %s", error->message);
-        /* Load pages from internal string */
-        gtk_builder_add_objects_from_string(builder,
-                WIZARD_GLADE_CONTENTS, sizeof(WIZARD_GLADE_CONTENTS) - 1,
-                (gchar**)page_names,
-                &error);
-        if (error != NULL)
-            error_msg_and_die("Error loading glade data: %s", error->message);
+        error_msg_and_die("Error loading glade data: %s", error->message);
     }
-    else
+
+    /* Load pages from internal string */
+    gtk_builder_add_objects_from_string(builder,
+            WIZARD_GLADE_CONTENTS, sizeof(WIZARD_GLADE_CONTENTS) - 1,
+            (gchar**)page_names,
+            &error);
+    if (error != NULL)
     {
-        /* -g FILE: load UI from it */
-        /* load additional widgets from glade */
-        gtk_builder_add_objects_from_file(builder, g_glade_file, (gchar**)misc_widgets, &error);
-        if (error != NULL)
-            error_msg_and_die("Can't load %s: %s", g_glade_file, error->message);
-        gtk_builder_add_objects_from_file(builder, g_glade_file, (gchar**)page_names, &error);
-        if (error != NULL)
-            error_msg_and_die("Can't load %s: %s", g_glade_file, error->message);
+        error_msg_and_die("Error loading glade data: %s", error->message);
     }
 
     return builder;

--- a/src/gui-wizard-gtk/wizard.h
+++ b/src/gui-wizard-gtk/wizard.h
@@ -40,7 +40,6 @@ void update_gui_state_from_problem_data(int flags);
 void show_error_as_msgbox(const char *msg);
 
 
-extern char *g_glade_file;
 extern char *g_dump_dir_name;
 extern char *g_events;
 extern GList *g_auto_event_list;

--- a/src/gui-wizard-gtk/wizard.h
+++ b/src/gui-wizard-gtk/wizard.h
@@ -21,7 +21,7 @@
 
 #include "internal_libreport_gtk.h"
 
-void create_assistant(GtkApplication *app, bool expert_mode);
+void create_assistant(GtkApplication *app);
 
 enum
 {


### PR DESCRIPTION
The expert mode is completely broken and no one seems to be complaining - into the trash it goes.

The ability to user your own UI definitions is completely useless, since:
  1. we would normally have to implement changes in a backwards-compatible way,
  2. it is ridiculously easy to make everything crash and have the user not realize why,
  3. there is no valid use case, just implement a new client if you’re unhappy.