### PR TITLE
gui-wizard-gtk: Wrap event log messages

### DIFF
--- a/src/gui-wizard-gtk/wizard.glade
+++ b/src/gui-wizard-gtk/wizard.glade
@@ -705,6 +705,7 @@
                     <property name="expand">True</property>
                     <property name="visible">True</property>
                     <property name="editable">False</property>
+                    <property name="wrap-mode">word</property>
                   </object>
                 </child>
               </object>


### PR DESCRIPTION
Currently, large logs received by abrt-retrace-client may cause
X/Wayland protocol errors due to an overly large buffer being allocated
for GtkTextView. Enabling word wrapping and eliminating horizontal
scrolling seems to prevent that from happening.

Cf. https://gitlab.gnome.org/GNOME/gtk/issues/1143

https://bugzilla.redhat.com/show_bug.cgi?id=1815544