### PR TITLE
Accomodate for multiple debug directories

### DIFF
--- a/src/client-python/reportclient/debuginfo.py
+++ b/src/client-python/reportclient/debuginfo.py
@@ -433,16 +433,18 @@ class DebugInfoDownload(object):
         return RETURN_OK
 
 
-def build_ids_to_path(pfx, build_ids):
+def build_ids_to_paths(prefix, build_ids):
     """
-    Transforms build ids into a path.
-
-    build_id1=${build_id:0:2}
-    build_id2=${build_id:2}
-    file="usr/lib/debug/.build-id/$build_id1/$build_id2.debug"
+    Returns the list of posible locations of debug files
+    for the supplied build-ids.
     """
 
-    return ["%s/usr/lib/debug/.build-id/%s/%s.debug" % (pfx, b_id[:2], b_id[2:]) for b_id in build_ids]
+    paths = ["{0}/usr/lib/debug/.build-id/{1}/{2}.debug".format(prefix, b_id[:2], b_id[2:])
+             for b_id in build_ids]
+    paths += ["{0}/usr/lib/.build-id/{1}/{2}.debug".format(prefix, b_id[:2], b_id[2:])
+              for b_id in build_ids]
+
+    return paths
 
 # beware this finds only missing libraries, but not the executable itself ..
 


### PR DESCRIPTION
A change was introduced in Fedora 27 to allow for installing multiple versions of debuginfo packages in parallel. In effect, `/usr/lib/.build-id` may contain debug files as well in addition to `/usr/lib/debug/.build-id`.

See https://fedoraproject.org/wiki/Changes/ParallelInstallableDebuginfo for more details.

Follow-up to abrt/faf#851.

Corresponding ABRT change: abrt/abrt#1462.