### PR TITLE
ureport: Allow printf-like data attaching

### DIFF
--- a/src/include/ureport.h
+++ b/src/include/ureport.h
@@ -255,30 +255,34 @@ ureport_json_attachment_new(const char *bthash, const char *type, const char *da
 /*
  * Attach given string to uReport
  *
+ * @param config Configuration used in communication
  * @param bthash uReport identifier
  * @param type Type of attachment
  * @param data Attached data
- * @param config Configuration used in communication
  * @return True in case of any error; otherwise False
  */
-#define ureport_attach_string libreport_ureport_attach_string
 bool
-ureport_attach_string(const char *bthash, const char *type, const char *data,
-               struct ureport_server_config *config);
+ureport_attach_string(struct ureport_server_config *config,
+                      const char                   *bthash,
+                      const char                   *type,
+                      const char                   *data);
 
 /*
- * Attach given integer to uReport
+ * Attach formatted data to uReport
  *
+ * @param config Configuration used in communication
  * @param bthash uReport identifier
  * @param type Type of attachment
- * @param data Attached data
- * @param config Configuration used in communication
+ * @param format Data format string
+ * @param ... Values to replace format specifiers
  * @return True in case of any error; otherwise False
  */
-#define ureport_attach_int libreport_ureport_attach_int
 bool
-ureport_attach_int(const char *bthash, const char *type, int data,
-                   struct ureport_server_config *config);
+ureport_attach(struct ureport_server_config *config,
+               const char                   *bthash,
+               const char                   *type,
+               const char                   *format,
+               ...) G_GNUC_PRINTF(4, 5);
 
 /*
  * Build uReport from dump dir

--- a/src/lib/ureport.c
+++ b/src/lib/ureport.c
@@ -867,12 +867,16 @@ ureport_json_attachment_new(const char *bthash, const char *type, const char *da
 }
 
 bool
-ureport_attach_string(const char *bthash, const char *type, const char *data,
-               struct ureport_server_config *config)
+ureport_attach_string(struct ureport_server_config *config,
+                      const char *bthash,
+                      const char *type,
+                      const char *data)
 {
-    char *json = ureport_json_attachment_new(bthash, type, data);
+    g_autofree char *json = NULL;
+
+    json = ureport_json_attachment_new(bthash, type, data);
+
     post_state_t *post_state = ureport_do_post(json, config, UREPORT_ATTACH_ACTION);
-    free(json);
 
     struct ureport_server_response *resp =
         ureport_server_response_from_reply(post_state, config);
@@ -890,12 +894,18 @@ ureport_attach_string(const char *bthash, const char *type, const char *data,
 }
 
 bool
-ureport_attach_int(const char *bthash, const char *type, int data,
-                    struct ureport_server_config *config)
+ureport_attach(struct ureport_server_config *config,
+               const char *bthash,
+               const char *type,
+               const char *format,
+               ...)
 {
-    char *data_str = xasprintf("%d", data);
-    const bool result = ureport_attach_string(bthash, type, data_str, config);
-    free(data_str);
+    va_list args;
+    g_autofree char *string = NULL;
 
-    return result;
+    va_start(args, format);
+
+    string = g_strdup_vprintf(format, args);
+
+    return ureport_attach_string(config, bthash, type, string);
 }

--- a/src/plugins/reporter-ureport.c
+++ b/src/plugins/reporter-ureport.c
@@ -274,25 +274,25 @@ int main(int argc, char **argv)
 
         if (rhbz_bug >= 0)
         {
-            if (ureport_attach_int(ureport_hash, "RHBZ", rhbz_bug, &config))
+            if (ureport_attach(&config, ureport_hash, "RHBZ", "%d", rhbz_bug))
                 goto finalize;
         }
 
         if (email_address)
         {
-            if (ureport_attach_string(ureport_hash, "email", email_address, &config))
+            if (ureport_attach(&config, ureport_hash, "email", "%s", email_address))
                 goto finalize;
         }
 
         if (comment)
         {
-            if (ureport_attach_string(ureport_hash, "comment", comment, &config))
+            if (ureport_attach(&config, ureport_hash, "comment", "%s", comment))
                 goto finalize;
         }
 
         if (attach_value)
         {
-            if (ureport_attach_string(ureport_hash, attach_type, attach_value, &config))
+            if (ureport_attach(&config, ureport_hash, attach_type, "%s", attach_value))
                 goto finalize;
         }
 

--- a/tests/ureport.at
+++ b/tests/ureport.at
@@ -1065,41 +1065,14 @@ int main(void)
 {
     g_verbose=3;
 
-    /* wrong url */
     struct ureport_server_config config;
     ureport_server_config_init(&config);
 
-    bool res = ureport_attach_string("691cf824e3e07457156125636e86c50279e29496", "email", "abrt@email.com", &config);
+    bool res = ureport_attach(&config, "691cf824e3e07457156125636e86c50279e29496", "email", "abrt@email.com");
     assert(res == true);
 
-    ureport_server_config_destroy(&config);
-
-    return 0;
-}
-]])
-
-## ------------------ ##
-## ureport_attach_int ##
-## ------------------ ##
-
-AT_TESTFUN([ureport_attach_int],
-[[
-#include "internal_libreport.h"
-#include "ureport.h"
-#include <assert.h>
-#include "libreport_curl.h"
-#include "problem_data.h"
-
-int main(void)
-{
-    g_verbose=3;
-
-    /* wrong url */
-    struct ureport_server_config config;
-    ureport_server_config_init(&config);
-
-    bool res = ureport_attach_int("691cf824e3e07457156125636e86c50279e29496", "count", 5, &config);
-    assert(res == true);
+    res = ureport_attach(&config, "691cf824e3e07457156125636e86c50279e29496", "count", "%d", 5);
+    assert(res);
 
     ureport_server_config_destroy(&config);
 


### PR DESCRIPTION
Currently, it is only possible to attach string and integer data to reports (without formatting a string beforehand), with the latter case simply being a wrapper for the former.
    
This commit replaces the integer wrapper with a printf-like variadic one should there ever be a need to attach more specific kinds of data.