### PR TITLE
Remove #define's adding libreport_ to function names

### DIFF
--- a/src/cli/cli-report.c
+++ b/src/cli/cli-report.c
@@ -806,7 +806,7 @@ static int run_event_chain_real(struct run_event_state *run_state,
         else if (retval != 0 || !l_state.output_was_produced)
         {
             /* Program failed, or finished successfully with no output. */
-            char *msg = exit_status_as_string(event_name, run_state->process_status);
+            char *msg = libreport_exit_status_as_string(event_name, run_state->process_status);
             fputs(msg, stdout);
             free(msg);
         }

--- a/src/cli/cli-report.c
+++ b/src/cli/cli-report.c
@@ -435,15 +435,15 @@ static void ask_for_missing_settings(const char *event_name)
             switch (opt->eo_type) {
             case OPTION_TYPE_TEXT:
             case OPTION_TYPE_NUMBER:
-                opt->eo_value = ask(question);
+                opt->eo_value = libreport_ask(question);
                 break;
             case OPTION_TYPE_PASSWORD:
             {
-                opt->eo_value = ask_password(question);
+                opt->eo_value = libreport_ask_password(question);
                 break;
             }
             case OPTION_TYPE_BOOL:
-                if (ask_yes_no(question))
+                if (libreport_ask_yes_no(question))
                     opt->eo_value = xstrdup("yes");
                 else
                     opt->eo_value = xstrdup("no");
@@ -463,14 +463,14 @@ static void ask_for_missing_settings(const char *event_name)
         if (!err_list)
             return;
 
-        alert(_("Your input is not valid, because of:"));
+        libreport_alert(_("Your input is not valid, because of:"));
         for (iter = err_list; iter; iter = iter -> next)
         {
             invalid_option_t *err_data = (invalid_option_t *)iter->data;
             char *msg = xasprintf(_("Bad value for '%s': %s"),
                                     err_data->invopt_name,
                                     err_data->invopt_error);
-            alert(msg);
+            libreport_alert(msg);
             free(msg);
         }
 
@@ -490,7 +490,7 @@ struct logging_state {
 
 static char *do_log(char *log_line, void *param)
 {
-    client_log(log_line);
+    libreport_client_log(log_line);
     return log_line;
 }
 
@@ -671,7 +671,7 @@ static int run_event_on_dir_name_interactively(
             char *msg = xasprintf(_("Event '%s' requires permission to send possibly sensitive data."
                                     " Do you want to continue?"),
                         ec_get_screen_name(config) ? ec_get_screen_name(config) : event_name);
-            bool ok = ask_yes_no(msg);
+            bool ok = libreport_ask_yes_no(msg);
             free(msg);
             if (!ok)
                 goto ret;
@@ -709,14 +709,14 @@ static int choose_number_from_range(unsigned min, unsigned max, const char *mess
     unsigned ii;
     for (ii = 0; ii < 3; ++ii)
     {
-        char *answer = ask(message);
+        char *answer = libreport_ask(message);
 
         picked = xatou(answer);
         if (min <= picked && picked <= max)
             return picked;
 
         char *msg = xasprintf("%s (%u - %u)\n", _("You have chosen number out of range"), min, max);
-        alert(msg);
+        libreport_alert(msg);
         free(msg);
     }
 

--- a/src/cli/cli-report.c
+++ b/src/cli/cli-report.c
@@ -522,7 +522,7 @@ static int is_not_reportable(problem_data_t *problem_data)
     if (not_reportable)
     {
         printf("%s\n", not_reportable);
-        if (get_global_stop_on_not_reportable())
+        if (libreport_get_global_stop_on_not_reportable())
             return 1;
     }
     return 0;

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -25,12 +25,12 @@
 
 static char *steal_directory_if_needed(char *dump_dir_name)
 {
-    struct dump_dir *dd = open_directory_for_writing(dump_dir_name,
+    struct dump_dir *dd = libreport_open_directory_for_writing(dump_dir_name,
                                                      /* ask callback */ NULL);
 
     if (dd)
     {
-        dump_dir_name = xstrdup(dd->dd_dirname);
+        dump_dir_name = libreport_xstrdup(dd->dd_dirname);
         dd_close(dd);
     }
 
@@ -92,12 +92,12 @@ int main(int argc, char** argv)
         OPT_BOOL(     'x', "expert" , NULL,                    _("Expert mode")),
         OPT_BOOL(     'V', "version", NULL,                    _("Display version and exit")),
         OPT_BOOL(     'y', "always" , NULL,                    _("Noninteractive: don't ask questions, assume 'yes'")),
-        OPT__VERBOSE(&g_verbose),
+        OPT__VERBOSE(&libreport_g_verbose),
         OPT_BOOL(     's', NULL     , NULL,                    _("Log to syslog")),
         OPT_BOOL(     'p', NULL     , NULL,                    _("Add program names to log")),
         OPT_END()
     };
-    unsigned opts = parse_opts(argc, argv, program_options, program_usage_string);
+    unsigned opts = libreport_parse_opts(argc, argv, program_options, program_usage_string);
     unsigned op = (opts & OPTMASK_op);
     if (!op)
     {
@@ -106,7 +106,7 @@ int main(int argc, char** argv)
     }
     else if ((op-1) & op)
         /* "You must specify exactly one operation" */
-        show_usage_and_die(program_usage_string, program_options);
+        libreport_show_usage_and_die(program_usage_string, program_options);
 
     runaway_arguments = (argc - optind) > 1;
     missing_positional_argument = (opts & OPTMASK_need_arg) && (argc == optind);
@@ -114,7 +114,7 @@ int main(int argc, char** argv)
     /* Check for bad usage */
     if (runaway_arguments || (missing_positional_argument && op != OPT_list_events))
     {
-        show_usage_and_die(program_usage_string, program_options);
+        libreport_show_usage_and_die(program_usage_string, program_options);
     }
 
     argv += optind;
@@ -122,15 +122,15 @@ int main(int argc, char** argv)
 
     if (op == OPT_version)
     {
-        printf("%s "VERSION"\n", g_progname);
+        printf("%s "VERSION"\n", libreport_g_progname);
         return 0;
     }
 
-    export_abrt_envvars(opts & OPT_p);
+    libreport_export_abrt_envvars(opts & OPT_p);
     if (opts & OPT_s)
     {
-        openlog(msg_prefix, 0, LOG_DAEMON);
-        logmode = LOGMODE_SYSLOG;
+        openlog(libreport_msg_prefix, 0, LOG_DAEMON);
+        libreport_logmode = LOGMODE_SYSLOG;
     }
 
     char *dump_dir_name = argv[0];
@@ -141,7 +141,7 @@ int main(int argc, char** argv)
     /* At least, needed by ASK_YES_NO_YESFOREVER event command requests.
      * Removing of the following statement will get the yes forever stuff not
      * working. */
-    load_user_settings("report-cli");
+    libreport_load_user_settings("report-cli");
 
     /* Do the selected operation. */
     int exitcode = 0;
@@ -193,6 +193,6 @@ int main(int argc, char** argv)
     }
 
     /* At least, needed by ASK_YES_NO_YESFOREVER event command requests. */
-    save_user_settings();
+    libreport_save_user_settings();
     return exitcode;
 }

--- a/src/cli/run-command.c
+++ b/src/cli/run-command.c
@@ -61,9 +61,9 @@ static void start_command(struct command *cmd)
   if (cmd->pid == 0)
   {
     /* Child */
-    xmove_fd(cmd->tty_fd, 0);
-    xdup2(0, 1);
-    xdup2(0, 2);
+    libreport_xmove_fd(cmd->tty_fd, 0);
+    libreport_xdup2(0, 1);
+    libreport_xdup2(0, 2);
 
     /* tcsetpgrp() below will send us SIGTTOU if we aren't
      * foreground process group. Need to ignore it */
@@ -98,7 +98,7 @@ static int finish_command(struct command *cmd)
   int status;
   for (;;)
   {
-    pid_t waiting = safe_waitpid(cmd->pid, &status, WUNTRACED);
+    pid_t waiting = libreport_safe_waitpid(cmd->pid, &status, WUNTRACED);
     if (waiting < 0)
       perror_msg_and_die("waitpid");
     if (!WIFSTOPPED(status))

--- a/src/client-python/reportclient/client.c
+++ b/src/client-python/reportclient/client.c
@@ -28,7 +28,7 @@ PyObject *p_alert(PyObject *pself, PyObject *args)
     {
         return NULL;
     }
-    alert(message);
+    libreport_alert(message);
     Py_RETURN_NONE;
 }
 
@@ -41,7 +41,7 @@ PyObject *p_ask(PyObject *pself, PyObject *args)
         return NULL;
     }
 
-    char *response = ask(question);
+    char *response = libreport_ask(question);
     if (!response)
     {
         Py_RETURN_NONE;
@@ -61,7 +61,7 @@ PyObject *p_ask_password(PyObject *pself, PyObject *args)
         return NULL;
     }
 
-    char *response = ask_password(question);
+    char *response = libreport_ask_password(question);
     if (!response)
     {
         Py_RETURN_NONE;
@@ -72,7 +72,7 @@ PyObject *p_ask_password(PyObject *pself, PyObject *args)
     return r;
 }
 
-/* C: int ask_yes_no(const char *question); */
+/* C: int libreport_ask_yes_no(const char *question); */
 PyObject *p_ask_yes_no(PyObject *pself, PyObject *args)
 {
     const char *question;
@@ -81,7 +81,7 @@ PyObject *p_ask_yes_no(PyObject *pself, PyObject *args)
         return NULL;
     }
 
-    int response = ask_yes_no(question);
+    int response = libreport_ask_yes_no(question);
 
     return Py_BuildValue("i", response);
 }
@@ -96,7 +96,7 @@ PyObject *p_ask_yes_no_yesforever(PyObject *pself, PyObject *args)
         return NULL;
     }
 
-    int response = ask_yes_no_yesforever(key, question);
+    int response = libreport_ask_yes_no_yesforever(key, question);
 
     return Py_BuildValue("i", response);
 }
@@ -111,7 +111,7 @@ PyObject *p_ask_yes_no_save_result(PyObject *pself, PyObject *args)
         return NULL;
     }
 
-    int response = ask_yes_no_save_result(key, question);
+    int response = libreport_ask_yes_no_save_result(key, question);
 
     return Py_BuildValue("i", response);
 }

--- a/src/gtk-helpers/ask_dialogs.c
+++ b/src/gtk-helpers/ask_dialogs.c
@@ -56,11 +56,11 @@ static int run_ask_yes_no_save_generic_result_dialog(ask_yes_no_dialog_flags fla
 {
     INITIALIZE_LIBREPORT();
 
-    const char *ask_result = get_user_setting(key);
+    const char *ask_result = libreport_get_user_setting(key);
 
     if (ask_result)
     {
-        const bool ret = string_to_bool(ask_result);
+        const bool ret = libreport_string_to_bool(ask_result);
         if (!(flags & ASK_YES_NO__YESFOREVER))
             return ret;
 
@@ -111,12 +111,12 @@ static int run_ask_yes_no_save_generic_result_dialog(ask_yes_no_dialog_flags fla
 
     if (flags & ASK_YES_NO__YESFOREVER)
         /* the box is checked -> Don't ask me again and my response is always 'Yes' */
-        set_user_setting(key, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ask_yes_no_cb)) ? "no" : "yes");
+        libreport_set_user_setting(key, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ask_yes_no_cb)) ? "no" : "yes");
     else if (flags & ASK_YES_NO__SAVE_RESULT)
     {
         if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ask_yes_no_cb)))
             /* the box is checked -> remember my current answer */
-            set_user_setting(key, response == GTK_RESPONSE_YES ? "yes" : "no");
+            libreport_set_user_setting(key, response == GTK_RESPONSE_YES ? "yes" : "no");
     }
     else /* should not happen */
         error_msg("BUG:%s:%d %s() unknown type (0x%x) of libreport_ask_yes_no dialog",

--- a/src/gtk-helpers/ask_dialogs.c
+++ b/src/gtk-helpers/ask_dialogs.c
@@ -129,13 +129,13 @@ static int run_ask_yes_no_save_generic_result_dialog(ask_yes_no_dialog_flags fla
 
 /*
  * This function is little bit confusing. Please, consider usage of
- * run_ask_yes_no_save_result_dialog()
+ * libreport_run_ask_yes_no_save_result_dialog()
  *
  * Function shows a dialog with 'Yes/No' buttons and a check box allowing to
  * remember the answer. The "Don't ask me again" response is stored in
  * configuration file under 'key'.
  */
-int run_ask_yes_no_yesforever_dialog(const char *key, const char *message, GtkWindow *parent)
+int libreport_run_ask_yes_no_yesforever_dialog(const char *key, const char *message, GtkWindow *parent)
 {
     return run_ask_yes_no_save_generic_result_dialog(ASK_YES_NO__YESFOREVER, key, message, parent);
 }
@@ -145,7 +145,7 @@ int run_ask_yes_no_yesforever_dialog(const char *key, const char *message, GtkWi
  * remember the answer. The answer is stored in configuration file under
  * 'key'.
  */
-int run_ask_yes_no_save_result_dialog(const char *key, const char *message, GtkWindow *parent)
+int libreport_run_ask_yes_no_save_result_dialog(const char *key, const char *message, GtkWindow *parent)
 {
     return run_ask_yes_no_save_generic_result_dialog(ASK_YES_NO__SAVE_RESULT, key, message, parent);
 }

--- a/src/gtk-helpers/ask_dialogs.c
+++ b/src/gtk-helpers/ask_dialogs.c
@@ -119,7 +119,7 @@ static int run_ask_yes_no_save_generic_result_dialog(ask_yes_no_dialog_flags fla
             set_user_setting(key, response == GTK_RESPONSE_YES ? "yes" : "no");
     }
     else /* should not happen */
-        error_msg("BUG:%s:%d %s() unknown type (0x%x) of ask_yes_no dialog",
+        error_msg("BUG:%s:%d %s() unknown type (0x%x) of libreport_ask_yes_no dialog",
                     __FILE__, __LINE__, __func__, flags);
 
     gtk_widget_destroy(dialog);

--- a/src/gtk-helpers/autowrapped_label.c
+++ b/src/gtk-helpers/autowrapped_label.c
@@ -58,7 +58,7 @@ static void rewrap_label_to_parent_size(GtkWidget *widget,
         gtk_widget_set_size_request(widget, -1, lh);
 }
 
-void make_label_autowrap_on_resize(GtkLabel *label)
+void libreport_make_label_autowrap_on_resize(GtkLabel *label)
 {
     // So far, only tested to work on labels which were set up as:
     // gtk_label_set_justify(label, GTK_JUSTIFY_LEFT);

--- a/src/gtk-helpers/config_dialog.c
+++ b/src/gtk-helpers/config_dialog.c
@@ -61,7 +61,7 @@ config_dialog_t *new_config_dialog(GtkWidget *dialog,
                                    gpointer config_data,
                                    config_save_fun_t save_fun)
 {
-    config_dialog_t *cdialog = (config_dialog_t *)xmalloc(sizeof(*cdialog));
+    config_dialog_t *cdialog = (config_dialog_t *)libreport_xmalloc(sizeof(*cdialog));
     cdialog->dialog = dialog;
     cdialog->data = config_data;
     cdialog->save_data = save_fun;
@@ -155,7 +155,7 @@ static void save_value_from_widget(gpointer data, gpointer user_data)
     if (val && (val[0] != '\0' || ow->option->eo_value != NULL))
     {
         free(ow->option->eo_value);
-        ow->option->eo_value = xstrdup(val);
+        ow->option->eo_value = libreport_xstrdup(val);
         log_notice("saved: %s:%s", ow->option->eo_name, ow->option->eo_value);
     }
 }
@@ -176,10 +176,10 @@ void libreport_add_item_to_config_liststore(gpointer cdialog, gpointer inf, gpoi
     log_notice("adding '%s' to workflow list\n", ci_get_screen_name(info));
     char *label;
     if (ci_get_screen_name(info) != NULL && ci_get_description(info) != NULL)
-        label = xasprintf("<b>%s</b>\n%s",ci_get_screen_name(info), ci_get_description(info));
+        label = libreport_xasprintf("<b>%s</b>\n%s",ci_get_screen_name(info), ci_get_description(info));
     else
         //if event has no xml description
-        label = xasprintf("<b>%s</b>\n%s", _("No description available"), ci_get_name(info));
+        label = libreport_xasprintf("<b>%s</b>\n%s", _("No description available"), ci_get_name(info));
 
     GtkTreeIter iter;
     gtk_list_store_append(list_store, &iter);

--- a/src/gtk-helpers/config_dialog.c
+++ b/src/gtk-helpers/config_dialog.c
@@ -411,7 +411,7 @@ void show_config_list_dialog(GtkWindow *parent)
     GHashTable *events = load_event_config_data();
     libreport_load_event_config_data_from_user_storage(events);
 
-    GHashTable *workflows = load_workflow_config_data(WORKFLOWS_DIR);
+    GHashTable *workflows = libreport_load_workflow_config_data(WORKFLOWS_DIR);
     load_workflow_config_data_from_user_storage(workflows);
     GtkListStore *workflows_store = add_workflows_to_liststore(workflows);
     g_hash_table_insert(confs, _("Workflows"), workflows_store);

--- a/src/gtk-helpers/config_dialog.c
+++ b/src/gtk-helpers/config_dialog.c
@@ -166,7 +166,7 @@ void dehydrate_config_dialog(GList *option_widgets)
         g_list_foreach(option_widgets, &save_value_from_widget, NULL);
 }
 
-void add_item_to_config_liststore(gpointer cdialog, gpointer inf, gpointer user_data)
+void libreport_add_item_to_config_liststore(gpointer cdialog, gpointer inf, gpointer user_data)
 {
     INITIALIZE_LIBREPORT();
 
@@ -409,7 +409,7 @@ void show_config_list_dialog(GtkWindow *parent)
 
     //TODO: free the hashtables somewhere!!
     GHashTable *events = load_event_config_data();
-    load_event_config_data_from_user_storage(events);
+    libreport_load_event_config_data_from_user_storage(events);
 
     GHashTable *workflows = load_workflow_config_data(WORKFLOWS_DIR);
     load_workflow_config_data_from_user_storage(workflows);

--- a/src/gtk-helpers/event_config_dialog.c
+++ b/src/gtk-helpers/event_config_dialog.c
@@ -46,7 +46,7 @@ static GtkWidget *gtk_label_new_justify_left(const gchar *label_str)
 
 GList *add_option_widget(GList *options, GtkWidget *widget, event_option_t *option)
 {
-    option_widget_t *ow = (option_widget_t *)xmalloc(sizeof(*ow));
+    option_widget_t *ow = (option_widget_t *)libreport_xmalloc(sizeof(*ow));
     ow->widget = widget;
     ow->option = option;
     options = g_list_prepend(options, ow);
@@ -62,7 +62,7 @@ static void on_show_pass_cb(GtkToggleButton *tb, gpointer user_data)
 
 static void on_show_pass_store_cb(GtkToggleButton *tb, gpointer user_data)
 {
-    set_user_setting("store_passwords", gtk_toggle_button_get_active(tb) ? "no" : "yes");
+    libreport_set_user_setting("store_passwords", gtk_toggle_button_get_active(tb) ? "no" : "yes");
 }
 
 static unsigned add_one_row_to_grid(GtkGrid *table)
@@ -76,7 +76,7 @@ static unsigned add_one_row_to_grid(GtkGrid *table)
 void save_data_from_event_config_dialog(GList *widgets, event_config_t *ec)
 {
     dehydrate_config_dialog(widgets);
-    const char *const store_passwords_s = get_user_setting("store_passwords");
+    const char *const store_passwords_s = libreport_get_user_setting("store_passwords");
     libreport_save_event_config_data_to_user_storage(ec_get_name(ec),
                                            ec,
                                            !(store_passwords_s && !strcmp(store_passwords_s, "no")));
@@ -103,10 +103,10 @@ static void add_option_to_table(gpointer data, gpointer user_data)
 
     char *option_label;
     if (option->eo_label != NULL)
-        option_label = xstrdup(option->eo_label);
+        option_label = libreport_xstrdup(option->eo_label);
     else
     {
-        option_label = xstrdup(option->eo_name ? option->eo_name : "");
+        option_label = libreport_xstrdup(option->eo_name ? option->eo_name : "");
         /* Replace '_' with ' ' */
         char *p = option_label - 1;
         while (*++p)
@@ -169,7 +169,7 @@ static void add_option_to_table(gpointer data, gpointer user_data)
                              /*width,height:*/ 2, 1);
             if (option->eo_value != NULL)
                 gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(option_input),
-                                    string_to_bool(option->eo_value));
+                                    libreport_string_to_bool(option->eo_value));
             g_option_list = add_option_widget(g_option_list, option_input, option);
             break;
 
@@ -264,7 +264,7 @@ config_dialog_t *libreport_create_event_config_dialog_content(event_config_t *ev
         gtk_grid_attach(GTK_GRID(option_table), pass_store_cb,
                 /*left,top:*/ 0, last_row,
                 /*width,height:*/ 1, 1);
-        const char *store_passwords = get_user_setting("store_passwords");
+        const char *store_passwords = libreport_get_user_setting("store_passwords");
         if (store_passwords && !strcmp(store_passwords, "no"))
             gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(pass_store_cb), 1);
         g_signal_connect(pass_store_cb, "toggled", G_CALLBACK(on_show_pass_store_cb), NULL);
@@ -330,7 +330,7 @@ config_dialog_t *create_event_config_dialog(const char *event_name, GtkWindow *p
 
     GtkWindow *parent_window = parent ? parent : g_event_list_window;
 
-    char *window_title = xasprintf("%s - Reporting Configuration",
+    char *window_title = libreport_xasprintf("%s - Reporting Configuration",
             ec_get_screen_name(event) ? ec_get_screen_name(event) : event_name);
 
     GtkWidget *dialog = gtk_dialog_new_with_buttons(

--- a/src/gtk-helpers/event_config_dialog.c
+++ b/src/gtk-helpers/event_config_dialog.c
@@ -77,7 +77,7 @@ void save_data_from_event_config_dialog(GList *widgets, event_config_t *ec)
 {
     dehydrate_config_dialog(widgets);
     const char *const store_passwords_s = get_user_setting("store_passwords");
-    save_event_config_data_to_user_storage(ec_get_name(ec),
+    libreport_save_event_config_data_to_user_storage(ec_get_name(ec),
                                            ec,
                                            !(store_passwords_s && !strcmp(store_passwords_s, "no")));
 }
@@ -153,7 +153,7 @@ static void add_option_to_table(gpointer data, gpointer user_data)
             gtk_widget_set_halign(label, GTK_ALIGN_START);
             gtk_widget_set_valign(label, GTK_ALIGN_START);
 
-            make_label_autowrap_on_resize(GTK_LABEL(label));
+            libreport_make_label_autowrap_on_resize(GTK_LABEL(label));
 
             last_row = add_one_row_to_grid(option_table);
             gtk_grid_attach(option_table, label,
@@ -188,7 +188,7 @@ static void add_option_to_table(gpointer data, gpointer user_data)
         gtk_widget_set_halign(label, GTK_ALIGN_START);
         gtk_widget_set_valign(label, GTK_ALIGN_START);
 
-        make_label_autowrap_on_resize(GTK_LABEL(label));
+        libreport_make_label_autowrap_on_resize(GTK_LABEL(label));
 
         last_row = add_one_row_to_grid(option_table);
         gtk_grid_attach(option_table, label,
@@ -222,7 +222,7 @@ static GtkWidget *create_event_config_grid()
     return option_table;
 }
 
-config_dialog_t *create_event_config_dialog_content(event_config_t *event, GtkWidget *content)
+config_dialog_t *libreport_create_event_config_dialog_content(event_config_t *event, GtkWidget *content)
 {
     INITIALIZE_LIBREPORT();
 
@@ -256,7 +256,7 @@ config_dialog_t *create_event_config_dialog_content(event_config_t *event, GtkWi
     /* if there is at least one password option, add checkbox to disable storing passwords */
     /* if the user storage is not available nothing is to be stored, so it is not necessary
      * to bother with an extra checkbox about storing passwords */
-    if (is_event_config_user_storage_available()
+    if (libreport_is_event_config_user_storage_available()
             && has_password_option)
     {
         unsigned last_row = add_one_row_to_grid(GTK_GRID(option_table));
@@ -290,7 +290,7 @@ config_dialog_t *create_event_config_dialog_content(event_config_t *event, GtkWi
     /* add warning if secrets service is not available showing the nagging dialog
      * is considered "too heavy UI" be designers
      */
-    if (!is_event_config_user_storage_available())
+    if (!libreport_is_event_config_user_storage_available())
     {
         GtkWidget *keyring_warn_lbl =
         gtk_label_new(
@@ -361,7 +361,7 @@ config_dialog_t *create_event_config_dialog(const char *event_name, GtkWindow *p
     }
 
     GtkWidget *content = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
-    config_dialog_t *cdialog = create_event_config_dialog_content(event, content);
+    config_dialog_t *cdialog = libreport_create_event_config_dialog_content(event, content);
     cdialog_set_widget(cdialog, dialog);
 
     return cdialog;
@@ -372,7 +372,7 @@ static void add_event_to_liststore(gpointer key, gpointer value, gpointer list_s
     config_item_info_t *info = ec_get_config_info((event_config_t *)value);
     config_dialog_t *cdialog = create_event_config_dialog(key, NULL);
 
-    add_item_to_config_liststore(cdialog, info, list_store);
+    libreport_add_item_to_config_liststore(cdialog, info, list_store);
 }
 
 GtkListStore *add_events_to_liststore(GHashTable *events)
@@ -383,7 +383,7 @@ GtkListStore *add_events_to_liststore(GHashTable *events)
     return list_store;
 }
 
-int show_event_config_dialog(const char *event_name, GtkWindow *parent)
+int libreport_show_event_config_dialog(const char *event_name, GtkWindow *parent)
 {
     INITIALIZE_LIBREPORT();
 

--- a/src/gtk-helpers/hyperlinks.c
+++ b/src/gtk-helpers/hyperlinks.c
@@ -54,7 +54,7 @@ GList *libreport_find_url_tokens(const char *line)
             /* need it for overlap correction */
             GList *prev = NULL;
             /* initialize it after overlap correction */
-            struct libreport_url_token *tok = xmalloc(sizeof(*tok));
+            struct libreport_url_token *tok = libreport_xmalloc(sizeof(*tok));
             if (anc)
             {   /* insert a new token before token following in the str*/
                 prev = g_list_previous(anc);
@@ -98,7 +98,7 @@ GList *libreport_find_url_tokens(const char *line)
 
 char *tag_url(const char *line, const char *prefix)
 {
-    struct strbuf *result = strbuf_new();
+    struct strbuf *result = libreport_strbuf_new();
     const char *last = line;
     GList *urls = libreport_find_url_tokens(line);
     for (GList *u = urls; u; u = g_list_next(u))
@@ -108,9 +108,9 @@ char *tag_url(const char *line, const char *prefix)
         /* add text between hyperlinks */
         if (last < t->start)
             /* TODO : add strbuf_append_strn() */
-            strbuf_append_strf(result, "%.*s", t->start - last, last);
+            libreport_strbuf_append_strf(result, "%.*s", t->start - last, last);
 
-        strbuf_append_strf(result, "%s<a href=\"%.*s\">%.*s</a>",
+        libreport_strbuf_append_strf(result, "%s<a href=\"%.*s\">%.*s</a>",
                                    prefix,
                                    t->len, t->start,
                                    t->len, t->start);
@@ -122,7 +122,7 @@ char *tag_url(const char *line, const char *prefix)
 
     /* add a text following the last link */
     if (last[0] != '\0')
-        strbuf_append_str(result, last);
+        libreport_strbuf_append_str(result, last);
 
-    return strbuf_free_nobuf(result);
+    return libreport_strbuf_free_nobuf(result);
 }

--- a/src/gtk-helpers/hyperlinks.c
+++ b/src/gtk-helpers/hyperlinks.c
@@ -29,7 +29,7 @@ static char *find_end(const char* url_start)
  *   http://google.com/
  *   https://gmail.com/
  */
-GList *find_url_tokens(const char *line)
+GList *libreport_find_url_tokens(const char *line)
 {
     static const char *const known_url_prefixes[] = {"http://", "https://", "ftp://", "file://", NULL};
     const char *const *pfx = known_url_prefixes;
@@ -46,7 +46,7 @@ GList *find_url_tokens(const char *line)
             GList *anc = tokens;
             for (; anc; anc = g_list_next(anc))
             {
-                const struct url_token *const t = (struct url_token *)anc->data;
+                const struct libreport_url_token *const t = (struct libreport_url_token *)anc->data;
                 if (t->start >= url_start)
                     break;
             }
@@ -54,12 +54,12 @@ GList *find_url_tokens(const char *line)
             /* need it for overlap correction */
             GList *prev = NULL;
             /* initialize it after overlap correction */
-            struct url_token *tok = xmalloc(sizeof(*tok));
+            struct libreport_url_token *tok = xmalloc(sizeof(*tok));
             if (anc)
             {   /* insert a new token before token following in the str*/
                 prev = g_list_previous(anc);
 
-                struct url_token *following = anc->data;
+                struct libreport_url_token *following = anc->data;
                 if (url_end > following->start)
                     /* correct ovrelaps with following token */
                     len -= url_end - following->start;
@@ -77,7 +77,7 @@ GList *find_url_tokens(const char *line)
 
             if (prev)
             {   /* correct overlaps with previous token */
-                struct url_token *previous = prev->data;
+                struct libreport_url_token *previous = prev->data;
                 const char *prev_end = previous->start + previous->len;
 
                 if (prev_end > url_start)
@@ -100,10 +100,10 @@ char *tag_url(const char *line, const char *prefix)
 {
     struct strbuf *result = strbuf_new();
     const char *last = line;
-    GList *urls = find_url_tokens(line);
+    GList *urls = libreport_find_url_tokens(line);
     for (GList *u = urls; u; u = g_list_next(u))
     {
-        const struct url_token *const t = (struct url_token *)u->data;
+        const struct libreport_url_token *const t = (struct libreport_url_token *)u->data;
 
         /* add text between hyperlinks */
         if (last < t->start)

--- a/src/gtk-helpers/internal_libreport_gtk.h
+++ b/src/gtk-helpers/internal_libreport_gtk.h
@@ -38,39 +38,29 @@ typedef struct
     GtkWidget *widget;
 } option_widget_t;
 
-#define make_label_autowrap_on_resize libreport_make_label_autowrap_on_resize
-void make_label_autowrap_on_resize(GtkLabel *label);
+void libreport_make_label_autowrap_on_resize(GtkLabel *label);
 
-#define show_events_list_dialog libreport_show_events_list_dialog
-void show_events_list_dialog(GtkWindow *parent);
+void libreport_show_events_list_dialog(GtkWindow *parent);
 
-#define is_event_config_user_storage_available libreport_is_event_config_user_storage_available
-bool is_event_config_user_storage_available();
+bool libreport_is_event_config_user_storage_available();
 
-#define load_single_event_config_data_from_user_storage libreport_load_single_event_config_data_from_user_storage
-void load_single_event_config_data_from_user_storage(event_config_t *config);
+void libreport_load_single_event_config_data_from_user_storage(event_config_t *config);
 
-#define load_event_config_data_from_user_storage libreport_load_event_config_data_from_user_storage
-void load_event_config_data_from_user_storage(GHashTable *event_config_list);
+void libreport_load_event_config_data_from_user_storage(GHashTable *event_config_list);
 
-#define save_event_config_data_to_user_storage libreport_save_event_config_data_to_user_storage
-void  save_event_config_data_to_user_storage(const char *event_name,
+void  libreport_save_event_config_data_to_user_storage(const char *event_name,
                                              const event_config_t *event_config,
                                              bool store_password);
 
-#define show_event_config_dialog libreport_show_event_config_dialog
-int show_event_config_dialog(const char *event_name, GtkWindow *parent);
+int libreport_show_event_config_dialog(const char *event_name, GtkWindow *parent);
 
-#define create_event_config_dialog_content libreport_create_event_config_dialog_content
-config_dialog_t *create_event_config_dialog_content(event_config_t *event, GtkWidget *content);
+config_dialog_t *libreport_create_event_config_dialog_content(event_config_t *event, GtkWidget *content);
 
-//#define show_workflow_list_dialog libreport_show_workflow_list_dialog
-//void show_workflow_list_dialog(GtkWindow *parent);
+//void libabrt_show_workflow_list_dialog(GtkWindow *parent);
 
 void save_data_from_event_config_dialog(GList *widgets, event_config_t *ec);
 
-#define add_item_to_config_liststore libreport_add_item_to_config_liststore
-void add_item_to_config_liststore(gpointer cdialog, gpointer inf, gpointer user_data);
+void libreport_add_item_to_config_liststore(gpointer cdialog, gpointer inf, gpointer user_data);
 
 GtkListStore *new_conf_liststore(void);
 void show_config_list_dialog(GtkWindow *parent);
@@ -88,25 +78,22 @@ void dehydrate_config_dialog(GList *option_widgets);
 
 char * tag_url(const char* line, const char* prefix);
 
-#define url_token libreport_url_token
-struct url_token
+struct libreport_url_token
 {
     const char *start;
     int len;
 };
 
-#define find_url_tokens libreport_find_url_tokens
-GList *find_url_tokens(const char *line);
+GList *libreport_find_url_tokens(const char *line);
 
 
-#define reload_text_to_text_view libreport_reload_text_to_text_view
-void reload_text_to_text_view(GtkTextView *tv, const char *text);
+void libreport_reload_text_to_text_view(GtkTextView *tv, const char *text);
 
 /* Ask dialogs */
 
 /*
  * This function is little bit confusing. Please, consider usage of
- * run_ask_yes_no_save_result_dialog()
+ * libreport_run_ask_yes_no_save_result_dialog()
  *
  * Runs a dialog with 'Yes'/'No' buttons and 'Don't ask me again' check box and
  * waits until the dialog is closed. This variant of dialog allows user to
@@ -122,8 +109,7 @@ void reload_text_to_text_view(GtkTextView *tv, const char *text);
  * @param parent Transient parent or NULL
  * @returns Non 0 if the answer is "Yes"; otherwise 0
  */
-#define run_ask_yes_no_yesforever_dialog libreport_run_ask_yes_no_yesforever_dialog
-int run_ask_yes_no_yesforever_dialog(const char *key, const char *message, GtkWindow *parent);
+int libreport_run_ask_yes_no_yesforever_dialog(const char *key, const char *message, GtkWindow *parent);
 
 /*
  * Runs a dialog with 'Yes'/'No' buttons and 'Don't ask me again' check box and
@@ -140,8 +126,7 @@ int run_ask_yes_no_yesforever_dialog(const char *key, const char *message, GtkWi
  * @param parent Transient parent or NULL
  * @returns Non 0 if the answer is "Yes"; otherwise 0
  */
-#define run_ask_yes_no_save_result_dialog libreport_run_ask_yes_no_save_result_dialog
-int run_ask_yes_no_save_result_dialog(const char *key, const char *message, GtkWindow *parent);
+int libreport_run_ask_yes_no_save_result_dialog(const char *key, const char *message, GtkWindow *parent);
 
 #ifdef __cplusplus
 }

--- a/src/gtk-helpers/internal_libreport_gtk.h
+++ b/src/gtk-helpers/internal_libreport_gtk.h
@@ -100,8 +100,8 @@ void libreport_reload_text_to_text_view(GtkTextView *tv, const char *text);
  * click only 'Yes' button if the check box is checked and stores "no" string
  * in user settings if the check box is checked.
  *
- * Uses libreport's user settings. Don't forget to call load_user_settings()
- * before the first call of this funcion and call save_user_settings() after
+ * Uses libreport's user settings. Don't forget to call libreport_load_user_settings()
+ * before the first call of this funcion and call libreport_save_user_settings() after
  * the last call of this function.
  *
  * @param key Key under which the response is stored. Not NULL
@@ -117,8 +117,8 @@ int libreport_run_ask_yes_no_yesforever_dialog(const char *key, const char *mess
  * click both of buttons if the check box is checked and stores the answer in
  * user settings if the check box is checked.
  *
- * Uses libreport's user settings. Don't forget to call load_user_settings()
- * before the first call of this funcion and call save_user_settings() after
+ * Uses libreport's user settings. Don't forget to call libreport_load_user_settings()
+ * before the first call of this funcion and call libreport_save_user_settings() after
  * the last call of this function.
  *
  * @param key Key under which the response is stored. Not NULL

--- a/src/gtk-helpers/problem_details_widget.c
+++ b/src/gtk-helpers/problem_details_widget.c
@@ -195,7 +195,7 @@ problem_details_widget_add_binary(ProblemDetailsWidget *self, const char *label,
     }
 
     gchar *size = g_format_size_full((long long)statbuf.st_size, G_FORMAT_SIZE_IEC_UNITS);
-    char *msg = xasprintf(_("$DATA_DIRECTORY/%s (binary file, %s)"), label, size);
+    char *msg = libreport_xasprintf(_("$DATA_DIRECTORY/%s (binary file, %s)"), label, size);
     problem_details_widget_add_single_line(self, label, msg);
     free(msg);
     g_free(size);
@@ -239,7 +239,7 @@ static void
 problem_data_entry_to_grid_row_one_line(const char *item_name, problem_item *item, ProblemDetailsWidget *self)
 {
     if (((item->flags & CD_FLAG_TXT) && (strchr(item->content, '\n') == NULL))
-             && !is_in_string_list(item_name, items_auto_blacklist))
+             && !libreport_is_in_string_list(item_name, items_auto_blacklist))
         problem_details_widget_add_single_line(self, item_name, item->content);
 }
 
@@ -247,7 +247,7 @@ static void
 problem_data_entry_to_grid_row_multi_line(const char *item_name, problem_item *item, ProblemDetailsWidget *self)
 {
     if (((item->flags & CD_FLAG_TXT) && (strchr(item->content, '\n') != NULL))
-            && !is_in_string_list(item_name, items_auto_blacklist))
+            && !libreport_is_in_string_list(item_name, items_auto_blacklist))
         problem_details_widget_add_multi_line(self, item_name, item->content);
 }
 
@@ -255,7 +255,7 @@ static void
 problem_data_entry_to_grid_row_binary(const char *item_name, problem_item *item, ProblemDetailsWidget *self)
 {
     if ((item->flags & CD_FLAG_BIN)
-            && !is_in_string_list(item_name, items_auto_blacklist))
+            && !libreport_is_in_string_list(item_name, items_auto_blacklist))
         problem_details_widget_add_binary(self, item_name, item->content);
 }
 
@@ -305,11 +305,11 @@ problem_details_widget_populate(ProblemDetailsWidget *self)
 
         char *line = NULL;
         if (uid && username)
-            line = xasprintf("%s (%s)", username, uid);
+            line = libreport_xasprintf("%s (%s)", username, uid);
         else if (!uid && !username)
-            line = xstrdup("unknown user");
+            line = libreport_xstrdup("unknown user");
         else
-            line = xasprintf("%s", uid ? uid : username);
+            line = libreport_xasprintf("%s", uid ? uid : username);
 
         problem_details_widget_add_single_line(self, "user", line);
         free(line);
@@ -327,19 +327,19 @@ problem_details_widget_populate(ProblemDetailsWidget *self)
         {
             if (strcmp(type, analyzer) != 0)
             {
-                label = xstrdup("type/analyzer");
-                line = xasprintf("%s/%s", type, analyzer);
+                label = libreport_xstrdup("type/analyzer");
+                line = libreport_xasprintf("%s/%s", type, analyzer);
             }
             else
             {
-                label = xstrdup("type");
-                line = xstrdup(type);
+                label = libreport_xstrdup("type");
+                line = libreport_xstrdup(type);
             }
         }
         else
         {
-            label = xstrdup(type ? "type" : "anlyzer");
-            line = xstrdup(type ? type : analyzer);
+            label = libreport_xstrdup(type ? "type" : "anlyzer");
+            line = libreport_xstrdup(type ? type : analyzer);
         }
 
         problem_details_widget_add_single_line(self, label, line);

--- a/src/gtk-helpers/problem_details_widget.c
+++ b/src/gtk-helpers/problem_details_widget.c
@@ -155,7 +155,7 @@ problem_details_widget_add_multi_line(ProblemDetailsWidget *self, const char *na
             || strcmp(name, FILENAME_REASON) == 0)
         gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(value), GTK_WRAP_WORD);
 
-    reload_text_to_text_view(GTK_TEXT_VIEW(value), content);
+    libreport_reload_text_to_text_view(GTK_TEXT_VIEW(value), content);
 #else
     GtkWidget *value = gtk_label_new(content);
     gtk_widget_set_halign(value, GTK_ALIGN_START);

--- a/src/gtk-helpers/search_item.c
+++ b/src/gtk-helpers/search_item.c
@@ -28,7 +28,7 @@ search_item_t *sitem_new(int page,
                          GtkTextIter end
                          )
 {
-    search_item_t *word = (search_item_t *)xmalloc(sizeof(search_item_t));
+    search_item_t *word = (search_item_t *)libreport_xmalloc(sizeof(search_item_t));
     word->start = start;
     word->end = end;
     word->buffer = buffer;

--- a/src/gtk-helpers/secrets.c
+++ b/src/gtk-helpers/secrets.c
@@ -1399,7 +1399,7 @@ static void load_event_config(gpointer key, gpointer value, gpointer user_data)
     event_config_t *const ec = (event_config_t *)value;
     struct secrets_object *const collection = (struct secrets_object *)user_data;
 
-    if (is_event_config_user_storage_available())
+    if (libreport_is_event_config_user_storage_available())
         load_settings(g_session_proxy, collection, event_name, ec);
 }
 
@@ -1491,7 +1491,7 @@ static void save_event_config(const char *event_name,
 /* Public interface                                                           */
 /******************************************************************************/
 
-bool is_event_config_user_storage_available()
+bool libreport_is_event_config_user_storage_available()
 {
     INITIALIZE_LIBREPORT();
 
@@ -1507,7 +1507,7 @@ bool is_event_config_user_storage_available()
  * @param name Event name
  * @param config Event config
  */
-void load_single_event_config_data_from_user_storage(event_config_t *config)
+void libreport_load_single_event_config_data_from_user_storage(event_config_t *config)
 {
     INITIALIZE_LIBREPORT();
 
@@ -1519,7 +1519,7 @@ void load_single_event_config_data_from_user_storage(event_config_t *config)
 
     g_hash_table_insert(tmp, xstrdup(ec_get_name(config)), config);
 
-    load_event_config_data_from_user_storage(tmp);
+    libreport_load_event_config_data_from_user_storage(tmp);
 
     g_hash_table_destroy(tmp);
 
@@ -1531,11 +1531,11 @@ void load_single_event_config_data_from_user_storage(event_config_t *config)
  *
  * @param event_config_list Events configs
  */
-void load_event_config_data_from_user_storage(GHashTable *event_config_list)
+void libreport_load_event_config_data_from_user_storage(GHashTable *event_config_list)
 {
     INITIALIZE_LIBREPORT();
 
-    if (is_event_config_user_storage_available())
+    if (libreport_is_event_config_user_storage_available())
     {
         bool dismissed = false;
         struct secrets_object *collection = NULL;
@@ -1591,13 +1591,13 @@ void load_event_config_data_from_user_storage(GHashTable *event_config_list)
  * @param event_config Event data
  * @param store_passwords If TRUE stores options with passwords, otherwise skips them
  */
-void save_event_config_data_to_user_storage(const char *event_name,
+void libreport_save_event_config_data_to_user_storage(const char *event_name,
                                             const event_config_t *event_config,
                                             bool store_passwords)
 {
     INITIALIZE_LIBREPORT();
 
-    if (is_event_config_user_storage_available())
+    if (libreport_is_event_config_user_storage_available())
         save_event_config(event_name, event_config->options, store_passwords);
     else
     {

--- a/src/gtk-helpers/secrets.c
+++ b/src/gtk-helpers/secrets.c
@@ -220,7 +220,7 @@ static bool is_dbus_remote_error(GError *error, const char *type)
 
 static struct secrets_object *secrets_object_new_from_proxy(GDBusProxy *proxy)
 {
-    struct secrets_object *obj = xzalloc(sizeof(*obj));
+    struct secrets_object *obj = libreport_xzalloc(sizeof(*obj));
     obj->proxy = proxy;
     obj->interface_name = g_dbus_proxy_get_interface_name(proxy);
 
@@ -1259,7 +1259,7 @@ static void load_event_options_from_item(GDBusProxy *session,
             if (option)
             {
                 free(option->eo_value);
-                option->eo_value = xstrdup(value);
+                option->eo_value = libreport_xstrdup(value);
                 log_info("loaded event option : '%s' => '%s'", name, option->eo_value);
             }
         }
@@ -1333,7 +1333,7 @@ static void load_event_options_from_item(GDBusProxy *session,
             }
             nelems -= sz;
 
-            char *name = xstrdup(data);
+            char *name = libreport_xstrdup(data);
             char *value = strchr(name, SECRETS_OPTION_VALUE_DELIMITER);
             if (!value)
             {
@@ -1347,7 +1347,7 @@ static void load_event_options_from_item(GDBusProxy *session,
             if (option)
             {
                 free(option->eo_value);
-                option->eo_value = xstrdup(value);
+                option->eo_value = libreport_xstrdup(value);
                 log_info("loaded event option : '%s' => '%s'", name, option->eo_value);
             }
 
@@ -1517,7 +1517,7 @@ void libreport_load_single_event_config_data_from_user_storage(event_config_t *c
                 /*key_destroy_func:*/ g_free,
                 /*value_destroy_func:*/ NULL);
 
-    g_hash_table_insert(tmp, xstrdup(ec_get_name(config)), config);
+    g_hash_table_insert(tmp, libreport_xstrdup(ec_get_name(config)), config);
 
     libreport_load_event_config_data_from_user_storage(tmp);
 

--- a/src/gtk-helpers/utils.c
+++ b/src/gtk-helpers/utils.c
@@ -1,6 +1,6 @@
 #include "internal_libreport_gtk.h"
 
-void reload_text_to_text_view(GtkTextView *tv, const char *text)
+void libreport_reload_text_to_text_view(GtkTextView *tv, const char *text)
 {
     GtkTextBuffer *tb = gtk_text_view_get_buffer(tv);
     GtkTextIter beg_iter, end_iter;

--- a/src/gtk-helpers/workflow_config_dialog.c
+++ b/src/gtk-helpers/workflow_config_dialog.c
@@ -80,7 +80,7 @@ config_dialog_t *create_workflow_config_dialog(const char *workflow_name, GtkWin
 
     GtkWindow *parent_window = parent ? parent : g_parent_window;
 
-    char *window_title = xasprintf("%s - Reporting Configuration",
+    char *window_title = libreport_xasprintf("%s - Reporting Configuration",
             wf_get_screen_name(workflow) ? wf_get_screen_name(workflow) : workflow_name);
 
     GtkWidget *dialog = gtk_dialog_new_with_buttons(

--- a/src/gtk-helpers/workflow_config_dialog.c
+++ b/src/gtk-helpers/workflow_config_dialog.c
@@ -43,7 +43,7 @@ static void create_event_config_dialog_content_cb(event_config_t *ec, gpointer n
     gtk_widget_set_margin_top(content, 5);
     gtk_widget_set_margin_bottom(content, 10);
 
-    config_dialog_t *cdialog = create_event_config_dialog_content(ec, (GtkWidget *)content);
+    config_dialog_t *cdialog = libreport_create_event_config_dialog_content(ec, (GtkWidget *)content);
 
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook), content, ev_lbl);
 
@@ -137,7 +137,7 @@ static void add_workflow_to_liststore(gpointer key, gpointer value, gpointer use
 {
     config_item_info_t *info = workflow_get_config_info((workflow_t *)value);
     config_dialog_t *cdialog = create_workflow_config_dialog(key, g_parent_window);
-    add_item_to_config_liststore(cdialog, info, user_data);
+    libreport_add_item_to_config_liststore(cdialog, info, user_data);
 }
 
 GtkListStore *add_workflows_to_liststore(GHashTable *workflows)
@@ -150,7 +150,7 @@ GtkListStore *add_workflows_to_liststore(GHashTable *workflows)
 
 static void load_single_event_config_foreach(event_config_t *ec, gpointer user_data)
 {
-    load_single_event_config_data_from_user_storage(ec);
+    libreport_load_single_event_config_data_from_user_storage(ec);
 }
 
 static void load_events_foreach_workflow(const char *name, workflow_t *workflow, gpointer user_data)

--- a/src/gui-wizard-gtk/main.c
+++ b/src/gui-wizard-gtk/main.c
@@ -35,7 +35,7 @@ void problem_data_reload_from_dump_dir(void)
 
     struct dump_dir *dd = dd_opendir(g_dump_dir_name, DD_OPEN_READONLY);
     if (!dd)
-        xfunc_die(); /* dd_opendir already logged error msg */
+        libreport_xfunc_die(); /* dd_opendir already logged error msg */
 
     problem_data_t *new_cd = create_problem_data_from_dump_dir(dd);
     problem_data_add_text_noteditable(new_cd, CD_DUMPDIR, g_dump_dir_name);
@@ -164,29 +164,29 @@ int main(int argc, char **argv)
     };
     /* Keep enum above and order of options below in sync! */
     struct options program_options[] = {
-        OPT__VERBOSE(&g_verbose),
+        OPT__VERBOSE(&libreport_g_verbose),
         OPT_BOOL(  'p', NULL, NULL,                           _("Add program names to log")),
         OPT_BOOL(  'd', "delete", NULL,                       _("Remove PROBLEM_DIR after reporting")),
         OPT_LIST(  'e', "event", &user_event_list, "EVENT",   _("Run only these events")),
         OPT_END()
     };
-    unsigned opts = parse_opts(argc, argv, program_options, program_usage_string);
+    unsigned opts = libreport_parse_opts(argc, argv, program_options, program_usage_string);
     argv += optind;
     if (!argv[0] || argv[1]) /* zero or >1 arguments */
-        show_usage_and_die(program_usage_string, program_options);
+        libreport_show_usage_and_die(program_usage_string, program_options);
 
     /* Copy the list of event names and expand wildcards, if any. */
     g_auto_event_list = expand_event_chain_wildcards(user_event_list);
 
-    export_abrt_envvars(opts & OPT_p);
+    libreport_export_abrt_envvars(opts & OPT_p);
 
-    g_dump_dir_name = xstrdup(argv[0]);
+    g_dump_dir_name = libreport_xstrdup(argv[0]);
 
     /* load /etc/abrt/events/foo.{conf,xml} stuff
        and $XDG_CACHE_HOME/abrt/events/foo.conf */
     g_event_config_list = load_event_config_data();
     libreport_load_event_config_data_from_user_storage(g_event_config_list);
-    load_user_settings("report-gtk");
+    libreport_load_user_settings("report-gtk");
 
     load_workflow_config_data(WORKFLOWS_DIR);
 
@@ -212,7 +212,7 @@ int main(int argc, char **argv)
 
     problem_data_reload_from_dump_dir();
 
-    g_custom_logger = &show_error_as_msgbox;
+    libreport_g_custom_logger = &show_error_as_msgbox;
     GtkApplication *app = gtk_application_new("org.freedesktop.libreport.report", G_APPLICATION_NON_UNIQUE);
     g_signal_connect(app, "activate", G_CALLBACK(activate_wizard), NULL);
     g_signal_connect(app, "startup",  G_CALLBACK(startup_wizard),  NULL);
@@ -224,7 +224,7 @@ int main(int argc, char **argv)
     if (opts & OPT_d)
         delete_dump_dir_possibly_using_abrtd(g_dump_dir_name);
 
-    save_user_settings();
+    libreport_save_user_settings();
 
     return 0;
 }

--- a/src/gui-wizard-gtk/main.c
+++ b/src/gui-wizard-gtk/main.c
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
     /* load /etc/abrt/events/foo.{conf,xml} stuff
        and $XDG_CACHE_HOME/abrt/events/foo.conf */
     g_event_config_list = load_event_config_data();
-    load_event_config_data_from_user_storage(g_event_config_list);
+    libreport_load_event_config_data_from_user_storage(g_event_config_list);
     load_user_settings("report-gtk");
 
     load_workflow_config_data(WORKFLOWS_DIR);

--- a/src/gui-wizard-gtk/main.c
+++ b/src/gui-wizard-gtk/main.c
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
     libreport_load_event_config_data_from_user_storage(g_event_config_list);
     libreport_load_user_settings("report-gtk");
 
-    load_workflow_config_data(WORKFLOWS_DIR);
+    libreport_load_workflow_config_data(WORKFLOWS_DIR);
 
     /* list of workflows applicable to the currently processed problem */
     GList *possible_names = list_possible_events_glist(g_dump_dir_name, "workflow");

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -1045,7 +1045,7 @@ static void update_ls_details_checkboxes(const char *event_name)
     char *name;
     struct problem_item *item;
     g_hash_table_iter_init(&iter, g_cd);
-    string_vector_ptr_t global_exclude = get_global_always_excluded_elements();
+    string_vector_ptr_t global_exclude = libreport_get_global_always_excluded_elements();
     while (g_hash_table_iter_next(&iter, (void**)&name, (void**)&item))
     {
         /* Decide whether item is allowed, required, and what's the default */
@@ -1640,7 +1640,7 @@ static gboolean consume_cmd_output(GIOChannel *source, GIOCondition condition, g
             dd_sanitize_mode_and_owner(dd);
     }
 
-    if (retval == 0 && get_global_stop_on_not_reportable())
+    if (retval == 0 && libreport_get_global_stop_on_not_reportable())
     {
         /* Check whether NOT_REPORTABLE element appeared. If it did, we'll stop
          * even if exit code is "success".
@@ -1887,7 +1887,7 @@ static void add_warning(const char   *warning,
 
 static void on_sensitive_ticket_clicked_cb(GtkWidget *button, gpointer user_data)
 {
-    set_global_create_private_ticket(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)), /*transient*/0);
+    libreport_set_global_create_private_ticket(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)), /*transient*/0);
 }
 
 static void on_privacy_info_btn(GtkWidget *button, gpointer user_data)
@@ -2426,7 +2426,7 @@ static void on_page_prepare(GtkNotebook *assistant, GtkWidget *page, gpointer us
 
     if (pages[PAGENO_SUMMARY].page_widget == page)
     {
-        if (get_global_create_private_ticket())
+        if (libreport_get_global_create_private_ticket())
             private_ticket_creation_warning(  PRIV_WARN_SHOW_BTN
                                             | PRIV_WARN_BTN_CHECKED
                                             | PRIV_WARN_HIDE_MSG);
@@ -2667,7 +2667,7 @@ static gint select_next_page_no(gint current_page_no)
                             problem_data_get_content_or_NULL(g_cd, FILENAME_NOT_REPORTABLE)
             );
 
-            if (get_global_stop_on_not_reportable())
+            if (libreport_get_global_stop_on_not_reportable())
             {
                 free(event);
                 cancel_processing(g_lbl_event_log, msg, TERMINATE_NOFLAGS);

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -1615,7 +1615,7 @@ static gboolean consume_cmd_output(GIOChannel *source, GIOCondition condition, g
     /* If program failed, or if it finished successfully without saying anything... */
     if (retval != 0 || evd->event_log_state == LOGSTATE_FIRSTLINE)
     {
-        g_autofree char *msg = exit_status_as_string(evd->event_name,
+        g_autofree char *msg = libreport_exit_status_as_string(evd->event_name,
                 run_state->process_status);
         if (retval != 0)
         {

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -304,7 +304,7 @@ static void wrap_fixer(GtkWidget *widget, gpointer data_unused)
           && (gtk_widget_get_margin_top(widget) == 0)
           && (gtk_widget_get_margin_bottom(widget) == 0)
         ) {
-            make_label_autowrap_on_resize(label);
+            libreport_make_label_autowrap_on_resize(label);
             return;
         }
     }
@@ -340,7 +340,7 @@ static bool ask_continue_before_steal(const char *base_dir, const char *dump_dir
             _("Need writable directory, but '%s' is not writable."
               " Move it to '%s' and operate on the moved data?"),
             dump_dir, base_dir);
-    const bool response = run_ask_yes_no_yesforever_dialog("ask_steal_dir", msg, GTK_WINDOW(g_wnd_assistant));
+    const bool response = libreport_run_ask_yes_no_yesforever_dialog("ask_steal_dir", msg, GTK_WINDOW(g_wnd_assistant));
 
     return response;
 }
@@ -384,7 +384,7 @@ static void load_text_to_text_view(GtkTextView *tv, const char *name)
     /* gtk_text_buffer_set_text(tb, (str ? str : ""), -1);*/
     /* Start torturing ourself instead: */
 
-    reload_text_to_text_view(tv, str);
+    libreport_reload_text_to_text_view(tv, str);
 }
 
 static gchar *get_malloced_string_from_text_view(GtkTextView *tv)
@@ -452,10 +452,10 @@ static void append_to_textview(GtkTextView *tv, const char *str)
     gtk_text_buffer_get_end_iter(tb, &text_iter);
 
     const char *last = str;
-    GList *urls = find_url_tokens(str);
+    GList *urls = libreport_find_url_tokens(str);
     for (GList *u = urls; u; u = g_list_next(u))
     {
-        const struct url_token *const t = (struct url_token *)u->data;
+        const struct libreport_url_token *const t = (struct libreport_url_token *)u->data;
         if (last < t->start)
             gtk_text_buffer_insert(tb, &text_iter, last, t->start - last);
 
@@ -846,7 +846,7 @@ static void check_event_config(const char *event_name)
     if (errors != NULL)
     {
         g_list_free_full(errors, (GDestroyNotify)free_invalid_options);
-        show_event_config_dialog(event_name, GTK_WINDOW(g_top_most_window));
+        libreport_show_event_config_dialog(event_name, GTK_WINDOW(g_top_most_window));
         update_private_ticket_creation_warning_for_selected_event();
     }
 }
@@ -1514,14 +1514,14 @@ static int run_event_gtk_ask_yes_no(const char *msg, void *args)
 
 static int run_event_gtk_ask_yes_no_yesforever(const char *key, const char *msg, void *args)
 {
-    const int ret = run_ask_yes_no_yesforever_dialog(key, msg, GTK_WINDOW(g_wnd_assistant));
+    const int ret = libreport_run_ask_yes_no_yesforever_dialog(key, msg, GTK_WINDOW(g_wnd_assistant));
     log_request_response_communication(msg, ret ? "YES" : "NO", (struct analyze_event_data *)args);
     return ret;
 }
 
 static int run_event_gtk_ask_yes_no_save_result(const char *key, const char *msg, void *args)
 {
-    const int ret = run_ask_yes_no_save_result_dialog(key, msg, GTK_WINDOW(g_wnd_assistant));
+    const int ret = libreport_run_ask_yes_no_save_result_dialog(key, msg, GTK_WINDOW(g_wnd_assistant));
     log_request_response_communication(msg, ret ? "YES" : "NO", (struct analyze_event_data *)args);
     return ret;
 }
@@ -1895,7 +1895,7 @@ static void on_privacy_info_btn(GtkWidget *button, gpointer user_data)
     if (g_event_selected == NULL)
         return;
 
-    show_event_config_dialog(g_event_selected, GTK_WINDOW(g_top_most_window));
+    libreport_show_event_config_dialog(g_event_selected, GTK_WINDOW(g_top_most_window));
 }
 
 static void private_ticket_creation_warning(int flags)
@@ -2524,7 +2524,7 @@ static void set_auto_event_chain(GtkButton *button, gpointer user_data)
     while(wf_event_list)
     {
         g_auto_event_list = g_list_append(g_auto_event_list, xstrdup(ec_get_name(wf_event_list->data)));
-        load_single_event_config_data_from_user_storage((event_config_t *)wf_event_list->data);
+        libreport_load_single_event_config_data_from_user_storage((event_config_t *)wf_event_list->data);
 
         wf_event_list = g_list_next(wf_event_list);
     }
@@ -2619,7 +2619,7 @@ static bool get_sensitive_data_permission(const char *event_name)
             _("Event '%s' requires permission to send possibly sensitive data.\n"
               "Do you want to continue?"),
             event_name);
-    const bool response = run_ask_yes_no_yesforever_dialog("ask_send_sensitive_data",
+    const bool response = libreport_run_ask_yes_no_yesforever_dialog("ask_send_sensitive_data",
             msg, GTK_WINDOW(g_wnd_assistant));
 
     return response;

--- a/src/include/client.h
+++ b/src/include/client.h
@@ -86,11 +86,9 @@
 extern "C" {
 #endif
 
-#define set_echo libreport_set_echo
-int set_echo(int enable);
+int libreport_set_echo(int enable);
 
-#define ask_yes_no libreport_ask_yes_no
-int ask_yes_no(const char *question);
+int libreport_ask_yes_no(const char *question);
 
 /**
  * Prints out the question and if the reply is 'yesforever' temporarily stores
@@ -102,40 +100,34 @@ int ask_yes_no(const char *question);
  * by applications, but are not required to do so.
  *
  * The function uses the global libreport application configuration. If the
- * ask_yes_no_yesforever() function is called from a library function, the
+ * libreport_ask_yes_no_yesforever() function is called from a library function, the
  * configuration key will be stored in the configuration of the application
  * which called that library function.
  *
  * In the case you are developing a front-end application, you have to call the
- * load_user_setting() function before calling the ask_yes_no_yesforever()
+ * load_user_setting() function before calling the libreport_ask_yes_no_yesforever()
  * function and call the save_user_settings() function after calling the
- * ask_yes_no_yesforever() function to make the 'yesforever' reply persistent.
+ * libreport_ask_yes_no_yesforever() function to make the 'yesforever' reply persistent.
  *
  * @param key The key under which the yes forever answer is stored
  * @param question The asked question
  * @return 0 if user's answer is 'no', otherwise non 0 value
  */
-#define ask_yes_no_yesforever libreport_ask_yes_no_yesforever
-int ask_yes_no_yesforever(const char *key, const char *question);
+int libreport_ask_yes_no_yesforever(const char *key, const char *question);
 
 /**
- * The function behaves exactly like the ask_yes_no_yesforever() function, but
+ * The function behaves exactly like the libreport_ask_yes_no_yesforever() function, but
  * allows to remember both "Yes" and "No" replies.
  */
-#define ask_yes_no_save_resutl libreport_ask_yes_no_save_result
-int ask_yes_no_save_result(const char *key, const char *question);
+int libreport_ask_yes_no_save_result(const char *key, const char *question);
 
-#define ask libreport_ask
-char *ask(const char *question);
+char *libreport_ask(const char *question);
 
-#define ask_password libreport_ask_password
-char *ask_password(const char *question);
+char *libreport_ask_password(const char *question);
 
-#define alert libreport_alert
-void alert(const char *message);
+void libreport_alert(const char *message);
 
-#define client_log libreport_client_log
-void client_log(const char *message);
+void libreport_client_log(const char *message);
 
 #ifdef __cplusplus
 }

--- a/src/include/client.h
+++ b/src/include/client.h
@@ -106,7 +106,7 @@ int libreport_ask_yes_no(const char *question);
  *
  * In the case you are developing a front-end application, you have to call the
  * load_user_setting() function before calling the libreport_ask_yes_no_yesforever()
- * function and call the save_user_settings() function after calling the
+ * function and call the libreport_save_user_settings() function after calling the
  * libreport_ask_yes_no_yesforever() function to make the 'yesforever' reply persistent.
  *
  * @param key The key under which the yes forever answer is stored

--- a/src/include/dump_dir.h
+++ b/src/include/dump_dir.h
@@ -480,7 +480,7 @@ struct dump_dir *create_dump_dir_ext(const char *base_dir_name, const char *type
  *   - '.tag.gz' (note: the implementation uses child gzip process)
  *
  * The archive will include only the files that are not in the exclude_elements
- * list. See get_global_always_excluded_elements().
+ * list. See libreport_get_global_always_excluded_elements().
  *
  * The argument "flags" is currently unused.
  *

--- a/src/include/dump_dir.h
+++ b/src/include/dump_dir.h
@@ -377,38 +377,38 @@ time_t dd_get_last_occurrence(struct dump_dir *dd);
  * @param line The appended line
  * @return 1 if the line was added at the end of the reported_to; otherwise 0.
  */
-int add_reported_to_data(char **reported_to, const char *line);
+int libreport_add_reported_to_data(char **reported_to, const char *line);
 
 /* Appends a new unique entry to the list of report results
  *
  * result->label must be non-empty string which does not contain ':' character.
  *
  * The function converts the result to a valid reported_to line and calls
- * add_reported_to_data().
+ * libreport_add_reported_to_data().
  *
  * @param reported_to The data
  * @param result The appended entry
  * @return -EINVAL if result->label is invalid; otherwise return value of
- * add_reported_to_data
+ * libreport_add_reported_to_data
  */
-int add_reported_to_entry_data(char **reported_to, struct report_result *result);
+int libreport_add_reported_to_entry_data(char **reported_to, struct report_result *result);
 
-/* This is a wrapper of add_reported_to_data which accepts 'struct dump_dir *'
+/* This is a wrapper of libreport_add_reported_to_data which accepts 'struct dump_dir *'
  * in the first argument instead of 'char **'. The added line is stored in
  * 'reported_to' dump directory file.
  */
-void add_reported_to(struct dump_dir *dd, const char *line);
+void libreport_add_reported_to(struct dump_dir *dd, const char *line);
 
-/* This is a wrapper of add_reported_to_entry_data which accepts 'struct
+/* This is a wrapper of libreport_add_reported_to_entry_data which accepts 'struct
  * dump_dir *' in the first argument instead of 'char **'. The added entry is
  * stored in 'reported_to' dump directory file.
  */
-void add_reported_to_entry(struct dump_dir *dd, struct report_result *result);
+void libreport_add_reported_to_entry(struct dump_dir *dd, struct report_result *result);
 
-report_result_t *find_in_reported_to_data(const char *reported_to, const char *report_label);
-report_result_t *find_in_reported_to(struct dump_dir *dd, const char *report_label);
-GList *read_entire_reported_to_data(const char* reported_to);
-GList *read_entire_reported_to(struct dump_dir *dd);
+report_result_t *libreport_find_in_reported_to_data(const char *reported_to, const char *report_label);
+report_result_t *libreport_find_in_reported_to(struct dump_dir *dd, const char *report_label);
+GList *libreport_read_entire_reported_to_data(const char* reported_to);
+GList *libreport_read_entire_reported_to(struct dump_dir *dd);
 
 
 void delete_dump_dir(const char *dirname);

--- a/src/include/dump_dir.h
+++ b/src/include/dump_dir.h
@@ -377,7 +377,6 @@ time_t dd_get_last_occurrence(struct dump_dir *dd);
  * @param line The appended line
  * @return 1 if the line was added at the end of the reported_to; otherwise 0.
  */
-#define add_reported_to_data libreport_add_reported_to_data
 int add_reported_to_data(char **reported_to, const char *line);
 
 /* Appends a new unique entry to the list of report results
@@ -392,30 +391,23 @@ int add_reported_to_data(char **reported_to, const char *line);
  * @return -EINVAL if result->label is invalid; otherwise return value of
  * add_reported_to_data
  */
-#define add_reported_to_entry_data libreport_add_reported_to_entry_data
 int add_reported_to_entry_data(char **reported_to, struct report_result *result);
 
 /* This is a wrapper of add_reported_to_data which accepts 'struct dump_dir *'
  * in the first argument instead of 'char **'. The added line is stored in
  * 'reported_to' dump directory file.
  */
-#define add_reported_to libreport_add_reported_to
 void add_reported_to(struct dump_dir *dd, const char *line);
 
 /* This is a wrapper of add_reported_to_entry_data which accepts 'struct
  * dump_dir *' in the first argument instead of 'char **'. The added entry is
  * stored in 'reported_to' dump directory file.
  */
-#define add_reported_to_entry libreport_add_reported_to_entry
 void add_reported_to_entry(struct dump_dir *dd, struct report_result *result);
 
-#define find_in_reported_to_data libreport_find_in_reported_to_data
 report_result_t *find_in_reported_to_data(const char *reported_to, const char *report_label);
-#define find_in_reported_to libreport_find_in_reported_to
 report_result_t *find_in_reported_to(struct dump_dir *dd, const char *report_label);
-#define read_entire_reported_to_data libreport_read_entire_reported_to_data
 GList *read_entire_reported_to_data(const char* reported_to);
-#define read_entire_reported_to libreport_read_entire_reported_to
 GList *read_entire_reported_to(struct dump_dir *dd);
 
 

--- a/src/include/global_configuration.h
+++ b/src/include/global_configuration.h
@@ -26,20 +26,15 @@
 extern "C" {
 #endif
 
-#define load_global_configuration libreport_load_global_configuration
-bool load_global_configuration(void);
+bool libreport_load_global_configuration(void);
 
-#define load_global_configuration_from_dirs libreport_load_global_configuration_from_dirs
-bool load_global_configuration_from_dirs(const char *dirs[], int dir_flags[]);
+bool libreport_load_global_configuration_from_dirs(const char *dirs[], int dir_flags[]);
 
-#define free_global_configuration libreport_free_global_configuration
-void free_global_configuration(void);
+void libreport_free_global_configuration(void);
 
-#define get_global_always_excluded_elements libreport_get_global_always_excluded_elements
-string_vector_ptr_t get_global_always_excluded_elements(void);
+string_vector_ptr_t libreport_get_global_always_excluded_elements(void);
 
-#define get_global_create_private_ticket libreport_get_global_create_private_ticket
-bool get_global_create_private_ticket(void);
+bool libreport_get_global_create_private_ticket(void);
 
 /**
  * Configures the create private ticket global option
@@ -50,8 +45,7 @@ bool get_global_create_private_ticket(void);
  * @param enabled The option's value
  * @param flags For future needs (enable persistent configuration)
  */
-#define set_global_create_private_ticket libreport_set_global_create_private_ticket
-void set_global_create_private_ticket(bool enabled, int flags);
+void libreport_set_global_create_private_ticket(bool enabled, int flags);
 
 /**
  * Returns logical true if the reporting process shall not start or contine if
@@ -63,8 +57,7 @@ void set_global_create_private_ticket(bool enabled, int flags);
  * @return true if the process shall stop; otherwise the function returns
  * false.
  */
-#define get_global_stop_on_not_reportable libreport_get_global_stop_on_not_reportable
-bool get_global_stop_on_not_reportable(void);
+bool libreport_get_global_stop_on_not_reportable(void);
 
 /**
  * Configures the stop on not reportable global option
@@ -78,8 +71,7 @@ bool get_global_stop_on_not_reportable(void);
  * @param enabled The option's value
  * @param flags For future needs (enable persistent configuration)
  */
-#define set_global_stop_on_not_reportable libreport_set_global_stop_on_not_reportable
-void set_global_stop_on_not_reportable(bool enabled, int flags);
+void libreport_set_global_stop_on_not_reportable(bool enabled, int flags);
 
 #ifdef __cplusplus
 }

--- a/src/include/internal_libreport.h
+++ b/src/include/internal_libreport.h
@@ -1122,7 +1122,7 @@ struct dump_dir *open_directory_for_writing(
 /* Multi-line list of places problem was reported.
  * Recommended line format:
  * "Reporter: VAR=VAL VAR=VAL"
- * Use add_reported_to(dd, "line_without_newline"): it adds line
+ * Use libreport_add_reported_to(dd, "line_without_newline"): it adds line
  * only if it is not already there.
  */
 #define FILENAME_REPORTED_TO  "reported_to"

--- a/src/include/internal_libreport.h
+++ b/src/include/internal_libreport.h
@@ -108,56 +108,38 @@ int vdprintf(int d, const char *format, va_list ap);
 extern "C" {
 #endif
 
-#define prefixcmp libreport_prefixcmp
-int prefixcmp(const char *str, const char *prefix);
-#define suffixcmp libreport_suffixcmp
-int suffixcmp(const char *str, const char *suffix);
-#define trim_all_whitespace libreport_trim_all_whitespace
-char *trim_all_whitespace(const char *str);
-#define shorten_string_to_length libreport_shorten_string_to_length
-char *shorten_string_to_length(const char *str, unsigned length);
-#define strtrim libreport_strtrim
-char *strtrim(char *str);
-#define strtrimch libreport_strtrimch
-char *strtrimch(char *str, int ch);
-#define strremovech libreport_strremovech
-char *strremovech(char *str, int ch);
-#define append_to_malloced_string libreport_append_to_malloced_string
-char *append_to_malloced_string(char *mstr, const char *append);
-#define skip_blank libreport_skip_blank
-char* skip_blank(const char *s);
-#define skip_whitespace libreport_skip_whitespace
-char* skip_whitespace(const char *s);
-#define skip_non_whitespace libreport_skip_non_whitespace
-char* skip_non_whitespace(const char *s);
+int libreport_prefixcmp(const char *str, const char *prefix);
+int libreport_suffixcmp(const char *str, const char *suffix);
+char *libreport_trim_all_whitespace(const char *str);
+char *libreport_shorten_string_to_length(const char *str, unsigned length);
+char *libreport_strtrim(char *str);
+char *libreport_strtrimch(char *str, int ch);
+char *libreport_strremovech(char *str, int ch);
+char *libreport_append_to_malloced_string(char *mstr, const char *append);
+char *libreport_skip_blank(const char *s);
+char *libreport_skip_whitespace(const char *s);
+char *libreport_skip_non_whitespace(const char *s);
 /* Like strcpy but can copy overlapping strings. */
-#define overlapping_strcpy libreport_overlapping_strcpy
-void overlapping_strcpy(char *dst, const char *src);
+void libreport_overlapping_strcpy(char *dst, const char *src);
 
-#define concat_path_file libreport_concat_path_file
-char *concat_path_file(const char *path, const char *filename);
+char *libreport_concat_path_file(const char *path, const char *filename);
 /*
  * Used to construct a name in a different directory with the basename
  * similar to the old name, if possible.
  */
-#define concat_path_basename libreport_concat_path_basename
-char *concat_path_basename(const char *path, const char *filename);
+char *libreport_concat_path_basename(const char *path, const char *filename);
 
 /* Allows all printable characters except '/',
  * the string must not exceed 64 characters of length
  * and must not equal neither "." nor ".." (these strings may appear in the string) */
-#define str_is_correct_filename libreport_str_is_correct_filename
-bool str_is_correct_filename(const char *str);
+bool libreport_str_is_correct_filename(const char *str);
 
 /* A-la fgets, but malloced and of unlimited size */
-#define xmalloc_fgets libreport_xmalloc_fgets
-char *xmalloc_fgets(FILE *file);
+char *libreport_xmalloc_fgets(FILE *file);
 /* Similar, but removes trailing \n */
-#define xmalloc_fgetline libreport_xmalloc_fgetline
-char *xmalloc_fgetline(FILE *file);
+char *libreport_xmalloc_fgetline(FILE *file);
 /* Useful for easy reading of various /proc files */
-#define xmalloc_fopen_fgetline_fclose libreport_xmalloc_fopen_fgetline_fclose
-char *xmalloc_fopen_fgetline_fclose(const char *filename);
+char *libreport_xmalloc_fopen_fgetline_fclose(const char *filename);
 
 
 typedef enum {
@@ -180,74 +162,49 @@ typedef enum {
  * @return Number of read Bytes on success. On errors, return -1 and prints out
  * reasonable good error messages.
  */
-#define copyfd_ext_at libreport_copyfd_ext_at
-off_t copyfd_ext_at(int src, int dir_fd, const char *name, int mode,
+off_t libreport_copyfd_ext_at(int src, int dir_fd, const char *name, int mode,
         uid_t uid, gid_t gid, int open_flags, int copy_flags, off_t size);
 
 /* On error, copyfd_XX prints error messages and returns -1 */
-#define copyfd_eof libreport_copyfd_eof
-off_t copyfd_eof(int src_fd, int dst_fd, int flags);
-#define copyfd_size libreport_copyfd_size
-off_t copyfd_size(int src_fd, int dst_fd, off_t size, int flags);
-#define copyfd_exact_size libreport_copyfd_exact_size
-void copyfd_exact_size(int src_fd, int dst_fd, off_t size);
-#define copy_file_ext_2at libreport_copy_file_ext_2at
-off_t copy_file_ext_2at(int src_dir_fd, const char *src_name, int dir_fd, const char *name, int mode, uid_t uid, gid_t gid, int src_flags, int dst_flags);
-#define copy_file_ext_at libreport_copy_file_ext_at
-off_t copy_file_ext_at(const char *src_name, int dir_fd, const char *name, int mode, uid_t uid, gid_t gid, int src_flags, int dst_flags);
-#define copy_file_ext(src_name, dst_name, mode, uid, gid, src_flags, dst_flags) \
-    copy_file_ext_at(src_name, AT_FDCWD, dst_name, mode, uid, gid, src_flags, dst_flags)
-#define copy_file libreport_copy_file
-off_t copy_file(const char *src_name, const char *dst_name, int mode);
-#define copy_file_at libreport_copy_file_at
-off_t copy_file_at(const char *src_name, int dir_fd, const char *name, int mode);
-#define copy_file_recursive libreport_copy_file_recursive
-int copy_file_recursive(const char *source, const char *dest);
+off_t libreport_copyfd_eof(int src_fd, int dst_fd, int flags);
+off_t libreport_copyfd_size(int src_fd, int dst_fd, off_t size, int flags);
+void libreport_copyfd_exact_size(int src_fd, int dst_fd, off_t size);
+off_t libreport_copy_file_ext_2at(int src_dir_fd, const char *src_name, int dir_fd, const char *name, int mode, uid_t uid, gid_t gid, int src_flags, int dst_flags);
+off_t libreport_copy_file_ext_at(const char *src_name, int dir_fd, const char *name, int mode, uid_t uid, gid_t gid, int src_flags, int dst_flags);
+#define libreport_copy_file_ext(src_name, dst_name, mode, uid, gid, src_flags, dst_flags) \
+    libreport_copy_file_ext_at(src_name, AT_FDCWD, dst_name, mode, uid, gid, src_flags, dst_flags)
+off_t libreport_copy_file(const char *src_name, const char *dst_name, int mode);
+off_t libreport_copy_file_at(const char *src_name, int dir_fd, const char *name, int mode);
+int libreport_copy_file_recursive(const char *source, const char *dest);
 
-#define decompress_fd libreport_decompress_fd
-int decompress_fd(int fdi, int fdo);
-#define decompress_file libreport_decompress_file
-int decompress_file(const char *path_in, const char *path_out, mode_t mode_out);
-#define decompress_file_ext_at libreport_decompress_file_ext_at
-int decompress_file_ext_at(const char *path_in, int dir_fd, const char *path_out,
+int libreport_decompress_fd(int fdi, int fdo);
+int libreport_decompress_file(const char *path_in, const char *path_out, mode_t mode_out);
+int libreport_decompress_file_ext_at(const char *path_in, int dir_fd, const char *path_out,
         mode_t mode_out, uid_t uid, gid_t gid, int src_flags, int dst_flags);
 
 // NB: will return short read on error, not -1,
 // if some data was read before error occurred
-#define xread libreport_xread
-void xread(int fd, void *buf, size_t count);
-#define safe_read libreport_safe_read
-ssize_t safe_read(int fd, void *buf, size_t count);
-#define safe_write libreport_safe_write
-ssize_t safe_write(int fd, const void *buf, size_t count);
-#define full_read libreport_full_read
-ssize_t full_read(int fd, void *buf, size_t count);
-#define full_write libreport_full_write
-ssize_t full_write(int fd, const void *buf, size_t count);
-#define full_write_str libreport_full_write_str
-ssize_t full_write_str(int fd, const char *buf);
-#define xmalloc_read libreport_xmalloc_read
-void* xmalloc_read(int fd, size_t *maxsz_p);
-#define xmalloc_open_read_close libreport_xmalloc_open_read_close
-void* xmalloc_open_read_close(const char *filename, size_t *maxsz_p);
-#define xmalloc_xopen_read_close libreport_xmalloc_xopen_read_close
-void* xmalloc_xopen_read_close(const char *filename, size_t *maxsz_p);
-#define malloc_readlink libreport_malloc_readlink
-char* malloc_readlink(const char *linkname);
-#define malloc_readlinkat libreport_malloc_readlinkat
-char* malloc_readlinkat(int dir_fd, const char *linkname);
+void libreport_xread(int fd, void *buf, size_t count);
+ssize_t libreport_safe_read(int fd, void *buf, size_t count);
+ssize_t libreport_safe_write(int fd, const void *buf, size_t count);
+ssize_t libreport_full_read(int fd, void *buf, size_t count);
+ssize_t libreport_full_write(int fd, const void *buf, size_t count);
+ssize_t libreport_full_write_str(int fd, const char *buf);
+void *libreport_xmalloc_read(int fd, size_t *maxsz_p);
+void *libreport_xmalloc_open_read_close(const char *filename, size_t *maxsz_p);
+void *libreport_xmalloc_xopen_read_close(const char *filename, size_t *maxsz_p);
+char *libreport_malloc_readlink(const char *linkname);
+char *libreport_malloc_readlinkat(int dir_fd, const char *linkname);
 
 
 /* Returns malloc'ed block */
-#define encode_base64 libreport_encode_base64
-char *encode_base64(const void *src, int length);
+char *libreport_encode_base64(const void *src, int length);
 
 /* Returns NULL if the string needs no sanitizing.
  * control_chars_to_sanitize is a bit mask.
  * If Nth bit is set, Nth control char will be sanitized (replaced by [XX]).
  */
-#define sanitize_utf8 libreport_sanitize_utf8
-char *sanitize_utf8(const char *src, uint32_t control_chars_to_sanitize);
+char *libreport_sanitize_utf8(const char *src, uint32_t control_chars_to_sanitize);
 enum {
     SANITIZE_ALL = 0xffffffff,
     SANITIZE_TAB = (1 << 9),
@@ -255,33 +212,26 @@ enum {
     SANITIZE_CR  = (1 << 13),
 };
 
-#define try_atou libreport_try_atou
-int try_atou(const char *numstr, unsigned *value);
-#define xatou libreport_xatou
-unsigned xatou(const char *numstr);
-#define try_atoi libreport_try_atoi
-int try_atoi(const char *numstr, int *value);
-#define xatoi libreport_xatoi
-int xatoi(const char *numstr);
-/* Using xatoi() instead of naive atoi() is not always convenient -
+int libreport_try_atou(const char *numstr, unsigned *value);
+unsigned libreport_xatou(const char *numstr);
+int libreport_try_atoi(const char *numstr, int *value);
+int libreport_xatoi(const char *numstr);
+/* Using libreport_xatoi() instead of naive atoi() is not always convenient -
  * in many places people want *non-negative* values, but store them
  * in signed int. Therefore we need this one:
  * dies if input is not in [0, INT_MAX] range. Also will reject '-0' etc.
  * It should really be named xatoi_nonnegative (since it allows 0),
  * but that would be too long.
  */
-#define try_atoi_positive libreport_try_atoi_positive
-int try_atoi_positive(const char *numstr, int *value);
-#define xatoi_positive libreport_xatoi_positive
-int xatoi_positive(const char *numstr);
+int libreport_try_atoi_positive(const char *numstr, int *value);
+int libreport_xatoi_positive(const char *numstr);
 
 //unused for now
 //unsigned long long monotonic_ns(void);
 //unsigned long long monotonic_us(void);
 //unsigned monotonic_sec(void);
 
-#define safe_waitpid libreport_safe_waitpid
-pid_t safe_waitpid(pid_t pid, int *wstat, int options);
+pid_t libreport_safe_waitpid(pid_t pid, int *wstat, int options);
 
 enum {
         /* on return, pipefds[1] is fd to which parent may write
@@ -310,8 +260,7 @@ enum {
  *
  * Returns pid.
  */
-#define fork_execv_on_steroids libreport_fork_execv_on_steroids
-pid_t fork_execv_on_steroids(int flags,
+pid_t libreport_fork_execv_on_steroids(int flags,
                 char **argv,
                 int *pipefds,
                 char **env_vec,
@@ -319,92 +268,63 @@ pid_t fork_execv_on_steroids(int flags,
                 uid_t uid);
 /* Returns malloc'ed string. NULs are retained, and extra one is appended
  * after the last byte (this NUL is not accounted for in *size_p) */
-#define run_in_shell_and_save_output libreport_run_in_shell_and_save_output
-char *run_in_shell_and_save_output(int flags,
+char *libreport_run_in_shell_and_save_output(int flags,
                 const char *cmd,
                 const char *dir,
                 size_t *size_p);
 
 /* Random utility functions */
 
-#define is_in_string_list libreport_is_in_string_list
-bool is_in_string_list(const char *name, const char *const *v);
+bool libreport_is_in_string_list(const char *name, const char *const *v);
 
-#define index_of_string_in_list libreport_index_of_string_in_list
-int index_of_string_in_list(const char *name, const char *const *v);
+int libreport_index_of_string_in_list(const char *name, const char *const *v);
 
-#define is_in_comma_separated_list libreport_is_in_comma_separated_list
-bool is_in_comma_separated_list(const char *value, const char *list);
-#define is_in_comma_separated_list_of_glob_patterns libreport_is_in_comma_separated_list_of_glob_patterns
-bool is_in_comma_separated_list_of_glob_patterns(const char *value, const char *list);
+bool libreport_is_in_comma_separated_list(const char *value, const char *list);
+bool libreport_is_in_comma_separated_list_of_glob_patterns(const char *value, const char *list);
 
 /* Calls GLib version appropriate initialization function.
  */
-#define glib_init libreport_glib_init
-void glib_init(void);
+void libreport_glib_init(void);
 
 /* Frees every element'd data using free(),
  * then frees list itself using g_list_free(list):
  */
-#define list_free_with_free libreport_list_free_with_free
-void list_free_with_free(GList *list);
+void libreport_list_free_with_free(GList *list);
 
-#define get_dirsize libreport_get_dirsize
-double get_dirsize(const char *pPath);
-#define get_dirsize_find_largest_dir libreport_get_dirsize_find_largest_dir
-double get_dirsize_find_largest_dir(
+double libreport_get_dirsize(const char *pPath);
+double libreport_get_dirsize_find_largest_dir(
                 const char *pPath,
                 char **worst_dir, /* can be NULL */
                 const char *excluded /* can be NULL */
 );
 
-#define ndelay_on libreport_ndelay_on
-int ndelay_on(int fd);
-#define ndelay_off libreport_ndelay_off
-int ndelay_off(int fd);
-#define close_on_exec_on libreport_close_on_exec_on
-int close_on_exec_on(int fd);
+int libreport_ndelay_on(int fd);
+int libreport_ndelay_off(int fd);
+int libreport_close_on_exec_on(int fd);
 
-#define xmalloc libreport_xmalloc
-void* xmalloc(size_t size);
-#define xrealloc libreport_xrealloc
-void* xrealloc(void *ptr, size_t size);
-#define xzalloc libreport_xzalloc
-void* xzalloc(size_t size);
-#define xstrdup libreport_xstrdup
-char* xstrdup(const char *s);
-#define xstrndup libreport_xstrndup
-char* xstrndup(const char *s, int n);
-#define xstrdup_between libreport_xstrdup_between
-char* xstrdup_between(const char *s, const char *open, const char *close);
+void *libreport_xmalloc(size_t size);
+void *libreport_xrealloc(void *ptr, size_t size);
+void *libreport_xzalloc(size_t size);
+char *libreport_xstrdup(const char *s);
+char *libreport_xstrndup(const char *s, int n);
+char *libreport_xstrdup_between(const char *s, const char *open, const char *close);
 
-#define xpipe libreport_xpipe
-void xpipe(int filedes[2]);
-#define xdup libreport_xdup
-int xdup(int from);
-#define xdup2 libreport_xdup2
-void xdup2(int from, int to);
-#define xmove_fd libreport_xmove_fd
-void xmove_fd(int from, int to);
+void libreport_xpipe(int filedes[2]);
+int libreport_xdup(int from);
+void libreport_xdup2(int from, int to);
+void libreport_xmove_fd(int from, int to);
 
-#define xwrite libreport_xwrite
-void xwrite(int fd, const void *buf, size_t count);
-#define xwrite_str libreport_xwrite_str
-void xwrite_str(int fd, const char *str);
+void libreport_xwrite(int fd, const void *buf, size_t count);
+void libreport_xwrite_str(int fd, const char *str);
 
-#define xlseek libreport_xlseek
-off_t xlseek(int fd, off_t offset, int whence);
+off_t libreport_xlseek(int fd, off_t offset, int whence);
 
-#define xchdir libreport_xchdir
-void xchdir(const char *path);
+void libreport_xchdir(const char *path);
 
-#define xvasprintf libreport_xvasprintf
-char* xvasprintf(const char *format, va_list p);
-#define xasprintf libreport_xasprintf
-char* xasprintf(const char *format, ...);
+char *libreport_xvasprintf(const char *format, va_list p);
+char *libreport_xasprintf(const char *format, ...);
 
-#define xsetenv libreport_xsetenv
-void xsetenv(const char *key, const char *value);
+void libreport_xsetenv(const char *key, const char *value);
 /*
  * Utility function to unsetenv a string which was possibly putenv'ed.
  * The problem here is that "natural" optimization:
@@ -415,34 +335,22 @@ void xsetenv(const char *key, const char *value);
  * Of course, saving/restoring the char wouldn't work either.
  * This helper creates a copy up to '=', unsetenv's it, and frees:
  */
-#define safe_unsetenv libreport_safe_unsetenv
-void safe_unsetenv(const char *var_val);
+void libreport_safe_unsetenv(const char *var_val);
 
-#define xsocket libreport_xsocket
-int xsocket(int domain, int type, int protocol);
-#define xbind libreport_xbind
-void xbind(int sockfd, struct sockaddr *my_addr, socklen_t addrlen);
-#define xlisten libreport_xlisten
-void xlisten(int s, int backlog);
-#define xsendto libreport_xsendto
-ssize_t xsendto(int s, const void *buf, size_t len,
+int libreport_xsocket(int domain, int type, int protocol);
+void libreport_xbind(int sockfd, struct sockaddr *my_addr, socklen_t addrlen);
+void libreport_xlisten(int s, int backlog);
+ssize_t libreport_xsendto(int s, const void *buf, size_t len,
                 const struct sockaddr *to, socklen_t tolen);
 
-#define xstat libreport_xstat
-void xstat(const char *name, struct stat *stat_buf);
-#define fstat_st_size_or_die libreport_fstat_st_size_or_die
-off_t fstat_st_size_or_die(int fd);
-#define stat_st_size_or_die libreport_stat_st_size_or_die
-off_t stat_st_size_or_die(const char *filename);
+void libreport_xstat(const char *name, struct stat *stat_buf);
+off_t libreport_fstat_st_size_or_die(int fd);
+off_t libreport_stat_st_size_or_die(const char *filename);
 
-#define xopen3 libreport_xopen3
-int xopen3(const char *pathname, int flags, int mode);
-#define xopen libreport_xopen
-int xopen(const char *pathname, int flags);
-#define xunlink libreport_xunlink
-void xunlink(const char *pathname);
-#define xunlinkat libreport_xunlinkat
-void xunlinkat(int dir_fd, const char *pathname, int flags);
+int libreport_xopen3(const char *pathname, int flags, int mode);
+int libreport_xopen(const char *pathname, int flags);
+void libreport_xunlink(const char *pathname);
+void libreport_xunlinkat(int dir_fd, const char *pathname, int flags);
 
 /* Just testing dent->d_type == DT_REG is wrong: some filesystems
  * do not report the type, they report DT_UNKNOWN for every dirent
@@ -450,37 +358,25 @@ void xunlinkat(int dir_fd, const char *pathname, int flags);
  * This function handles this case. Note: it returns 0 on symlinks
  * even if they point to regular files.
  */
-#define is_regular_file libreport_is_regular_file
-int is_regular_file(struct dirent *dent, const char *dirname);
-#define is_regular_file_at libreport_is_regular_file_at
-int is_regular_file_at(struct dirent *dent, int dir_fd);
+int libreport_is_regular_file(struct dirent *dent, const char *dirname);
+int libreport_is_regular_file_at(struct dirent *dent, int dir_fd);
 
-#define dot_or_dotdot libreport_dot_or_dotdot
-bool dot_or_dotdot(const char *filename);
-#define last_char_is libreport_last_char_is
-char *last_char_is(const char *s, int c);
+bool libreport_dot_or_dotdot(const char *filename);
+char *libreport_last_char_is(const char *s, int c);
 
-#define string_to_bool libreport_string_to_bool
-bool string_to_bool(const char *s);
+bool libreport_string_to_bool(const char *s);
 
-#define xseteuid libreport_xseteuid
-void xseteuid(uid_t euid);
-#define xsetegid libreport_xsetegid
-void xsetegid(gid_t egid);
-#define xsetreuid libreport_xsetreuid
-void xsetreuid(uid_t ruid, uid_t euid);
-#define xsetregid libreport_xsetregid
-void xsetregid(gid_t rgid, gid_t egid);
+void libreport_xseteuid(uid_t euid);
+void libreport_xsetegid(gid_t egid);
+void libreport_xsetreuid(uid_t ruid, uid_t euid);
+void libreport_xsetregid(gid_t rgid, gid_t egid);
 
-#define xfdopen libreport_xfdopen
-FILE *xfdopen(int fd, const char *mode);
+FILE *libreport_xfdopen(int fd, const char *mode);
 
 /* Emit a string of hex representation of bytes */
-#define bin2hex libreport_bin2hex
-char* bin2hex(char *dst, const char *str, int count);
+char *libreport_bin2hex(char *dst, const char *str, int count);
 /* Convert "xxxxxxxx" hex string to binary, no more than COUNT bytes */
-#define hex2bin libreport_hex2bin
-char* hex2bin(char *dst, const char *str, int count);
+char* libreport_hex2bin(char *dst, const char *str, int count);
 
 
 enum {
@@ -497,44 +393,34 @@ enum libreport_diemode {
     DIEMODE_ABORT = 1,
 };
 
-#define g_custom_logger libreport_g_custom_logger
-extern void (*g_custom_logger)(const char*);
-#define msg_prefix libreport_msg_prefix
-extern const char *msg_prefix;
-#define msg_eol libreport_msg_eol
-extern const char *msg_eol;
-#define logmode libreport_logmode
-extern int logmode;
-#define xfunc_error_retval libreport_xfunc_error_retval
-extern int xfunc_error_retval;
+extern void (*libreport_g_custom_logger)(const char*);
+extern const char *libreport_msg_prefix;
+extern const char *libreport_msg_eol;
+extern int libreport_logmode;
+extern int libreport_xfunc_error_retval;
 
 /* A few magic exit codes */
 #define EXIT_CANCEL_BY_USER 69
 #define EXIT_STOP_EVENT_RUN 70
 
-#define set_xfunc_error_retval libreport_set_xfunc_error_retval
-void set_xfunc_error_retval(int retval);
+void libreport_set_xfunc_error_retval(int retval);
 
-#define set_xfunc_diemode libreport_set_xfunc_diemode
-void set_xfunc_diemode(enum libreport_diemode mode);
+void libreport_set_xfunc_diemode(enum libreport_diemode mode);
 
 /* Verbosity level */
-#define g_verbose libreport_g_verbose
-extern int g_verbose;
+extern int libreport_g_verbose;
 /* VERB1 log_warning("what you sometimes want to see, even on a production box") */
-#define VERB1 if (g_verbose >= 1)
+#define VERB1 if (libreport_g_verbose >= 1)
 /* VERB2 log_warning("debug message, not going into insanely small details") */
-#define VERB2 if (g_verbose >= 2)
+#define VERB2 if (libreport_g_verbose >= 2)
 /* VERB3 log_warning("lots and lots of details") */
-#define VERB3 if (g_verbose >= 3)
+#define VERB3 if (libreport_g_verbose >= 3)
 /* there is no level > 3 */
 
 #define  libreport_
-#define xfunc_die libreport_xfunc_die
-void xfunc_die(void) NORETURN;
+void libreport_xfunc_die(void) NORETURN;
 
-#define die_out_of_memory libreport_die_out_of_memory
-void die_out_of_memory(void) NORETURN;
+void libreport_die_out_of_memory(void) NORETURN;
 
 /* It's a macro, not function, since it collides with log_warning() from math.h */
 #undef log
@@ -594,71 +480,62 @@ struct strbuf
  * Creates and initializes a new string buffer.
  * @returns
  * It never returns NULL. The returned pointer must be released by
- * calling the function strbuf_free().
+ * calling the function libreport_strbuf_free().
  */
-#define strbuf_new libreport_strbuf_new
-struct strbuf *strbuf_new(void);
+struct strbuf *libreport_strbuf_new(void);
 
 /**
  * Releases the memory held by the string buffer.
  * @param strbuf
  * If the strbuf is NULL, no operation is performed.
  */
-#define strbuf_free libreport_strbuf_free
-void strbuf_free(struct strbuf *strbuf);
+void libreport_strbuf_free(struct strbuf *strbuf);
 
 /**
  * Releases the strbuf, but not the internal buffer.  The internal
  * string buffer is returned.  Caller is responsible to release the
  * returned memory using free().
  */
-#define strbuf_free_nobuf libreport_strbuf_free_nobuf
-char* strbuf_free_nobuf(struct strbuf *strbuf);
+char *libreport_strbuf_free_nobuf(struct strbuf *strbuf);
 
 /**
  * The string content is set to an empty string, erasing any previous
  * content and leaving its length at 0 characters.
  */
-#define strbuf_clear libreport_strbuf_clear
-void strbuf_clear(struct strbuf *strbuf);
+void libreport_strbuf_clear(struct strbuf *strbuf);
 
 /**
  * The current content of the string buffer is extended by adding a
  * character c at its end.
  */
-#define strbuf_append_char libreport_strbuf_append_char
-struct strbuf *strbuf_append_char(struct strbuf *strbuf, char c);
+struct strbuf *libreport_strbuf_append_char(struct strbuf *strbuf, char c);
 
 /**
  * The current content of the string buffer is extended by adding a
  * string str at its end.
  */
-#define strbuf_append_str libreport_strbuf_append_str
-struct strbuf *strbuf_append_str(struct strbuf *strbuf,
+struct strbuf *libreport_strbuf_append_str(struct strbuf *strbuf,
                                  const char *str);
 
 /**
  * The current content of the string buffer is extended by inserting a
  * string str at its beginning.
  */
-#define strbuf_prepend_str libreport_strbuf_prepend_str
-struct strbuf *strbuf_prepend_str(struct strbuf *strbuf,
+struct strbuf *libreport_strbuf_prepend_str(struct strbuf *strbuf,
                                   const char *str);
 
 /**
  * The current content of the string buffer is extended by adding a
  * sequence of data formatted as the format argument specifies.
  */
-#define strbuf_append_strf libreport_strbuf_append_strf
-struct strbuf *strbuf_append_strf(struct strbuf *strbuf,
+struct strbuf *libreport_strbuf_append_strf(struct strbuf *strbuf,
                                   const char *format, ...);
 
 /**
- * Same as strbuf_append_strf except that va_list is passed instead of
+ * Same as libreport_strbuf_append_strf except that va_list is passed instead of
  * variable number of arguments.
  */
-#define strbuf_append_strfv libreport_strbuf_append_strfv
-struct strbuf *strbuf_append_strfv(struct strbuf *strbuf,
+struct strbuf *libreport_strbuf_append_strfv(struct strbuf *strbuf,
                                    const char *format, va_list p);
 
 /**
@@ -666,16 +543,14 @@ struct strbuf *strbuf_append_strfv(struct strbuf *strbuf,
  * sequence of data formatted as the format argument specifies at the
  * buffer beginning.
  */
-#define strbuf_prepend_strf libreport_strbuf_prepend_strf
-struct strbuf *strbuf_prepend_strf(struct strbuf *strbuf,
+struct strbuf *libreport_strbuf_prepend_strf(struct strbuf *strbuf,
                                    const char *format, ...);
 
 /**
- * Same as strbuf_prepend_strf except that va_list is passed instead of
+ * Same as libreport_strbuf_prepend_strf except that va_list is passed instead of
  * variable number of arguments.
  */
-#define strbuf_prepend_strfv libreport_strbuf_prepend_strfv
-struct strbuf *strbuf_prepend_strfv(struct strbuf *strbuf,
+struct strbuf *libreport_strbuf_prepend_strfv(struct strbuf *strbuf,
                                     const char *format, va_list p);
 
 /* Returns command line of running program.
@@ -683,43 +558,25 @@ struct strbuf *strbuf_prepend_strfv(struct strbuf *strbuf,
  * If the pid is not valid or command line can not be obtained,
  * empty string is returned.
  */
-#define open_proc_pid_dir libreport_open_proc_pid_dir
-int open_proc_pid_dir(pid_t pid);
-#define get_cmdline_at libreport_get_cmdline_at
-char* get_cmdline_at(pid_t pid);
-#define get_cmdline libreport_get_cmdline
-char* get_cmdline(pid_t pid);
-#define get_environ_at libreport_get_environ_at
-char* get_environ_at(pid_t pid);
-#define get_environ libreport_get_environ
-char* get_environ(pid_t pid);
-#define get_executable_at libreport_get_executable_at
-char *get_executable_at(pid_t pid);
-#define get_executable libreport_get_executable
-char *get_executable(pid_t pid);
-#define get_cwd_at libreport_get_cwd_at
-char* get_cwd_at(pid_t pid);
-#define get_cwd libreport_get_cwd
-char* get_cwd(pid_t pid);
-#define get_rootdir_at libreport_get_rootdir_at
-char* get_rootdir_at(pid_t pid);
-#define get_rootdir libreport_get_rootdir
-char* get_rootdir(pid_t pid);
+int libreport_open_proc_pid_dir(pid_t pid);
+char *libreport_get_cmdline_at(pid_t pid);
+char *libreport_get_cmdline(pid_t pid);
+char *libreport_get_environ_at(pid_t pid);
+char *libreport_get_environ(pid_t pid);
+char *libreport_get_executable_at(pid_t pid);
+char *libreport_get_executable(pid_t pid);
+char *libreport_get_cwd_at(pid_t pid);
+char *libreport_get_cwd(pid_t pid);
+char *libreport_get_rootdir_at(pid_t pid);
+char *libreport_get_rootdir(pid_t pid);
 
-#define get_fsuid libreport_get_fsuid
-int get_fsuid(const char *proc_pid_status);
-#define get_fsgid libreport_get_fsgid
-int get_fsgid(const char *proc_pid_status);
-#define dump_fd_info_at libreport_dump_fd_info_at
-int dump_fd_info_at(int pid_proc_fd, FILE *dest);
-#define dump_fd_info_ext libreport_dump_fd_info_ext
-int dump_fd_info_ext(const char *dest_filename, const char *proc_pid_fd_path, uid_t uid, gid_t gid);
-#define dump_fd_info libreport_dump_fd_info
-int dump_fd_info(const char *dest_filename, const char *proc_pid_fd_path);
-#define get_env_variable_ext libreport_get_env_variable_ext
-int get_env_variable_ext(int fd, char delim, const char *name, char **value);
-#define get_env_variable libreport_get_env_variable
-int get_env_variable(pid_t pid, const char *name, char **value);
+int libreport_get_fsuid(const char *proc_pid_status);
+int libreport_get_fsgid(const char *proc_pid_status);
+int libreport_dump_fd_info_at(int pid_proc_fd, FILE *dest);
+int libreport_dump_fd_info_ext(const char *dest_filename, const char *proc_pid_fd_path, uid_t uid, gid_t gid);
+int libreport_dump_fd_info(const char *dest_filename, const char *proc_pid_fd_path);
+int libreport_get_env_variable_ext(int fd, char delim, const char *name, char **value);
+int libreport_get_env_variable(pid_t pid, const char *name, char **value);
 
 #define PROC_NS_UNSUPPORTED ((ino_t)-1)
 #define PROC_NS_ID_CGROUP 0
@@ -747,29 +604,20 @@ struct ns_ids {
     ino_t nsi_ids[ARRAY_SIZE(libreport_proc_namespaces)];
 };
 
-#define get_ns_ids_at libreport_get_ns_ids_at
-int get_ns_ids_at(int pid_proc_fd, struct ns_ids *ids);
-#define get_ns_ids libreport_get_ns_ids
-int get_ns_ids(pid_t pid, struct ns_ids *ids);
+int libreport_get_ns_ids_at(int pid_proc_fd, struct ns_ids *ids);
+int libreport_get_ns_ids(pid_t pid, struct ns_ids *ids);
 
 /* These functions require a privileged user and does not work correctly in
  * processes running in own PID namespace
  */
-#define process_has_own_root_at libreport_process_has_own_root_at
-int process_has_own_root_at(int proc_pid_fd);
-#define process_has_own_root libreport_process_has_own_root
-int process_has_own_root(pid_t pid);
+int libreport_process_has_own_root_at(int proc_pid_fd);
+int libreport_process_has_own_root(pid_t pid);
 
-#define get_pid_of_container_at libreport_get_pid_of_container_at
-int get_pid_of_container_at(int pid_proc_fd, pid_t *init_pid);
-#define get_pid_of_container libreport_get_pid_of_container
-int get_pid_of_container(pid_t pid, pid_t *init_pid);
-#define dump_namespace_diff_at libreport_dump_namespace_diff_at
-int dump_namespace_diff_at(int base_pid_proc_fd, int tested_pid_proc_fd, FILE *dest);
-#define dump_namespace_diff_ext libreport_dump_namespace_diff_ext
-int dump_namespace_diff_ext(const char *dest_filename, pid_t base_pid, pid_t tested_pid, uid_t uid, gid_t gid);
-#define dump_namespace_diff libreport_dump_namespace_diff
-int dump_namespace_diff(const char *dest_filename, pid_t base_pid, pid_t tested_pid);
+int libreport_get_pid_of_container_at(int pid_proc_fd, pid_t *init_pid);
+int libreport_get_pid_of_container(pid_t pid, pid_t *init_pid);
+int libreport_dump_namespace_diff_at(int base_pid_proc_fd, int tested_pid_proc_fd, FILE *dest);
+int libreport_dump_namespace_diff_ext(const char *dest_filename, pid_t base_pid, pid_t tested_pid, uid_t uid, gid_t gid);
+int libreport_dump_namespace_diff(const char *dest_filename, pid_t base_pid, pid_t tested_pid);
 
 enum
 {
@@ -799,16 +647,13 @@ struct mountinfo
     /*      so the effective value is 9 */
     char *mntnf_items[_MOUNTINFO_INDEX_MAX];
 };
-#define mountinfo_destroy libreport_mountinfo_destroy
-void mountinfo_destroy(struct mountinfo *mntnf);
-#define get_mountinfo_for_mount_point libreport_get_mountinfo_for_mount_point
-int get_mountinfo_for_mount_point(FILE *fin, struct mountinfo *mntnf, const char *mnt_point);
+void libreport_mountinfo_destroy(struct mountinfo *mntnf);
+int libreport_get_mountinfo_for_mount_point(FILE *fin, struct mountinfo *mntnf, const char *mnt_point);
 
 /* Takes ptr to time_t, or NULL if you want to use current time.
  * Returns "YYYY-MM-DD-hh:mm:ss" string.
  */
-#define iso_date_string libreport_iso_date_string
-char *iso_date_string(const time_t *pt);
+char *libreport_iso_date_string(const time_t *pt);
 #define LIBREPORT_ISO_DATE_STRING_SAMPLE "YYYY-MM-DD-hh:mm:ss"
 #define LIBREPORT_ISO_DATE_STRING_FORMAT "%Y-%m-%d-%H:%M:%S"
 
@@ -819,8 +664,7 @@ char *iso_date_string(const time_t *pt);
  * @return 0 on success; otherwise non-0 number. -EINVAL if the parameter date
  * does not match LIBREPORT_ISO_DATE_STRING_FORMAT
  */
-#define iso_date_string_parse libreport_iso_date_string_parse
-int iso_date_string_parse(const char *date, time_t *pt);
+int libreport_iso_date_string_parse(const char *date, time_t *pt);
 
 enum {
     MAKEDESC_SHOW_FILES     = (1 << 0),
@@ -830,10 +674,8 @@ enum {
     /* Include all URLs from FILENAME_REPORTED_TO element in the description text */
     MAKEDESC_SHOW_URLS      = (1 << 4),
 };
-#define make_description libreport_make_description
-char *make_description(problem_data_t *problem_data, char **names_to_skip, unsigned max_text_size, unsigned desc_flags);
-#define make_description_logger libreport_make_description_logger
-char* make_description_logger(problem_data_t *problem_data, unsigned max_text_size);
+char *libreport_make_description(problem_data_t *problem_data, char **names_to_skip, unsigned max_text_size, unsigned desc_flags);
+char *libreport_make_description_logger(problem_data_t *problem_data, unsigned max_text_size);
 
 /* See man os-release(5) for details */
 #define OSINFO_ID "ID"
@@ -850,8 +692,7 @@ char* make_description_logger(problem_data_t *problem_data, unsigned max_text_si
  * @param osinfo_bytes Non-NULL pointer to osinfo bytes.
  * @param osinfo The map where result is stored
  */
-#define parse_osinfo libreport_parse_osinfo
-void parse_osinfo(const char *osinfo_bytes, map_string_t *osinfo);
+void libreport_parse_osinfo(const char *osinfo_bytes, map_string_t *osinfo);
 
 /* @brief Builds product string and product's version string for Bugzilla
  *
@@ -867,8 +708,7 @@ void parse_osinfo(const char *osinfo_bytes, map_string_t *osinfo);
  * @param produc Non-NULL pointer where pointer to malloced string will be stored. Memory must be released by free()
  * @param version Non-NULL pointer where pointer to malloced string will be stored. Memory must be released by free()
  */
-#define parse_osinfo_for_bz libreport_parse_osinfo_for_bz
-void parse_osinfo_for_bz(map_string_t *osinfo, char **product, char **version);
+void libreport_parse_osinfo_for_bz(map_string_t *osinfo, char **product, char **version);
 
 /* @brief Extract BUG_REPORT_URL from os-release
  *
@@ -881,8 +721,7 @@ void parse_osinfo_for_bz(map_string_t *osinfo, char **product, char **version);
  * @param osinfo Input data from which the values are built
  * @param url Non-NULL pointer where pointer to malloced string will be stored. Memory must be released by free()
  */
-#define parse_osinfo_for_bug_url libreport_parse_osinfo_for_bug_url
-void parse_osinfo_for_bug_url(map_string_t *osinfo, char** url);
+void libreport_parse_osinfo_for_bug_url(map_string_t *osinfo, char** url);
 
 /* @brief Builds product string and product's version string for Red Hat Support
  *
@@ -898,13 +737,10 @@ void parse_osinfo_for_bug_url(map_string_t *osinfo, char** url);
  * @param produc Non-NULL pointer where pointer to malloced string will be stored. Memory must be released by free()
  * @param version Non-NULL pointer where pointer to malloced string will be stored. Memory must be released by free()
  */
-#define parse_osinfo_for_rhts libreport_parse_osinfo_for_rhts
-void parse_osinfo_for_rhts(map_string_t *osinfo, char **product, char **version);
+void libreport_parse_osinfo_for_rhts(map_string_t *osinfo, char **product, char **version);
 
-#define parse_release_for_bz libreport_parse_release_for_bz
-void parse_release_for_bz(const char *pRelease, char **product, char **version);
-#define parse_release_for_rhts libreport_parse_release_for_rhts
-void parse_release_for_rhts(const char *pRelease, char **product, char **version);
+void libreport_parse_release_for_bz(const char *pRelease, char **product, char **version);
+void libreport_parse_release_for_rhts(const char *pRelease, char **product, char **version);
 
 /**
  * Loads settings and stores it in second parameter. On success it
@@ -920,73 +756,51 @@ void parse_release_for_rhts(const char *pRelease, char **product, char **version
  *  in mid-2013 if no user for it is identified.
  * @return if it success it returns true, otherwise it returns false.
  */
-#define load_conf_file libreport_load_conf_file
-bool load_conf_file(const char *pPath, map_string_t *settings, bool skipKeysWithoutValue);
-#define load_plugin_conf_file libreport_load_plugin_conf_file
-bool load_plugin_conf_file(const char *name, map_string_t *settings, bool skipKeysWithoutValue);
+bool libreport_load_conf_file(const char *pPath, map_string_t *settings, bool skipKeysWithoutValue);
+bool libreport_load_plugin_conf_file(const char *name, map_string_t *settings, bool skipKeysWithoutValue);
 
-#define get_user_conf_base_dir libreport_get_user_conf_base_dir
-const char *get_user_conf_base_dir(void);
+const char *libreport_get_user_conf_base_dir(void);
 
-#define load_conf_file_from_dirs libreport_load_conf_file_from_dirs
-bool load_conf_file_from_dirs(const char *base_name, const char *const *directories, map_string_t *settings, bool skipKeysWithoutValue);
+bool libreport_load_conf_file_from_dirs(const char *base_name, const char *const *directories, map_string_t *settings, bool skipKeysWithoutValue);
 
 enum {
     CONF_DIR_FLAG_NONE = 0,
     CONF_DIR_FLAG_OPTIONAL = 1,
 };
 
-#define load_conf_file_from_dirs_ext libreport_load_conf_file_from_dirs_ext
-bool load_conf_file_from_dirs_ext(const char *base_name, const char *const *directories,
+bool libreport_load_conf_file_from_dirs_ext(const char *base_name, const char *const *directories,
                                   const int * dir_flags, map_string_t *settings,
                                   bool skipKeysWithoutValue);
 
-#define save_conf_file libreport_save_conf_file
-bool save_conf_file(const char *path, map_string_t *settings);
-#define save_plugin_conf_file libreport_save_plugin_conf_file
-bool save_plugin_conf_file(const char *name, map_string_t *settings);
+bool libreport_save_conf_file(const char *path, map_string_t *settings);
+bool libreport_save_plugin_conf_file(const char *name, map_string_t *settings);
 
-#define save_app_conf_file libreport_save_app_conf_file
-bool save_app_conf_file(const char* application_name, map_string_t *settings);
-#define load_app_conf_file libreport_load_app_conf_file
-bool load_app_conf_file(const char *application_name, map_string_t *settings);
-#define set_app_user_setting libreport_set_app_user_setting
-void set_app_user_setting(map_string_t *settings, const char *name, const char *value);
-#define get_app_user_setting libreport_get_app_user_setting
-const char *get_app_user_setting(map_string_t *settings, const char *name);
+bool libreport_save_app_conf_file(const char* application_name, map_string_t *settings);
+bool libreport_load_app_conf_file(const char *application_name, map_string_t *settings);
+void libreport_set_app_user_setting(map_string_t *settings, const char *name, const char *value);
+const char *libreport_get_app_user_setting(map_string_t *settings, const char *name);
 
-#define save_user_settings libreport_save_user_settings
-bool save_user_settings(void);
-#define load_user_settings libreport_load_user_settings
-bool load_user_settings(const char *application_name);
-#define set_user_setting libreport_set_user_setting
-void set_user_setting(const char *name, const char *value);
-#define get_user_setting libreport_get_user_setting
-const char *get_user_setting(const char *name);
+bool libreport_save_user_settings(void);
+bool libreport_load_user_settings(const char *application_name);
+void libreport_set_user_setting(const char *name, const char *value);
+const char *libreport_get_user_setting(const char *name);
 
 /* filename is expected to exist in CONF_DIR
  * usually /etc/libreport
  */
-#define load_forbidden_words libreport_load_forbidden_words
-GList *load_words_from_file(const char *filename);
-#define get_file_list libreport_get_file_list
-GList *get_file_list(const char *path, const char *ext);
-#define free_file_list libreport_free_file_list
-void free_file_list(GList *filelist);
-#define new_file_obj libreport_new_file_obj
-file_obj_t *new_file_obj(const char* fullpath, const char* filename);
-#define free_file_obj libreport_free_file_obj
-void free_file_obj(file_obj_t *f);
-#define parse_delimited_list libreport_parse_delimited_list
-GList *parse_delimited_list(const char *string, const char *delimiter);
+GList *libreport_load_words_from_file(const char *filename);
+GList *libreport_get_file_list(const char *path, const char *ext);
+void libreport_free_file_list(GList *filelist);
+file_obj_t *libreport_new_file_obj(const char* fullpath, const char* filename);
+void libreport_free_file_obj(file_obj_t *f);
+GList *libreport_parse_delimited_list(const char *string, const char *delimiter);
 
 /* Connect to abrtd over unix domain socket, issue DELETE command */
 int delete_dump_dir_possibly_using_abrtd(const char *dump_dir_name);
 
 /* Tries to create a copy of dump_dir_name in base_dir, with same or similar basename.
  * Returns NULL if copying failed. In this case, logs a message before returning. */
-#define steal_directory libreport_steal_directory
-struct dump_dir *steal_directory(const char *base_dir, const char *dump_dir_name);
+struct dump_dir *libreport_steal_directory(const char *base_dir, const char *dump_dir_name);
 
 /* Resolves if the given user is in given group
  *
@@ -994,8 +808,7 @@ struct dump_dir *steal_directory(const char *base_dir, const char *dump_dir_name
  * @param gid group ID
  * @returns TRUE in case the user is in the group otherwise returns FALSE
  */
-#define uid_in_group libreport_uid_in_group
-bool uid_in_group(uid_t uid, gid_t gid);
+bool libreport_uid_in_group(uid_t uid, gid_t gid);
 
 /* Tries to open dump_dir_name with writing access. If function needs to steal
  * directory calls ask_continue(new base dir, dump dir) callback to ask user
@@ -1003,8 +816,7 @@ bool uid_in_group(uid_t uid, gid_t gid);
  * answer is positive and steals directory.
  * Returns NULL if opening failed or if stealing was dismissed. In this case,
  * logs a message before returning. */
-#define open_directory_for_writing libreport_open_directory_for_writing
-struct dump_dir *open_directory_for_writing(
+struct dump_dir *libreport_open_directory_for_writing(
                          const char *dump_dir_name,
                          bool (*ask_continue)(const char *, const char *));
 
@@ -1178,8 +990,7 @@ struct dump_dir *open_directory_for_writing(
 // Not stored as files, added "on the fly":
 #define CD_DUMPDIR            "Directory"
 
-#define cmp_problem_data libreport_cmp_problem_data
-gint cmp_problem_data(gconstpointer a, gconstpointer b, gpointer filename);
+gint libreport_cmp_problem_data(gconstpointer a, gconstpointer b, gpointer filename);
 
 //UNUSED:
 //// "Which events are possible (make sense) on this dump dir?"
@@ -1194,8 +1005,7 @@ enum {
     EVENT_LOG_LOW_WATERMARK  = 20 * 1024,
 };
 
-#define log_problem_data libreport_log_problem_data
-void log_problem_data(problem_data_t *problem_data, const char *pfx);
+void libreport_log_problem_data(problem_data_t *problem_data, const char *pfx);
 
 extern int g_libreport_inited;
 void libreport_init(void);
@@ -1212,10 +1022,8 @@ void libreport_init(void);
     while (0)
 
 const char *abrt_init(char **argv);
-#define export_abrt_envvars libreport_export_abrt_envvars
-void export_abrt_envvars(int pfx);
-#define g_progname libreport_g_progname
-extern const char *g_progname;
+void libreport_export_abrt_envvars(int pfx);
+extern const char *libreport_g_progname;
 
 enum parse_opt_type {
     OPTION_BOOL,
@@ -1254,12 +1062,10 @@ struct options {
 #define OPT__VERBOSE(v)     OPT_BOOL('v', "verbose", (v), _("Be verbose"))
 #define OPT__DUMP_DIR(v)    OPT_STRING('d', "problem-dir", (v), "DIR", _("Problem directory"))
 
-#define parse_opts libreport_parse_opts
-unsigned parse_opts(int argc, char **argv, const struct options *opt,
+unsigned libreport_parse_opts(int argc, char **argv, const struct options *opt,
                 const char *usage);
 
-#define show_usage_and_die libreport_show_usage_and_die
-void show_usage_and_die(const char *usage, const struct options *opt) NORETURN;
+void libreport_show_usage_and_die(const char *usage, const struct options *opt) NORETURN;
 
 /* Can't include "abrt_curl.h", it's not a public API.
  * Resorting to just forward-declaring the struct we need.
@@ -1285,8 +1091,7 @@ struct abrt_post_state;
  * @param location Location of the uri. Can be NULL. Result is never NULL. Result
  * must be de-allocated by free.
  */
-#define uri_userinfo_remove libreport_uri_userinfo_remove
-int uri_userinfo_remove(const char *uri, char **result, char **scheme, char **hostname, char **username, char **password, char **location);
+int libreport_uri_userinfo_remove(const char *uri, char **result, char **scheme, char **hostname, char **username, char **password, char **location);
 
 #ifdef __cplusplus
 }

--- a/src/include/libreport_curl.h
+++ b/src/include/libreport_curl.h
@@ -138,8 +138,7 @@ enum {
     UPLOAD_FILE_HANDLE_ACCESS_DENIALS = 1 << 0,
 };
 
-#define upload_file libreport_upload_file
-char *upload_file(const char *url, const char *filename);
+char *libreport_upload_file(const char *url, const char *filename);
 
 /* Uploads filename to url.
  *
@@ -150,8 +149,7 @@ char *upload_file(const char *url, const char *filename);
  * @return Resulting URL on success (the URL does not contain userinfo);
  * otherwise NULL.
  */
-#define upload_file_ext libreport_upload_file_ext
-char *upload_file_ext(post_state_t *post_state,
+char *libreport_upload_file_ext(post_state_t *post_state,
                 const char *url,
                 const char *filename,
                 int flags);

--- a/src/include/libreport_types.h
+++ b/src/include/libreport_types.h
@@ -25,90 +25,67 @@
 typedef gchar **string_vector_ptr_t;
 typedef const gchar *const *const_string_vector_const_ptr_t;
 
-#define string_vector_new_from_string libreport_string_vector_new_from_string
-string_vector_ptr_t string_vector_new_from_string(const char *vector);
-#define string_vector_free libreport_string_vector_free
-void string_vector_free(string_vector_ptr_t vector);
+string_vector_ptr_t libreport_string_vector_new_from_string(const char *vector);
+void libreport_string_vector_free(string_vector_ptr_t vector);
 
 typedef GHashTable map_string_t;
-#define new_map_string libreport_new_map_string
-map_string_t *new_map_string(void);
-#define free_map_string libreport_free_map_string
-void free_map_string(map_string_t *ms);
-#define clone_map_string libreport_clone_map_string
-map_string_t *clone_map_string(map_string_t *ms);
-#define size_map_string libreport_size_map_string
+map_string_t *libreport_new_map_string(void);
+void libreport_free_map_string(map_string_t *ms);
+map_string_t *libreport_clone_map_string(map_string_t *ms);
 static inline
-unsigned size_map_string(map_string_t *ms)
+unsigned libreport_size_map_string(map_string_t *ms)
 {
     if (ms == NULL)
         return 0;
 
     return g_hash_table_size(ms);
 }
-#define insert_map_string_item libreport_insert_map_string_item
 static inline
 void insert_map_string(map_string_t *ms, char *key, char *value)
 {
     g_hash_table_insert(ms, key, value);
 }
-#define replace_map_string_item libreport_replace_map_string_item
 static inline
-void replace_map_string_item(map_string_t *ms, char *key, char *value)
+void libreport_replace_map_string_item(map_string_t *ms, char *key, char *value)
 {
     g_hash_table_replace(ms, key, value);
 }
-#define remove_map_string_item libreport_remove_map_string_item
 static inline
-void remove_map_string_item(map_string_t *ms, const char *key)
+void libreport_remove_map_string_item(map_string_t *ms, const char *key)
 {
     g_hash_table_remove(ms, key);
 }
-#define get_map_string_item_or_empty libreport_get_map_string_item_or_empty
-const char *get_map_string_item_or_empty(map_string_t *ms, const char *key);
-#define get_map_string_item_or_NULL libreport_get_map_string_item_or_NULL
+const char *libreport_get_map_string_item_or_empty(map_string_t *ms, const char *key);
 static inline
-const char *get_map_string_item_or_NULL(map_string_t *ms, const char *key)
+const char *libreport_get_map_string_item_or_NULL(map_string_t *ms, const char *key)
 {
     return (const char*)g_hash_table_lookup(ms, key);
 }
 
-#define set_map_string_item_from_bool libreport_set_map_string_item_from_bool
-void set_map_string_item_from_bool(map_string_t *ms, const char *key, int value);
-#define try_get_map_string_item_as_bool libreport_try_get_map_string_item_as_bool
-int try_get_map_string_item_as_bool(map_string_t *ms, const char *key, int *value);
+void libreport_set_map_string_item_from_bool(map_string_t *ms, const char *key, int value);
+int libreport_try_get_map_string_item_as_bool(map_string_t *ms, const char *key, int *value);
 
-#define set_map_string_item_from_int libreport_set_map_string_item_from_int
-void set_map_string_item_from_int(map_string_t *ms, const char *key, int value);
-#define try_get_map_string_item_as_int libreport_try_get_map_string_item_as_int
-int try_get_map_string_item_as_int(map_string_t *ms, const char *key, int *value);
+void libreport_set_map_string_item_from_int(map_string_t *ms, const char *key, int value);
+int libreport_try_get_map_string_item_as_int(map_string_t *ms, const char *key, int *value);
 
-#define set_map_string_item_from_uint libreport_set_map_string_item_from_uint
-void set_map_string_item_from_uint(map_string_t *ms, const char *key, unsigned int value);
-#define try_get_map_string_item_as_uint libreport_try_get_map_string_item_as_uint
-int try_get_map_string_item_as_uint(map_string_t *ms, const char *key, unsigned int *value);
+void libreport_set_map_string_item_from_uint(map_string_t *ms, const char *key, unsigned int value);
+int libreport_try_get_map_string_item_as_uint(map_string_t *ms, const char *key, unsigned int *value);
 
-#define set_map_string_item_from_string libreport_set_map_string_item_from_string
-void set_map_string_item_from_string(map_string_t *ms, const char *key, const char *value);
-#define try_get_map_string_item_as_string libreport_try_get_map_string_item_as_string
-int try_get_map_string_item_as_string(map_string_t *ms, const char *key, char **value);
+void libreport_set_map_string_item_from_string(map_string_t *ms, const char *key, const char *value);
+int libreport_try_get_map_string_item_as_string(map_string_t *ms, const char *key, char **value);
 
-#define set_map_string_item_from_string_vector libreport_set_map_string_item_from_string_vector
-void set_map_string_item_from_string_vector(map_string_t *ms, const char *key, string_vector_ptr_t value);
-#define try_get_map_string_item_as_string_vector libreport_try_get_map_string_item_as_string_vector
-int try_get_map_string_item_as_string_vector(map_string_t *ms, const char *key, string_vector_ptr_t *value);
+void libreport_set_map_string_item_from_string_vector(map_string_t *ms, const char *key, string_vector_ptr_t value);
+int libreport_try_get_map_string_item_as_string_vector(map_string_t *ms, const char *key, string_vector_ptr_t *value);
 
 
 typedef GHashTableIter map_string_iter_t;
-#define init_map_string_iter libreport_init_map_string_iter
 static inline
-void init_map_string_iter(map_string_iter_t *iter, map_string_t *ms)
+void libreport_init_map_string_iter(map_string_iter_t *iter, map_string_t *ms)
 {
     g_hash_table_iter_init(iter, ms);
 }
-#define next_map_string_iter libreport_next_map_string_iter
 static inline
-int next_map_string_iter(map_string_iter_t *iter, const char **key, const char **value)
+int libreport_next_map_string_iter(map_string_iter_t *iter, const char **key, const char **value)
 {
     return g_hash_table_iter_next(iter, (gpointer *)key, (gpointer *)value);
 }

--- a/src/include/reporters.h
+++ b/src/include/reporters.h
@@ -24,10 +24,8 @@
 extern "C" {
 #endif
 
-#define is_comment_dup libreport_is_comment_dup
-int is_comment_dup(GList *comments, const char *comment);
-#define comments_find_best_bt_rating libreport_comments_find_best_bt_rating
-unsigned comments_find_best_bt_rating(GList *comments);
+int libreport_is_comment_dup(GList *comments, const char *comment);
+unsigned libreport_comments_find_best_bt_rating(GList *comments);
 
 #ifdef __cplusplus
 }

--- a/src/include/run_event.h
+++ b/src/include/run_event.h
@@ -303,8 +303,7 @@ char *run_event_stdio_ask_password(const char *msg, void *param);
 
 
 /* A simple helper */
-#define exit_status_as_string libreport_exit_status_as_string
-char *exit_status_as_string(const char *progname, int status);
+char *libreport_exit_status_as_string(const char *progname, int status);
 
 
 #ifdef __cplusplus

--- a/src/include/run_event.h
+++ b/src/include/run_event.h
@@ -268,7 +268,7 @@ int run_event_stdio_ask_yes_no(const char *msg, void *param);
  * Prints the msg param on stdout and reads a response from stdin. To store the
  * yes forever answer uses libreport's user settings API. Therefore if you want
  * to get the yes forever stuff working you have to call load_user_setting()
- * function before this function call and call save_user_settings() function
+ * function before this function call and call libreport_save_user_settings() function
  * after this function call.
  *
  * @param msg a printed message
@@ -283,7 +283,7 @@ int run_event_stdio_ask_yes_no_yesforever(const char *msg, const char *key, void
  * forever or never answer uses libreport's user settings API.
  * Therefore if you want to get the forever or never stuff working you
  * have to call load_user_setting() function before this function call and call
- * save_user_settings() function after this function call.
+ * libreport_save_user_settings() function after this function call.
  *
  * @param msg a printed message
  * @param key a key under which the forever (yes) or never (no) answer is stored

--- a/src/include/ureport.h
+++ b/src/include/ureport.h
@@ -73,18 +73,16 @@ struct ureport_server_config
  *
  * @param config Initialized structure
  */
-#define ureport_server_config_init libreport_ureport_server_config_init
 void
-ureport_server_config_init(struct ureport_server_config *config);
+libreport_ureport_server_config_init(struct ureport_server_config *config);
 
 /*
  * Release all allocated resources
  *
  * @param config Released structure
  */
-#define ureport_server_config_destroy libreport_ureport_server_config_destroy
 void
-ureport_server_config_destroy(struct ureport_server_config *config);
+libreport_ureport_server_config_destroy(struct ureport_server_config *config);
 
 /*
  * Loads uReport configuration from various sources.
@@ -94,9 +92,8 @@ ureport_server_config_destroy(struct ureport_server_config *config);
  *
  * @param config a server configuration to be populated
  */
-#define ureport_server_config_load libreport_ureport_server_config_load
 void
-ureport_server_config_load(struct ureport_server_config *config,
+libreport_ureport_server_config_load(struct ureport_server_config *config,
                            map_string_t *settings);
 
 /*
@@ -105,9 +102,8 @@ ureport_server_config_load(struct ureport_server_config *config,
  * @param config Where the url is stored
  * @param server_url Index URL
  */
-#define ureport_server_config_set_url libreport_ureport_server_config_set_url
 void
-ureport_server_config_set_url(struct ureport_server_config *config,
+libreport_ureport_server_config_set_url(struct ureport_server_config *config,
                               char *server_url);
 
 /*
@@ -117,9 +113,8 @@ ureport_server_config_set_url(struct ureport_server_config *config,
  * @param client_path Path in form of cert_full_path:key_full_path or one of
  *        the following string: 'rhsm', 'puppet'.
  */
-#define ureport_server_config_set_client_auth libreport_ureport_server_config_set_client_auth
 void
-ureport_server_config_set_client_auth(struct ureport_server_config *config,
+libreport_ureport_server_config_set_client_auth(struct ureport_server_config *config,
                                       const char *client_auth);
 
 /*
@@ -129,9 +124,8 @@ ureport_server_config_set_client_auth(struct ureport_server_config *config,
  * @param username User name
  * @param password Password
  */
-#define ureport_server_config_set_basic_auth libreport_ureport_server_config_set_basic_auth
 void
-ureport_server_config_set_basic_auth(struct ureport_server_config *config,
+libreport_ureport_server_config_set_basic_auth(struct ureport_server_config *config,
                                      const char *username, const char *password);
 
 /*
@@ -177,9 +171,8 @@ struct post_state;
  * @param config Configuration used in communication
  * @return Pointer to malloced memory or NULL in case of error in communication
  */
-#define ureport_server_response_from_reply libreport_ureport_server_response_from_reply
 struct ureport_server_response *
-ureport_server_response_from_reply(struct post_state *post_state,
+libreport_ureport_server_response_from_reply(struct post_state *post_state,
                                    struct ureport_server_config *config);
 
 /*
@@ -190,9 +183,8 @@ ureport_server_response_from_reply(struct post_state *post_state,
  * @param config Configuration used in communication
  * @return False in case of any error; otherwise True.
  */
-#define ureport_server_response_save_in_dump_dir libreport_ureport_server_response_save_in_dump_dir
 bool
-ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
+libreport_ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
                                          const char *dump_dir_path,
                                          struct ureport_server_config *config);
 
@@ -203,9 +195,8 @@ ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
  * @param config Configuration used in communication
  * @return Malloced zero-terminated string
  */
-#define ureport_server_response_get_report_url libreport_ureport_server_response_get_report_url
 char *
-ureport_server_response_get_report_url(struct ureport_server_response *resp,
+libreport_ureport_server_response_get_report_url(struct ureport_server_response *resp,
                                        struct ureport_server_config *config);
 
 /*
@@ -213,9 +204,8 @@ ureport_server_response_get_report_url(struct ureport_server_response *resp,
  *
  * @param resp Released structured
  */
-#define ureport_server_response_free libreport_ureport_server_response_free
 void
-ureport_server_response_free(struct ureport_server_response *resp);
+libreport_ureport_server_response_free(struct ureport_server_response *resp);
 
 /*
  * Send JSON to server and obtain reply
@@ -225,9 +215,8 @@ ureport_server_response_free(struct ureport_server_response *resp);
  * @param url_sfx Local part of the upload URL
  * @return Malloced server reply or NULL in case of communication errors
  */
-#define ureport_do_post libreport_ureport_do_post
 struct post_state *
-ureport_do_post(const char *json, struct ureport_server_config *config,
+libreport_ureport_do_post(const char *json, struct ureport_server_config *config,
                 const char *url_sfx);
 
 /*
@@ -237,9 +226,8 @@ ureport_do_post(const char *json, struct ureport_server_config *config,
  * @param config Configuration used in communication
  * @return Malloced, parsed server response
  */
-#define ureport_submit libreport_ureport_submit
 struct ureport_server_response *
-ureport_submit(const char *json_ureport, struct ureport_server_config *config);
+libreport_ureport_submit(const char *json_ureport, struct ureport_server_config *config);
 
 /*
  * Build a new uReport attachement from give arguments
@@ -290,12 +278,10 @@ ureport_attach(struct ureport_server_config *config,
  * @param dump_dir_path FS path to dump dir
  * @return Malloced JSON string
  */
-#define ureport_from_dump_dir libreport_ureport_from_dump_dir
 char *
-ureport_from_dump_dir(const char *dump_dir_path);
+libreport_ureport_from_dump_dir(const char *dump_dir_path);
 
-#define ureport_from_dump_dir_ext libreport_ureport_from_dump_dir_ext
-char *ureport_from_dump_dir_ext(const char *dump_dir_path,
+char *libreport_ureport_from_dump_dir_ext(const char *dump_dir_path,
                                 const struct ureport_preferences *preferences);
 
 #ifdef __cplusplus

--- a/src/include/ureport.h
+++ b/src/include/ureport.h
@@ -142,7 +142,7 @@ ureport_server_config_set_basic_auth(struct ureport_server_config *config,
  *  "<user_name>:<password>" - Manually supply user name and password.
  *  "<user_name>" - Manually supply user name and be asked for password.
  *
- * The function uses ask_password() function from client.h
+ * The function uses libreport_ask_password() function from client.h
  *
  * @param config Configured structure
  * @param http_auth_pref User HTTP Authentication preferences

--- a/src/include/ureport.h
+++ b/src/include/ureport.h
@@ -28,7 +28,7 @@ extern "C" {
 #define UREPORT_CONF_FILE_PATH PLUGINS_CONF_DIR"/ureport.conf"
 
 #define UREPORT_OPTION_VALUE_FROM_CONF(settings, opt, var, tr) do { const char *value = getenv("uReport_"opt); \
-        if (!value) { value = get_map_string_item_or_NULL(settings, opt); } if (value) { var = tr(value); } \
+        if (!value) { value = libreport_get_map_string_item_or_NULL(settings, opt); } if (value) { var = tr(value); } \
     } while(0)
 
 #define UREPORT_SUBMIT_ACTION "reports/new/"

--- a/src/include/workflow.h
+++ b/src/include/workflow.h
@@ -86,8 +86,7 @@ GHashTable *load_workflow_config_data_from_list(GList *wf_names, const char *pat
  * configuration files. If NULL, the default 'WORKFLOWS_DIR' is used instead.
  * @returns A map where the key is workflow's name and the value is workflow_t *.
  */
-#define load_workflow_config_data libreport_load_workflow_config_data
-GHashTable *load_workflow_config_data(const char* directory);
+GHashTable *libreport_load_workflow_config_data(const char* directory);
 
 #ifdef __cplusplus
 }

--- a/src/lib/abrt_dbus.c
+++ b/src/lib/abrt_dbus.c
@@ -30,27 +30,27 @@ DBusConnection* g_dbus_conn;
 //{
 //    dbus_bool_t db = val;
 //    if (!dbus_message_iter_append_basic(iter, DBUS_TYPE_BOOLEAN, &db))
-//        die_out_of_memory();
+//        libreport_die_out_of_memory();
 //}
 void store_int32(DBusMessageIter* iter, int32_t val)
 {
     if (!dbus_message_iter_append_basic(iter, DBUS_TYPE_INT32, &val))
-        die_out_of_memory();
+        libreport_die_out_of_memory();
 }
 void store_uint32(DBusMessageIter* iter, uint32_t val)
 {
     if (!dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT32, &val))
-        die_out_of_memory();
+        libreport_die_out_of_memory();
 }
 void store_int64(DBusMessageIter* iter, int64_t val)
 {
     if (!dbus_message_iter_append_basic(iter, DBUS_TYPE_INT64, &val))
-        die_out_of_memory();
+        libreport_die_out_of_memory();
 }
 void store_uint64(DBusMessageIter* iter, uint64_t val)
 {
     if (!dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT64, &val))
-        die_out_of_memory();
+        libreport_die_out_of_memory();
 }
 
 void store_string(DBusMessageIter* iter, const char* val)
@@ -58,9 +58,9 @@ void store_string(DBusMessageIter* iter, const char* val)
     /* dbus daemon will simply close our connection if we send broken utf8.
      * Therefore we must never do that.
      */
-    const char *sanitized = sanitize_utf8(val, /*ctrl:*/ 0);
+    const char *sanitized = libreport_sanitize_utf8(val, /*ctrl:*/ 0);
     if (!dbus_message_iter_append_basic(iter, DBUS_TYPE_STRING, sanitized ? &sanitized : &val))
-        die_out_of_memory();
+        libreport_die_out_of_memory();
     free((char*)sanitized);
 }
 
@@ -218,7 +218,7 @@ static dbus_bool_t add_watch(DBusWatch *watch, void* data)
 {
     log_debug("%s(watch:%p, data)", __func__, watch);
 
-    watch_app_info_t* app_info = (watch_app_info_t*)xzalloc(sizeof(*app_info));
+    watch_app_info_t* app_info = (watch_app_info_t*)libreport_xzalloc(sizeof(*app_info));
     dbus_watch_set_data(watch, app_info, free);
 
     int fd = dbus_watch_get_unix_fd(watch);
@@ -309,7 +309,7 @@ void attach_dbus_conn_to_glib_main_loop(DBusConnection* conn,
                 NULL /* free_data_function */
                 )
     ) {
-        die_out_of_memory();
+        libreport_die_out_of_memory();
     }
     log_debug("dbus_connection_set_timeout_functions");
     if (!dbus_connection_set_timeout_functions(conn,
@@ -320,7 +320,7 @@ void attach_dbus_conn_to_glib_main_loop(DBusConnection* conn,
                 NULL /* free_data_function */
                 )
     ) {
-        die_out_of_memory();
+        libreport_die_out_of_memory();
     }
 
     if (object_path && message_received_func)
@@ -337,7 +337,7 @@ void attach_dbus_conn_to_glib_main_loop(DBusConnection* conn,
                     NULL /* data */
                     )
         ) {
-            die_out_of_memory();
+            libreport_die_out_of_memory();
         }
     }
 }

--- a/src/lib/abrt_sock.c
+++ b/src/lib/abrt_sock.c
@@ -27,10 +27,10 @@
  */
 static int connect_to_abrtd_socket()
 {
-    int socketfd = xsocket(AF_UNIX, SOCK_STREAM, 0);
+    int socketfd = libreport_xsocket(AF_UNIX, SOCK_STREAM, 0);
     if (socketfd == -1)
         return -1;
-    /*close_on_exec_on(socketfd); - not needed, we are closing it soon */
+    /*libreport_close_on_exec_on(socketfd); - not needed, we are closing it soon */
     struct sockaddr_un local;
     memset(&local, 0, sizeof(local));
     local.sun_family = AF_UNIX;
@@ -52,13 +52,13 @@ static int connect_to_abrtd_and_call_DeleteDebugDump(const char *dump_dir_name)
     int socketfd = connect_to_abrtd_socket();
     if (socketfd != -1)
     {
-        full_write(socketfd, "DELETE ", strlen("DELETE "));
-        full_write(socketfd, dump_dir_name, strlen(dump_dir_name));
-        full_write(socketfd, " HTTP/1.1\r\n\r\n", strlen(" HTTP/1.1\r\n\r\n"));
+        libreport_full_write(socketfd, "DELETE ", strlen("DELETE "));
+        libreport_full_write(socketfd, dump_dir_name, strlen(dump_dir_name));
+        libreport_full_write(socketfd, " HTTP/1.1\r\n\r\n", strlen(" HTTP/1.1\r\n\r\n"));
         shutdown(socketfd, SHUT_WR);
 
         char response[64];
-        int r = full_read(socketfd, response, sizeof(response) - 1);
+        int r = libreport_full_read(socketfd, response, sizeof(response) - 1);
         if (r >= 0)
         {
             log_notice("Response via socket:'%.*s'", r, response);
@@ -94,7 +94,7 @@ int problem_data_send_to_abrt(problem_data_t* problem_data)
         struct problem_item *value;
         g_hash_table_iter_init(&iter, problem_data);
 
-        full_write(socketfd, "PUT / HTTP/1.1\r\n\r\n", strlen("PUT / HTTP/1.1\r\n\r\n"));
+        libreport_full_write(socketfd, "PUT / HTTP/1.1\r\n\r\n", strlen("PUT / HTTP/1.1\r\n\r\n"));
         while (g_hash_table_iter_next(&iter, (void**)&name, (void**)&value))
         {
             if (value->flags & CD_FLAG_BIN)
@@ -111,14 +111,14 @@ int problem_data_send_to_abrt(problem_data_t* problem_data)
                 continue;
             }
 
-            char* msg = xasprintf("%s=%s", name, value->content);
-            full_write(socketfd, msg, strlen(msg)+1 /* yes, +1 coz we want to send the trailing 0 */);
+            char *msg = libreport_xasprintf("%s=%s", name, value->content);
+            libreport_full_write(socketfd, msg, strlen(msg)+1 /* yes, +1 coz we want to send the trailing 0 */);
             free(msg);
         }
         shutdown(socketfd, SHUT_WR);
 
         char response[64];
-        int r = full_read(socketfd, response, sizeof(response) - 1);
+        int r = libreport_full_read(socketfd, response, sizeof(response) - 1);
         if (r >= 0)
         {
             log_notice("Response via socket:'%.*s'", r, response);

--- a/src/lib/abrt_types.c
+++ b/src/lib/abrt_types.c
@@ -18,66 +18,66 @@
 */
 #include "internal_libreport.h"
 
-map_string_t *new_map_string(void)
+map_string_t *libreport_new_map_string(void)
 {
     return g_hash_table_new_full(g_str_hash, g_str_equal, free, free);
 }
 
-void free_map_string(map_string_t *ms)
+void libreport_free_map_string(map_string_t *ms)
 {
     if (ms)
         g_hash_table_destroy(ms);
 }
 
-map_string_t *clone_map_string(map_string_t *ms)
+map_string_t *libreport_clone_map_string(map_string_t *ms)
 {
     if (ms == NULL)
         return NULL;
 
-    map_string_t *clone = new_map_string();
+    map_string_t *clone = libreport_new_map_string();
 
     const char *key;
     const char *value;
     map_string_iter_t iter;
-    init_map_string_iter(&iter, ms);
-    while(next_map_string_iter(&iter, &key, &value))
+    libreport_init_map_string_iter(&iter, ms);
+    while(libreport_next_map_string_iter(&iter, &key, &value))
         insert_map_string(clone, libreport_xstrdup(key), libreport_xstrdup(value));
 
     return clone;
 }
 
-const char *get_map_string_item_or_empty(map_string_t *ms, const char *key)
+const char *libreport_get_map_string_item_or_empty(map_string_t *ms, const char *key)
 {
     const char *v = (const char*)g_hash_table_lookup(ms, key);
     if (!v) v = "";
     return v;
 }
 
-string_vector_ptr_t string_vector_new_from_string(const char *value)
+string_vector_ptr_t libreport_string_vector_new_from_string(const char *value)
 {
     return g_strsplit(value == NULL ? "" : value, ", ", /*all tokens*/0);
 }
 
-void string_vector_free(string_vector_ptr_t vector)
+void libreport_string_vector_free(string_vector_ptr_t vector)
 {
     g_strfreev(vector);
 }
 
-void set_map_string_item_from_bool(map_string_t *ms, const char *key, int value)
+void libreport_set_map_string_item_from_bool(map_string_t *ms, const char *key, int value)
 {
     const char *const raw_value = value ? "yes" : "no";
-    set_map_string_item_from_string(ms, key, raw_value);
+    libreport_set_map_string_item_from_string(ms, key, raw_value);
 }
 
 #define GET_ITEM_OR_RETURN(val_name, conf, item_name)\
-    const char *const val_name = get_map_string_item_or_NULL(conf, item_name); \
+    const char *const val_name = libreport_get_map_string_item_or_NULL(conf, item_name); \
     if (val_name == NULL) \
     { \
         log_debug("Configuration option '%s' not found in loaded settings", item_name); \
         return 0; \
     }
 
-int try_get_map_string_item_as_bool(map_string_t *ms, const char *key, int *value)
+int libreport_try_get_map_string_item_as_bool(map_string_t *ms, const char *key, int *value)
 {
     GET_ITEM_OR_RETURN(option, ms, key);
 
@@ -85,14 +85,14 @@ int try_get_map_string_item_as_bool(map_string_t *ms, const char *key, int *valu
     return true;
 }
 
-void set_map_string_item_from_int(map_string_t *ms, const char *key, int value)
+void libreport_set_map_string_item_from_int(map_string_t *ms, const char *key, int value)
 {
     char raw_value[sizeof(int)*3 + 1];
     snprintf(raw_value, sizeof(raw_value), "%d", value);
-    set_map_string_item_from_string(ms, key, raw_value);
+    libreport_set_map_string_item_from_string(ms, key, raw_value);
 }
 
-int try_get_map_string_item_as_int(map_string_t *ms, const char *key, int *value)
+int libreport_try_get_map_string_item_as_int(map_string_t *ms, const char *key, int *value)
 {
     GET_ITEM_OR_RETURN(option, ms, key);
 
@@ -119,14 +119,14 @@ int try_get_map_string_item_as_int(map_string_t *ms, const char *key, int *value
     return 1;
 }
 
-void set_map_string_item_from_uint(map_string_t *ms, const char *key, unsigned int value)
+void libreport_set_map_string_item_from_uint(map_string_t *ms, const char *key, unsigned int value)
 {
     char raw_value[sizeof(int)*3 + 1];
     snprintf(raw_value, sizeof(raw_value), "%u", value);
-    set_map_string_item_from_string(ms, key, raw_value);
+    libreport_set_map_string_item_from_string(ms, key, raw_value);
 }
 
-int try_get_map_string_item_as_uint(map_string_t *ms, const char *key, unsigned int *value)
+int libreport_try_get_map_string_item_as_uint(map_string_t *ms, const char *key, unsigned int *value)
 {
     GET_ITEM_OR_RETURN(option, ms, key);
 
@@ -172,12 +172,12 @@ int try_get_map_string_item_as_uint(map_string_t *ms, const char *key, unsigned 
     return 1;
 }
 
-void set_map_string_item_from_string(map_string_t *ms, const char *key, const char *value)
+void libreport_set_map_string_item_from_string(map_string_t *ms, const char *key, const char *value)
 {
-    replace_map_string_item(ms, libreport_xstrdup(key), libreport_xstrdup(value));
+    libreport_replace_map_string_item(ms, libreport_xstrdup(key), libreport_xstrdup(value));
 }
 
-int try_get_map_string_item_as_string(map_string_t *ms, const char *key, char **value)
+int libreport_try_get_map_string_item_as_string(map_string_t *ms, const char *key, char **value)
 {
     GET_ITEM_OR_RETURN(option, ms, key);
 
@@ -192,23 +192,23 @@ int try_get_map_string_item_as_string(map_string_t *ms, const char *key, char **
     return 1;
 }
 
-void set_map_string_item_from_string_vector(map_string_t *ms, const char *key, string_vector_ptr_t value)
+void libreport_set_map_string_item_from_string_vector(map_string_t *ms, const char *key, string_vector_ptr_t value)
 {
     if (value == NULL)
     {
-        set_map_string_item_from_string(ms, key, "");
+        libreport_set_map_string_item_from_string(ms, key, "");
         return;
     }
 
     gchar *opt_val = g_strjoinv(", ", (gchar **)value);
-    set_map_string_item_from_string(ms, key, opt_val);
+    libreport_set_map_string_item_from_string(ms, key, opt_val);
     g_free(opt_val);
 }
 
-int try_get_map_string_item_as_string_vector(map_string_t *ms, const char *key, string_vector_ptr_t *value)
+int libreport_try_get_map_string_item_as_string_vector(map_string_t *ms, const char *key, string_vector_ptr_t *value)
 {
     GET_ITEM_OR_RETURN(option, ms, key);
 
-    *value = string_vector_new_from_string(option);
+    *value = libreport_string_vector_new_from_string(option);
     return 1;
 }

--- a/src/lib/abrt_types.c
+++ b/src/lib/abrt_types.c
@@ -41,7 +41,7 @@ map_string_t *clone_map_string(map_string_t *ms)
     map_string_iter_t iter;
     init_map_string_iter(&iter, ms);
     while(next_map_string_iter(&iter, &key, &value))
-        insert_map_string(clone, xstrdup(key), xstrdup(value));
+        insert_map_string(clone, libreport_xstrdup(key), libreport_xstrdup(value));
 
     return clone;
 }
@@ -81,7 +81,7 @@ int try_get_map_string_item_as_bool(map_string_t *ms, const char *key, int *valu
 {
     GET_ITEM_OR_RETURN(option, ms, key);
 
-    *value = string_to_bool(option);
+    *value = libreport_string_to_bool(option);
     return true;
 }
 
@@ -174,7 +174,7 @@ int try_get_map_string_item_as_uint(map_string_t *ms, const char *key, unsigned 
 
 void set_map_string_item_from_string(map_string_t *ms, const char *key, const char *value)
 {
-    replace_map_string_item(ms, xstrdup(key), xstrdup(value));
+    replace_map_string_item(ms, libreport_xstrdup(key), libreport_xstrdup(value));
 }
 
 int try_get_map_string_item_as_string(map_string_t *ms, const char *key, char **value)

--- a/src/lib/abrt_xmlrpc.c
+++ b/src/lib/abrt_xmlrpc.c
@@ -42,7 +42,7 @@ struct abrt_xmlrpc *abrt_xmlrpc_new_client(const char *url, int ssl_verify)
     xmlrpc_env env;
     xmlrpc_env_init(&env);
 
-    struct abrt_xmlrpc *ax = xzalloc(sizeof(struct abrt_xmlrpc));
+    struct abrt_xmlrpc *ax = libreport_xzalloc(sizeof(struct abrt_xmlrpc));
 
     /* This should be done at program startup, once. We do it in main */
     /* xmlrpc_client_setup_global_const(&env); */
@@ -86,7 +86,7 @@ struct abrt_xmlrpc *abrt_xmlrpc_new_client(const char *url, int ssl_verify)
                          &client_parms, XMLRPC_CPSIZE(transportparm_size),
                          &ax->ax_client);
 
-    list_free_with_free(proxies);
+    libreport_list_free_with_free(proxies);
 
     if (env.fault_occurred)
         abrt_xmlrpc_die(&env);
@@ -128,8 +128,8 @@ void abrt_xmlrpc_free_client(struct abrt_xmlrpc *ax)
 void abrt_xmlrpc_client_add_session_param_string(xmlrpc_env *env, struct abrt_xmlrpc *ax,
         const char *name, const char *value)
 {
-    struct abrt_xmlrpc_param_pair *new_ses_param = xmalloc(sizeof(*new_ses_param));
-    new_ses_param->name = xstrdup(name);
+    struct abrt_xmlrpc_param_pair *new_ses_param = libreport_xmalloc(sizeof(*new_ses_param));
+    new_ses_param->name = libreport_xstrdup(name);
 
     new_ses_param->value = xmlrpc_string_new(env, value);
     if (env->fault_occurred)

--- a/src/lib/append_to_malloced_string.c
+++ b/src/lib/append_to_malloced_string.c
@@ -18,10 +18,10 @@
 */
 #include "internal_libreport.h"
 
-char *append_to_malloced_string(char *mstr, const char *append)
+char *libreport_append_to_malloced_string(char *mstr, const char *append)
 {
 	unsigned mlen = strlen(mstr);
-	mstr = (char*) xrealloc(mstr, mlen + strlen(append) + 1);
+	mstr = (char*) libreport_xrealloc(mstr, mlen + strlen(append) + 1);
 	strcpy(mstr + mlen, append);
 	return mstr;
 }

--- a/src/lib/binhex.c
+++ b/src/lib/binhex.c
@@ -21,7 +21,7 @@
 static const char hexdigits_locase[] = "0123456789abcdef";
 
 /* Emit a string of hex representation of bytes */
-char *bin2hex(char *dst, const char *str, int count)
+char *libreport_bin2hex(char *dst, const char *str, int count)
 {
 	while (count) {
 		unsigned char c = *str++;
@@ -34,7 +34,7 @@ char *bin2hex(char *dst, const char *str, int count)
 }
 
 /* Convert "xxxxxxxx" hex string to binary, no more than COUNT bytes */
-char *hex2bin(char *dst, const char *str, int count)
+char *libreport_hex2bin(char *dst, const char *str, int count)
 {
 	/* Parts commented out with // allow parsing
 	 * of strings like "xx:x:x:xx:xx:xx:xxxxxx"

--- a/src/lib/client.c
+++ b/src/lib/client.c
@@ -31,7 +31,7 @@ static int is_noninteractive_mode()
 }
 
 /* Returns 1 if echo has been changed from another state. */
-int set_echo(int enable)
+int libreport_set_echo(int enable)
 {
     struct termios t;
     int chvalue = 0;
@@ -60,7 +60,7 @@ int set_echo(int enable)
     return 1;
 }
 
-int ask_yes_no(const char *question)
+int libreport_ask_yes_no(const char *question)
 {
     INITIALIZE_LIBREPORT();
 
@@ -92,7 +92,7 @@ int ask_yes_no(const char *question)
     return ((is_slave_mode() && response[0] == 'y') || strncasecmp(yes, response, strlen(yes)) == 0);
 }
 
-int ask_yes_no_yesforever(const char *key, const char *question)
+int libreport_ask_yes_no_yesforever(const char *key, const char *question)
 {
     INITIALIZE_LIBREPORT();
 
@@ -149,7 +149,7 @@ int ask_yes_no_yesforever(const char *key, const char *question)
     return ((is_slave_mode() && response[0] == 'y') || strncasecmp(yes, response, strlen(yes)) == 0);
 }
 
-int ask_yes_no_save_result(const char *key, const char *question)
+int libreport_ask_yes_no_save_result(const char *key, const char *question)
 {
     INITIALIZE_LIBREPORT();
 
@@ -211,7 +211,7 @@ int ask_yes_no_save_result(const char *key, const char *question)
     return ((is_slave_mode() && response[0] == 'y') || strncasecmp(yes, response, strlen(yes)) == 0);
 }
 
-char *ask(const char *question)
+char *libreport_ask(const char *question)
 {
     if (is_slave_mode())
         printf(REPORT_PREFIX_ASK "%s\n", question);
@@ -233,7 +233,7 @@ char *ask(const char *question)
     return result;
 }
 
-char *ask_password(const char *question)
+char *libreport_ask_password(const char *question)
 {
     if (is_slave_mode())
         printf(REPORT_PREFIX_ASK_PASSWORD "%s\n", question);
@@ -249,18 +249,18 @@ char *ask_password(const char *question)
         return xstrdup("");
     }
 
-    bool changed = set_echo(false);
+    bool changed = libreport_set_echo(false);
 
     char *result = xmalloc_fgets(stdin);
     strtrimch(result, '\n');
 
     if (changed)
-        set_echo(true);
+        libreport_set_echo(true);
 
     return result;
 }
 
-void alert(const char *message)
+void libreport_alert(const char *message)
 {
     if (is_slave_mode())
         printf(REPORT_PREFIX_ALERT);
@@ -269,7 +269,7 @@ void alert(const char *message)
     fflush(stdout);
 }
 
-void client_log(const char *message)
+void libreport_client_log(const char *message)
 {
     if (message != NULL
         && (message[0] == '.' && message[1] == '\0')

--- a/src/lib/client.c
+++ b/src/lib/client.c
@@ -114,8 +114,8 @@ int libreport_ask_yes_no_yesforever(const char *key, const char *question)
     {   /* Load an value for the key from user setting.
          * NO means 'Don't ask me again, I said yes forever'.
          */
-        const char *option = get_user_setting(key);
-        if (option && string_to_bool(option) == false)
+        const char *option = libreport_get_user_setting(key);
+        if (option && libreport_string_to_bool(option) == false)
             return 1;
     }
 
@@ -140,11 +140,11 @@ int libreport_ask_yes_no_yesforever(const char *key, const char *question)
     if ((is_slave_mode() && response[0] == 'f') || strncasecmp(forever, response, strlen(forever)) == 0)
     {
         /* NO means 'Don't ask me again, I said yes forever'. */
-        set_user_setting(key, "no");
+        libreport_set_user_setting(key, "no");
         return 1;
     }
     else
-        set_user_setting(key, "yes");
+        libreport_set_user_setting(key, "yes");
 
     return ((is_slave_mode() && response[0] == 'y') || strncasecmp(yes, response, strlen(yes)) == 0);
 }
@@ -174,9 +174,9 @@ int libreport_ask_yes_no_save_result(const char *key, const char *question)
          * NO means never
          * 'no_value' means ask me
          */
-        const char *option = get_user_setting(key);
+        const char *option = libreport_get_user_setting(key);
         if (option)
-            return string_to_bool(option);
+            return libreport_string_to_bool(option);
     }
 
     if (is_slave_mode())
@@ -199,12 +199,12 @@ int libreport_ask_yes_no_save_result(const char *key, const char *question)
 
     if ((is_slave_mode() && response[0] == 'f') || strncasecmp(forever, response, strlen(forever)) == 0)
     {
-        set_user_setting(key, "yes");
+        libreport_set_user_setting(key, "yes");
         return 1;
     }
     else if ((is_slave_mode() && response[0] == 'e') || strncasecmp(never, response, strlen(never)) == 0)
     {
-        set_user_setting(key, "no");
+        libreport_set_user_setting(key, "no");
         return 0;
     }
 
@@ -224,11 +224,11 @@ char *libreport_ask(const char *question)
     {
         putchar('\n');
         fflush(stdout);
-        return xstrdup("");
+        return libreport_xstrdup("");
     }
 
-    char *result = xmalloc_fgets(stdin);
-    strtrimch(result, '\n');
+    char *result = libreport_xmalloc_fgets(stdin);
+    libreport_strtrimch(result, '\n');
 
     return result;
 }
@@ -246,13 +246,13 @@ char *libreport_ask_password(const char *question)
     {
         putchar('\n');
         fflush(stdout);
-        return xstrdup("");
+        return libreport_xstrdup("");
     }
 
     bool changed = libreport_set_echo(false);
 
-    char *result = xmalloc_fgets(stdin);
-    strtrimch(result, '\n');
+    char *result = libreport_xmalloc_fgets(stdin);
+    libreport_strtrimch(result, '\n');
 
     if (changed)
         libreport_set_echo(true);

--- a/src/lib/compress.c
+++ b/src/lib/compress.c
@@ -80,7 +80,7 @@ decompress_using_fork_execvp(const char** cmd, int fdi, int fdo)
     }
 
     int status = 0;
-    int r = safe_waitpid(child, &status, 0);
+    int r = libreport_safe_waitpid(child, &status, 0);
     if (r < 0)
     {
         VERB1 perror_msg("Decompression failed: waitpid($1) failed");
@@ -130,7 +130,7 @@ decompress_fd_xz(int fdi, int fdo)
         if (strm.avail_in == 0 && action == LZMA_RUN)
         {
             strm.next_in = buf_in;
-            strm.avail_in = safe_read(fdi, buf_in, sizeof(buf_in));
+            strm.avail_in = libreport_safe_read(fdi, buf_in, sizeof(buf_in));
 
             if (strm.avail_in < 0)
             {
@@ -150,7 +150,7 @@ decompress_fd_xz(int fdi, int fdo)
         if (strm.avail_out == 0 || ret == LZMA_STREAM_END)
         {
             const ssize_t n = sizeof(buf_out) - strm.avail_out;
-            if (n != safe_write(fdo, buf_out, n))
+            if (n != libreport_safe_write(fdo, buf_out, n))
             {
                 perror_msg("Failed to write decompressed data");
                 close(fdi);
@@ -234,7 +234,7 @@ decompress_fd_lz4(int fdi, int fdo)
             goto cleanup;
         }
 
-        r = safe_write(fdo, buf, produced);
+        r = libreport_safe_write(fdo, buf, produced);
         if (r < 0)
         {
             log_debug("Failed to write decoded block");
@@ -262,18 +262,17 @@ cleanup:
 #endif /*HAVE_LZ4*/
 }
 
-int
-decompress_fd(int fdi, int fdo)
+int libreport_decompress_fd(int fdi, int fdo)
 {
     uint8_t header[6];
 
-    if (sizeof(header) != safe_read(fdi, header, sizeof(header)))
+    if (sizeof(header) != libreport_safe_read(fdi, header, sizeof(header)))
     {
         perror_msg("Failed to read header bytes");
         return -1;
     }
 
-    xlseek(fdi, 0, SEEK_SET);
+    libreport_xlseek(fdi, 0, SEEK_SET);
 
     if (is_format("xz", header, sizeof(header), s_xz_magic, sizeof(s_xz_magic)))
         return decompress_fd_xz(fdi, fdo);
@@ -285,8 +284,7 @@ decompress_fd(int fdi, int fdo)
     return -1;
 }
 
-int
-decompress_file_ext_at(const char *path_in, int dir_fd, const char *path_out, mode_t mode_out,
+int libreport_decompress_file_ext_at(const char *path_in, int dir_fd, const char *path_out, mode_t mode_out,
                        uid_t uid, gid_t gid, int src_flags, int dst_flags)
 {
     int fdi = open(path_in, src_flags);
@@ -304,7 +302,7 @@ decompress_file_ext_at(const char *path_in, int dir_fd, const char *path_out, mo
         return -1;
     }
 
-    int ret = decompress_fd(fdi, fdo);
+    int ret = libreport_decompress_fd(fdi, fdo);
     close(fdi);
     if (uid != (uid_t)-1L)
     {
@@ -322,8 +320,8 @@ decompress_file_ext_at(const char *path_in, int dir_fd, const char *path_out, mo
     return ret;
 }
 
-int decompress_file(const char *path_in, const char *path_out, mode_t mode_out)
+int libreport_decompress_file(const char *path_in, const char *path_out, mode_t mode_out)
 {
-    return decompress_file_ext_at(path_in, AT_FDCWD, path_out, mode_out, -1, -1,
+    return libreport_decompress_file_ext_at(path_in, AT_FDCWD, path_out, mode_out, -1, -1,
             O_RDONLY, O_WRONLY | O_CREAT | O_EXCL | O_TRUNC);
 }

--- a/src/lib/concat_path_file.c
+++ b/src/lib/concat_path_file.c
@@ -24,17 +24,17 @@
  * If path is NULL, it is assumed to be "/".
  * filename should not be NULL.
  */
-char *concat_path_file(const char *path, const char *filename)
+char *libreport_concat_path_file(const char *path, const char *filename)
 {
 	if (!path)
 		path = "";
 	const char *end = path + strlen(path);
 	while (*filename == '/')
 		filename++;
-	return xasprintf("%s%s%s", path, (end != path && end[-1] != '/' ? "/" : ""), filename);
+	return libreport_xasprintf("%s%s%s", path, (end != path && end[-1] != '/' ? "/" : ""), filename);
 }
 
-char *concat_path_basename(const char *path, const char *filename)
+char *libreport_concat_path_basename(const char *path, const char *filename)
 {
     char *abspath = realpath(filename, NULL);
     char *base = strrchr((abspath ? abspath : filename), '/');
@@ -50,15 +50,15 @@ char *concat_path_basename(const char *path, const char *filename)
     }
     else
     {
-        sprintf(buf, "tmp-%s-%lu", iso_date_string(NULL), (long)getpid());
+        sprintf(buf, "tmp-%s-%lu", libreport_iso_date_string(NULL), (long)getpid());
         base = buf;
     }
-    char *name = concat_path_file(path, base);
+    char *name = libreport_concat_path_file(path, base);
     free(abspath);
     return name;
 }
 
-bool str_is_correct_filename(const char *str)
+bool libreport_str_is_correct_filename(const char *str)
 {
 #define NOT_PRINTABLE(c) (c < ' ' || c == 0x7f)
 

--- a/src/lib/config_item_info.c
+++ b/src/lib/config_item_info.c
@@ -31,8 +31,8 @@ struct config_item_info
 
 config_item_info_t *new_config_info(const char *name)
 {
-    config_item_info_t *info = (config_item_info_t *)xzalloc(sizeof(*info));
-    info->name = xstrdup(name);
+    config_item_info_t *info = (config_item_info_t *)libreport_xzalloc(sizeof(*info));
+    info->name = libreport_xstrdup(name);
     return info;
 }
 
@@ -52,19 +52,19 @@ void free_config_info(config_item_info_t *info)
 void ci_set_screen_name(config_item_info_t *ci, const char *screen_name)
 {
     free(ci->screen_name);
-    ci->screen_name = xstrdup(screen_name);
+    ci->screen_name = libreport_xstrdup(screen_name);
 }
 
 void ci_set_description(config_item_info_t *ci, const char *description)
 {
     free(ci->description);
-    ci->description = xstrdup(description);
+    ci->description = libreport_xstrdup(description);
 }
 
 void ci_set_long_desc(config_item_info_t *ci, const char *long_description)
 {
     free(ci->long_desc);
-    ci->long_desc = xstrdup(long_description);
+    ci->long_desc = libreport_xstrdup(long_description);
 }
 
 const char *ci_get_screen_name(config_item_info_t *ci)

--- a/src/lib/configuration_files.c
+++ b/src/lib/configuration_files.c
@@ -300,7 +300,7 @@ bool libreport_load_conf_file(const char *path, map_string_t *settings, bool ski
         log_info("Loaded option '%s' = '%s'", option, value);
 
         if (!skipKeysWithoutValue || value[0] != '\0')
-            replace_map_string_item(settings, libreport_xstrdup(option), libreport_xstrdup(value));
+            libreport_replace_map_string_item(settings, libreport_xstrdup(option), libreport_xstrdup(value));
 
         free(matches[i]);
     }
@@ -417,8 +417,8 @@ bool libreport_save_conf_file(const char *path, map_string_t *settings)
     const char *name = NULL;
     const char *value = NULL;
     map_string_iter_t iter;
-    init_map_string_iter(&iter, settings);
-    while (next_map_string_iter(&iter, &name, &value))
+    libreport_init_map_string_iter(&iter, settings);
+    while (libreport_next_map_string_iter(&iter, &name, &value))
     {
         char *aug_path = libreport_xasprintf("/files%s/%s", real_path, name);
         const int ret = aug_set(aug, aug_path, value);

--- a/src/lib/copy_file_recursive.c
+++ b/src/lib/copy_file_recursive.c
@@ -101,7 +101,7 @@ static int report_copy_gfile_recursive(GFile *source, GFile *destination)
     return 0;
 }
 
-int copy_file_recursive(const char *source, const char *dest)
+int libreport_copy_file_recursive(const char *source, const char *dest)
 {
     g_autoptr(GFile) source_file = NULL;
     g_autoptr(GFile) destination_file = NULL;

--- a/src/lib/create_dump_dir.c
+++ b/src/lib/create_dump_dir.c
@@ -28,7 +28,7 @@ static uid_t parse_uid(const char *uid_str)
 
     uid_t uid = (uid_t)-1;
 
-    if (try_atou(uid_str, &uid) != 0)
+    if (libreport_try_atou(uid_str, &uid) != 0)
         error_msg(_("uid value is not valid: '%s'"), uid_str);
 
     return uid;
@@ -36,7 +36,7 @@ static uid_t parse_uid(const char *uid_str)
 
 static struct dump_dir *try_dd_create(const char *base_dir_name, const char *dir_name, uid_t uid)
 {
-    char *path = concat_path_file(base_dir_name, dir_name);
+    char *path = libreport_concat_path_file(base_dir_name, dir_name);
     struct dump_dir *dd = dd_create(path, uid, DEFAULT_DUMP_DIR_MODE);
     free(path);
     return dd;
@@ -46,7 +46,7 @@ struct dump_dir *create_dump_dir_ext(const char *base_dir_name, const char *type
 {
     INITIALIZE_LIBREPORT();
 
-    if (!str_is_correct_filename(type))
+    if (!libreport_str_is_correct_filename(type))
     {
         error_msg(_("'%s' is not correct file name"), FILENAME_TYPE);
         return NULL;
@@ -59,7 +59,7 @@ struct dump_dir *create_dump_dir_ext(const char *base_dir_name, const char *type
         return NULL;
     }
 
-    char *problem_id = xasprintf("%s-%s.%ld-%lu"NEW_PD_SUFFIX, type, iso_date_string(&(tv.tv_sec)), (long)tv.tv_usec, (long)pid);
+    char *problem_id = libreport_xasprintf("%s-%s.%ld-%lu"NEW_PD_SUFFIX, type, libreport_iso_date_string(&(tv.tv_sec)), (long)tv.tv_usec, (long)pid);
 
     log_info("Saving to %s/%s with uid %d", base_dir_name, problem_id, uid);
 
@@ -76,7 +76,7 @@ struct dump_dir *create_dump_dir_ext(const char *base_dir_name, const char *type
             char *home = getenv("HOME");
             if (home && home[0])
             {
-                home = concat_path_file(home, "tmp");
+                home = libreport_concat_path_file(home, "tmp");
                 /*mkdir(home, 0777); - do we want this? */
                 dd = try_dd_create(home, problem_id, uid);
                 free(home);
@@ -141,7 +141,7 @@ struct dump_dir *create_dump_dir_ext(const char *base_dir_name, const char *type
     free(type_str);
 
     problem_id[strlen(problem_id) - strlen(NEW_PD_SUFFIX)] = '\0';
-    char* new_path = concat_path_file(base_dir_name, problem_id);
+    char* new_path = libreport_concat_path_file(base_dir_name, problem_id);
     log_info("Renaming from '%s' to '%s'", dd->dd_dirname, new_path);
     dd_rename(dd, new_path);
     free(new_path);
@@ -166,7 +166,7 @@ int save_problem_data_in_dump_dir(struct dump_dir *dd, problem_data_t *problem_d
     g_hash_table_iter_init(&iter, problem_data);
     while (g_hash_table_iter_next(&iter, (void**)&name, (void**)&value))
     {
-        if (!str_is_correct_filename(name))
+        if (!libreport_str_is_correct_filename(name))
         {
             error_msg("Problem data field name contains disallowed chars: '%s'", name);
             continue;

--- a/src/lib/curl.c
+++ b/src/lib/curl.c
@@ -689,13 +689,13 @@ char *upload_file_ext(post_state_t *state, const char *url, const char *filename
         {
             char *msg = xasprintf(_("Please enter user name for '%s//%s':"), scheme, hostname);
             free(username);
-            username = ask(msg);
+            username = libreport_ask(msg);
             free(msg);
             if (username != NULL && username[0] != '\0')
             {
                 msg = xasprintf(_("Please enter password for '%s//%s@%s':"), scheme, username, hostname);
                 free(password);
-                password = ask_password(msg);
+                password = libreport_ask_password(msg);
                 free(msg);
                 /* What about empty password? */
                 if (password != NULL && password[0] != '\0')

--- a/src/lib/curl.c
+++ b/src/lib/curl.c
@@ -593,16 +593,16 @@ post(post_state_t *state,
 /* Unlike post_file(),
  * this function will use PUT, not POST if url is "http(s)://..."
  */
-char *upload_file(const char *url, const char *filename)
+char *libreport_upload_file(const char *url, const char *filename)
 {
     post_state_t *state = new_post_state(POST_WANT_ERROR_MSG);
-    char *retval = upload_file_ext(state, url, filename, UPLOAD_FILE_NOFLAGS);
+    char *retval = libreport_upload_file_ext(state, url, filename, UPLOAD_FILE_NOFLAGS);
     free_post_state(state);
 
     return retval;
 }
 
-char *upload_file_ext(post_state_t *state, const char *url, const char *filename, int flags)
+char *libreport_upload_file_ext(post_state_t *state, const char *url, const char *filename, int flags)
 {
     /* we don't want to print the whole url as it may contain password
      * rhbz#856960

--- a/src/lib/dump_dir.c
+++ b/src/lib/dump_dir.c
@@ -2139,51 +2139,51 @@ int dd_get_next_file(struct dump_dir *dd, char **short_name, char **full_name)
 
 /* reported_to handling */
 
-void add_reported_to(struct dump_dir *dd, const char *line)
+void libreport_add_reported_to(struct dump_dir *dd, const char *line)
 {
     if (!dd->locked)
         error_msg_and_die("dump_dir is not opened"); /* bug */
 
     char *reported_to = dd_load_text_ext(dd, FILENAME_REPORTED_TO, DD_FAIL_QUIETLY_ENOENT | DD_LOAD_TEXT_RETURN_NULL_ON_FAILURE);
-    if (add_reported_to_data(&reported_to, line))
+    if (libreport_add_reported_to_data(&reported_to, line))
         dd_save_text(dd, FILENAME_REPORTED_TO, reported_to);
 
     free(reported_to);
 }
 
-void add_reported_to_entry(struct dump_dir *dd, struct report_result *result)
+void libreport_add_reported_to_entry(struct dump_dir *dd, struct report_result *result)
 {
     if (!dd->locked)
         error_msg_and_die("dump_dir is not opened"); /* bug */
 
     char *reported_to = dd_load_text_ext(dd, FILENAME_REPORTED_TO, DD_FAIL_QUIETLY_ENOENT | DD_LOAD_TEXT_RETURN_NULL_ON_FAILURE);
-    if (add_reported_to_entry_data(&reported_to, result))
+    if (libreport_add_reported_to_entry_data(&reported_to, result))
         dd_save_text(dd, FILENAME_REPORTED_TO, reported_to);
 
     free(reported_to);
 }
 
-report_result_t *find_in_reported_to(struct dump_dir *dd, const char *report_label)
+report_result_t *libreport_find_in_reported_to(struct dump_dir *dd, const char *report_label)
 {
     char *reported_to = dd_load_text_ext(dd, FILENAME_REPORTED_TO,
                 DD_FAIL_QUIETLY_ENOENT | DD_LOAD_TEXT_RETURN_NULL_ON_FAILURE);
     if (!reported_to)
         return NULL;
 
-    report_result_t *result = find_in_reported_to_data(reported_to, report_label);
+    report_result_t *result = libreport_find_in_reported_to_data(reported_to, report_label);
 
     free(reported_to);
     return result;
 }
 
-GList *read_entire_reported_to(struct dump_dir *dd)
+GList *libreport_read_entire_reported_to(struct dump_dir *dd)
 {
     char *reported_to = dd_load_text_ext(dd, FILENAME_REPORTED_TO,
                 DD_FAIL_QUIETLY_ENOENT | DD_LOAD_TEXT_RETURN_NULL_ON_FAILURE);
     if (!reported_to)
         return NULL;
 
-    GList *result = read_entire_reported_to_data(reported_to);
+    GList *result = libreport_read_entire_reported_to_data(reported_to);
 
     free(reported_to);
     return result;

--- a/src/lib/encbase64.c
+++ b/src/lib/encbase64.c
@@ -18,7 +18,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#include "internal_libreport.h" /* xmalloc */
+#include "internal_libreport.h" /* libreport_xmalloc */
 
 /* Conversion table for base 64 */
 static const char tbl_base64[65 /*+ 2*/] = {
@@ -85,9 +85,9 @@ static void encode_64bit(char *p, const void *src, int length, const char *tbl)
 	}
 }
 
-char *encode_base64(const void *src, int length)
+char *libreport_encode_base64(const void *src, int length)
 {
-	char *dst = (char *)xmalloc(4 * ((length + 2) / 3) + 1);
+	char *dst = (char *)libreport_xmalloc(4 * ((length + 2) / 3) + 1);
 	encode_64bit(dst, src, length, tbl_base64);
 	return dst;
 }

--- a/src/lib/event_config.c
+++ b/src/lib/event_config.c
@@ -195,7 +195,7 @@ static void load_config_files(const char *dir_path)
         if (new_config)
             event_config = new_event_config(filename);
 
-        map_string_t *keys_and_values = new_map_string();
+        map_string_t *keys_and_values = libreport_new_map_string();
 
         libreport_load_conf_file(fullpath, keys_and_values, /*skipKeysWithoutValue:*/ false);
 
@@ -203,8 +203,8 @@ static void load_config_files(const char *dir_path)
         map_string_iter_t iter;
         const char *name;
         const char *value;
-        init_map_string_iter(&iter, keys_and_values);
-        while (next_map_string_iter(&iter, &name, &value))
+        libreport_init_map_string_iter(&iter, keys_and_values);
+        while (libreport_next_map_string_iter(&iter, &name, &value))
         {
             event_option_t *opt;
             GList *elem = g_list_find_custom(event_config->options, name,
@@ -226,7 +226,7 @@ static void load_config_files(const char *dir_path)
                 event_config->options = g_list_append(event_config->options, opt);
         }
 
-        free_map_string(keys_and_values);
+        libreport_free_map_string(keys_and_values);
 
         if (new_config)
             g_hash_table_replace(g_event_config_list, libreport_xstrdup(ec_get_name(event_config)), event_config);

--- a/src/lib/event_xml_parser.c
+++ b/src/lib/event_xml_parser.c
@@ -96,7 +96,7 @@ static char *get_element_lang(struct my_parse_data *parse_data, const gchar **at
             if (strcmp(att_values[i], parse_data->cur_locale) == 0)
             {
                 log_debug("found translation for: %s", parse_data->cur_locale);
-                return xstrdup(att_values[i]);
+                return libreport_xstrdup(att_values[i]);
             }
 
             /* try to match shorter locale
@@ -106,13 +106,13 @@ static char *get_element_lang(struct my_parse_data *parse_data, const gchar **at
              && strncmp(att_values[i], parse_data->cur_locale, short_locale_end - parse_data->cur_locale) == 0
             ) {
                 log_debug("found translation for shortlocale: %s", parse_data->cur_locale);
-                return xstrndup(att_values[i], short_locale_end - parse_data->cur_locale);
+                return libreport_xstrndup(att_values[i], short_locale_end - parse_data->cur_locale);
             }
         }
     }
     /* if the element has no attribute then it's a default non-localized value */
     if (i == 0)
-        return xstrdup("");
+        return libreport_xstrdup("");
     /* if the element is in different language than the current locale */
     return NULL;
 }
@@ -138,7 +138,7 @@ static void consume_cur_option(struct my_parse_data *parse_data)
      * (strcmp would segfault, etc), so provide invented name:
      */
     if (!opt->eo_name)
-        opt->eo_name = xasprintf("%u", (unsigned)g_list_length(event_config->values->options));
+        opt->eo_name = libreport_xasprintf("%u", (unsigned)g_list_length(event_config->values->options));
 
     GList *elem = g_list_find_custom(event_config->values->options, opt->eo_name, cmp_event_option_name_with_string);
     if (elem)
@@ -200,7 +200,7 @@ static void start_element(GMarkupParseContext *context,
             if (strcmp(attribute_names[i], "name") == 0)
             {
                 free(opt->eo_name);
-                opt->eo_name = xstrdup(attribute_values[i]);
+                opt->eo_name = libreport_xstrdup(attribute_values[i]);
             }
             else if (strcmp(attribute_names[i], "type") == 0)
             {
@@ -225,7 +225,7 @@ static void start_element(GMarkupParseContext *context,
         }
 
         GList *head = parse_data->event_config.values->ec_imported_event_names;
-        parse_data->event_config.values->ec_imported_event_names = g_list_append(head, xstrdup(attribute_values[0]));
+        parse_data->event_config.values->ec_imported_event_names = g_list_append(head, libreport_xstrdup(attribute_values[0]));
     }
     else
     if (strcmp(element_name, LABEL_ELEMENT) == 0
@@ -249,7 +249,7 @@ static void start_element(GMarkupParseContext *context,
             return;
         }
 
-        parse_data->event_config.values->ec_restricted_access_option = xstrdup(attribute_values[0]);
+        parse_data->event_config.values->ec_restricted_access_option = libreport_xstrdup(attribute_values[0]);
     }
 }
 
@@ -290,7 +290,7 @@ static void text(GMarkupParseContext *context,
     event_config_t *ui = parse_data->event_config.values;
 
     const gchar *inner_element = g_markup_parse_context_get_element(context);
-    char *text_copy = xstrndup(text, text_len);
+    char *text_copy = libreport_xstrndup(text, text_len);
     event_option_t *opt = parse_data->cur_option.values;
     if (opt)
     {
@@ -356,7 +356,7 @@ static void text(GMarkupParseContext *context,
         else if (strcmp(inner_element, ALLOW_EMPTY_ELEMENT) == 0)
         {
             log_info("allow-empty:'%s'", text_copy);
-            opt->eo_allow_empty = string_to_bool(text_copy);
+            opt->eo_allow_empty = libreport_string_to_bool(text_copy);
         }
         /*
         if (strcmp(inner_element, DESCRIPTION_ELEMENT) == 0)
@@ -485,7 +485,7 @@ static void text(GMarkupParseContext *context,
         }
         else if (strcmp(inner_element, EXCL_BINARY_ELEMENT) == 0)
         {
-            ui->ec_exclude_binary_items = string_to_bool(text_copy);
+            ui->ec_exclude_binary_items = libreport_string_to_bool(text_copy);
         }
         else if (strcmp(inner_element, MINIMAL_RATING_ELEMENT) == 0)
         {
@@ -500,19 +500,19 @@ static void text(GMarkupParseContext *context,
         }
         else if (strcmp(inner_element, GUI_REVIEW_ELEMENTS) == 0)
         {
-            ui->ec_skip_review = !string_to_bool(text_copy);
+            ui->ec_skip_review = !libreport_string_to_bool(text_copy);
         }
         else if (strcmp(inner_element, SENDING_SENSITIVE_DATA_ELEMENT) == 0)
         {
-            ui->ec_sending_sensitive_data = string_to_bool(text_copy);
+            ui->ec_sending_sensitive_data = libreport_string_to_bool(text_copy);
         }
         else if (strcmp(inner_element, SUPPORTS_RESTRICTED_ACCESS_ELEMENT) == 0)
         {
-            ui->ec_supports_restricted_access = string_to_bool(text_copy);
+            ui->ec_supports_restricted_access = libreport_string_to_bool(text_copy);
         }
         else if (strcmp(inner_element, REQUIRES_DETAILS) == 0)
         {
-            ui->ec_requires_details = string_to_bool(text_copy);
+            ui->ec_requires_details = libreport_string_to_bool(text_copy);
         }
     }
     free(text_copy);
@@ -555,7 +555,7 @@ void load_event_description_from_file(event_config_t *event_config, const char* 
         NULL,
         NULL
     };
-    parse_data.cur_locale = xstrdup(setlocale(LC_ALL, NULL));
+    parse_data.cur_locale = libreport_xstrdup(setlocale(LC_ALL, NULL));
     strchrnul(parse_data.cur_locale, '.')[0] = '\0';
 
     GMarkupParser parser;

--- a/src/lib/file_list.c
+++ b/src/lib/file_list.c
@@ -19,7 +19,7 @@
 
 #include "internal_libreport.h"
 
-GList *get_file_list(const char *path, const char *ext_filter)
+GList *libreport_get_file_list(const char *path, const char *ext_filter)
 {
     /* Load .$ext files */
     DIR *dir;
@@ -34,7 +34,7 @@ GList *get_file_list(const char *path, const char *ext_filter)
         /* skip . and .. */
         if (strcmp(dent->d_name, ".") == 0 || strcmp(dent->d_name, "..") == 0)
             continue;
-        char *fullname = concat_path_file(path, dent->d_name);
+        char *fullname = libreport_concat_path_file(path, dent->d_name);
         char *ext = NULL;
 
         if (ext_filter)
@@ -77,15 +77,15 @@ GList *get_file_list(const char *path, const char *ext_filter)
                 *ext = '\0';
             }
             free(fullname);
-            fullname = concat_path_file(path, target);
-            files = g_list_prepend(files, new_file_obj(fullname, target));
+            fullname = libreport_concat_path_file(path, target);
+            files = g_list_prepend(files, libreport_new_file_obj(fullname, target));
             g_free(link);
             g_free(target);
 
             goto next;
         }
 
-        file_obj_t *file = new_file_obj(fullname, dent->d_name);
+        file_obj_t *file = libreport_new_file_obj(fullname, dent->d_name);
         files = g_list_prepend(files, file);
  next:
         free(fullname);
@@ -95,7 +95,7 @@ GList *get_file_list(const char *path, const char *ext_filter)
     return files;
 }
 
-void free_file_list(GList *filelist)
+void libreport_free_file_list(GList *filelist)
 {
-    g_list_free_full(filelist, (GDestroyNotify)free_file_obj);
+    g_list_free_full(filelist, (GDestroyNotify)libreport_free_file_obj);
 }

--- a/src/lib/file_obj.c
+++ b/src/lib/file_obj.c
@@ -19,15 +19,15 @@
 
 #include "internal_libreport.h"
 
-file_obj_t *new_file_obj(const char* fullpath, const char* filename)
+file_obj_t *libreport_new_file_obj(const char* fullpath, const char* filename)
 {
-    file_obj_t *file = xmalloc(sizeof(file_obj_t));
-    file->fullpath = xstrdup(fullpath);
-    file->filename = xstrdup(filename);
+    file_obj_t *file = libreport_xmalloc(sizeof(file_obj_t));
+    file->fullpath = libreport_xstrdup(fullpath);
+    file->filename = libreport_xstrdup(filename);
     return file;
 }
 
-void free_file_obj(file_obj_t *f)
+void libreport_free_file_obj(file_obj_t *f)
 {
     if (f == NULL)
         return;

--- a/src/lib/glib_support.c
+++ b/src/lib/glib_support.c
@@ -19,7 +19,7 @@
 #include "internal_libreport.h"
 #include <glib-object.h>
 
-void glib_init(void)
+void libreport_glib_init(void)
 {
     /* This is not necessary but is IMO is good to know that:
      *
@@ -35,7 +35,7 @@ void glib_init(void)
      */
 
     /* Help with mysterious bug */
-    if (g_verbose > 0)
+    if (libreport_g_verbose > 0)
     {
         const gchar *version_mismatch = glib_check_version(GLIB_MAJOR_VERSION,
                                                            GLIB_MINOR_VERSION,
@@ -54,7 +54,7 @@ void glib_init(void)
  * @param delim a set of bytes that delimit the tokens in the parsed string
  * @returns GList or null if the list is empty
  */
-GList *parse_delimited_list(const char *string, const char *delimiter)
+GList *libreport_parse_delimited_list(const char *string, const char *delimiter)
 {
     char **substrings;
     GList *list = NULL;
@@ -78,7 +78,7 @@ GList *parse_delimited_list(const char *string, const char *delimiter)
     return g_list_reverse(list);
 }
 
-void list_free_with_free(GList *list)
+void libreport_list_free_with_free(GList *list)
 {
     GList *li;
     for (li = list; li; li = g_list_next(li))

--- a/src/lib/global_configuration.c
+++ b/src/lib/global_configuration.c
@@ -55,7 +55,7 @@ bool libreport_load_global_configuration_from_dirs(const char *dirs[], int dir_f
 {
     if (s_global_settings == NULL)
     {
-        s_global_settings = new_map_string();
+        s_global_settings = libreport_new_map_string();
 
         bool ret = libreport_load_conf_file_from_dirs_ext("libreport.conf", dirs, dir_flags, s_global_settings,
                                                /*don't skip without value*/ false);
@@ -67,9 +67,9 @@ bool libreport_load_global_configuration_from_dirs(const char *dirs[], int dir_f
         }
 
         map_string_iter_t iter;
-        init_map_string_iter(&iter, s_global_settings);
+        libreport_init_map_string_iter(&iter, s_global_settings);
         const char *key, *value;
-        while(next_map_string_iter(&iter, &key, &value))
+        while(libreport_next_map_string_iter(&iter, &key, &value))
         {
             /* Die to avoid security leaks in case where someone made a typo in a option name */
             if (!libreport_is_in_string_list(key, s_recognized_options))
@@ -90,7 +90,7 @@ void libreport_free_global_configuration(void)
 {
     if (s_global_settings != NULL)
     {
-        free_map_string(s_global_settings);
+        libreport_free_map_string(s_global_settings);
         s_global_settings = NULL;
     }
 }
@@ -119,19 +119,19 @@ string_vector_ptr_t libreport_get_global_always_excluded_elements(void)
     assert_global_configuration_initialized();
 
     char *env_exclude = getenv("EXCLUDE_FROM_REPORT");
-    const char *gc_exclude = get_map_string_item_or_NULL(s_global_settings, OPT_NAME_EXCLUDED_ELEMENTS);
+    const char *gc_exclude = libreport_get_map_string_item_or_NULL(s_global_settings, OPT_NAME_EXCLUDED_ELEMENTS);
 
     if (env_exclude != NULL && gc_exclude == NULL)
-        return string_vector_new_from_string(env_exclude);
+        return libreport_string_vector_new_from_string(env_exclude);
 
     if (env_exclude == NULL && gc_exclude != NULL)
-        return string_vector_new_from_string(gc_exclude);
+        return libreport_string_vector_new_from_string(gc_exclude);
 
     if (env_exclude == NULL && gc_exclude == NULL)
-        return string_vector_new_from_string(NULL);
+        return libreport_string_vector_new_from_string(NULL);
 
     char *joined_exclude = libreport_xasprintf("%s, %s", env_exclude, gc_exclude);
-    string_vector_ptr_t ret = string_vector_new_from_string(joined_exclude);
+    string_vector_ptr_t ret = libreport_string_vector_new_from_string(joined_exclude);
     free(joined_exclude);
 
     return ret;

--- a/src/lib/global_configuration.c
+++ b/src/lib/global_configuration.c
@@ -31,7 +31,7 @@ static const char *const s_recognized_options[] = {
 
 static map_string_t *s_global_settings;
 
-bool load_global_configuration(void)
+bool libreport_load_global_configuration(void)
 {
     static const char *dirs[] = {
         CONF_DIR,
@@ -48,10 +48,10 @@ bool load_global_configuration(void)
     if (dirs[1] == NULL)
         dirs[1] = get_user_conf_base_dir();
 
-    return load_global_configuration_from_dirs(dirs, dir_flags);
+    return libreport_load_global_configuration_from_dirs(dirs, dir_flags);
 }
 
-bool load_global_configuration_from_dirs(const char *dirs[], int dir_flags[])
+bool libreport_load_global_configuration_from_dirs(const char *dirs[], int dir_flags[])
 {
     if (s_global_settings == NULL)
     {
@@ -62,7 +62,7 @@ bool load_global_configuration_from_dirs(const char *dirs[], int dir_flags[])
         if (!ret)
         {
             error_msg("Failed to load libreport global configuration");
-            free_global_configuration();
+            libreport_free_global_configuration();
             return false;
         }
 
@@ -75,7 +75,7 @@ bool load_global_configuration_from_dirs(const char *dirs[], int dir_flags[])
             if (!is_in_string_list(key, s_recognized_options))
             {
                 error_msg("libreport global configuration contains unrecognized option : '%s'", key);
-                free_global_configuration();
+                libreport_free_global_configuration();
                 return false;
             }
         }
@@ -86,7 +86,7 @@ bool load_global_configuration_from_dirs(const char *dirs[], int dir_flags[])
     return true;
 }
 
-void free_global_configuration(void)
+void libreport_free_global_configuration(void)
 {
     if (s_global_settings != NULL)
     {
@@ -114,7 +114,7 @@ static void assert_global_configuration_initialized(void)
     opt;\
     })
 
-string_vector_ptr_t get_global_always_excluded_elements(void)
+string_vector_ptr_t libreport_get_global_always_excluded_elements(void)
 {
     assert_global_configuration_initialized();
 
@@ -137,7 +137,7 @@ string_vector_ptr_t get_global_always_excluded_elements(void)
     return ret;
 }
 
-bool get_global_create_private_ticket(void)
+bool libreport_get_global_create_private_ticket(void)
 {
     assert_global_configuration_initialized();
 
@@ -149,7 +149,7 @@ bool get_global_create_private_ticket(void)
     return string_to_bool(env_create_private);
 }
 
-void set_global_create_private_ticket(bool enabled, int flags/*unused - persistent*/)
+void libreport_set_global_create_private_ticket(bool enabled, int flags/*unused - persistent*/)
 {
     assert_global_configuration_initialized();
 
@@ -159,7 +159,7 @@ void set_global_create_private_ticket(bool enabled, int flags/*unused - persiste
         safe_unsetenv(CREATE_PRIVATE_TICKET);
 }
 
-bool get_global_stop_on_not_reportable(void)
+bool libreport_get_global_stop_on_not_reportable(void)
 {
     assert_global_configuration_initialized();
 
@@ -171,7 +171,7 @@ bool get_global_stop_on_not_reportable(void)
     return string_to_bool(env_create_private);
 }
 
-void set_global_stop_on_not_reportable(bool enabled, int flags/*unused - persistent*/)
+void libreport_set_global_stop_on_not_reportable(bool enabled, int flags/*unused - persistent*/)
 {
     assert_global_configuration_initialized();
 

--- a/src/lib/global_configuration.c
+++ b/src/lib/global_configuration.c
@@ -46,7 +46,7 @@ bool libreport_load_global_configuration(void)
     };
 
     if (dirs[1] == NULL)
-        dirs[1] = get_user_conf_base_dir();
+        dirs[1] = libreport_get_user_conf_base_dir();
 
     return libreport_load_global_configuration_from_dirs(dirs, dir_flags);
 }
@@ -57,7 +57,7 @@ bool libreport_load_global_configuration_from_dirs(const char *dirs[], int dir_f
     {
         s_global_settings = new_map_string();
 
-        bool ret = load_conf_file_from_dirs_ext("libreport.conf", dirs, dir_flags, s_global_settings,
+        bool ret = libreport_load_conf_file_from_dirs_ext("libreport.conf", dirs, dir_flags, s_global_settings,
                                                /*don't skip without value*/ false);
         if (!ret)
         {
@@ -72,7 +72,7 @@ bool libreport_load_global_configuration_from_dirs(const char *dirs[], int dir_f
         while(next_map_string_iter(&iter, &key, &value))
         {
             /* Die to avoid security leaks in case where someone made a typo in a option name */
-            if (!is_in_string_list(key, s_recognized_options))
+            if (!libreport_is_in_string_list(key, s_recognized_options))
             {
                 error_msg("libreport global configuration contains unrecognized option : '%s'", key);
                 libreport_free_global_configuration();
@@ -130,7 +130,7 @@ string_vector_ptr_t libreport_get_global_always_excluded_elements(void)
     if (env_exclude == NULL && gc_exclude == NULL)
         return string_vector_new_from_string(NULL);
 
-    char *joined_exclude = xasprintf("%s, %s", env_exclude, gc_exclude);
+    char *joined_exclude = libreport_xasprintf("%s, %s", env_exclude, gc_exclude);
     string_vector_ptr_t ret = string_vector_new_from_string(joined_exclude);
     free(joined_exclude);
 
@@ -146,7 +146,7 @@ bool libreport_get_global_create_private_ticket(void)
     if (env_create_private == NULL)
         return false;
 
-    return string_to_bool(env_create_private);
+    return libreport_string_to_bool(env_create_private);
 }
 
 void libreport_set_global_create_private_ticket(bool enabled, int flags/*unused - persistent*/)
@@ -154,9 +154,9 @@ void libreport_set_global_create_private_ticket(bool enabled, int flags/*unused 
     assert_global_configuration_initialized();
 
     if (enabled)
-        xsetenv(CREATE_PRIVATE_TICKET, "1");
+        libreport_xsetenv(CREATE_PRIVATE_TICKET, "1");
     else
-        safe_unsetenv(CREATE_PRIVATE_TICKET);
+        libreport_safe_unsetenv(CREATE_PRIVATE_TICKET);
 }
 
 bool libreport_get_global_stop_on_not_reportable(void)
@@ -168,7 +168,7 @@ bool libreport_get_global_stop_on_not_reportable(void)
     if (env_create_private == NULL)
         return true;
 
-    return string_to_bool(env_create_private);
+    return libreport_string_to_bool(env_create_private);
 }
 
 void libreport_set_global_stop_on_not_reportable(bool enabled, int flags/*unused - persistent*/)
@@ -176,7 +176,7 @@ void libreport_set_global_stop_on_not_reportable(bool enabled, int flags/*unused
     assert_global_configuration_initialized();
 
     if (enabled)
-        xsetenv(STOP_ON_NOT_REPORTABLE, "1");
+        libreport_xsetenv(STOP_ON_NOT_REPORTABLE, "1");
     else
-        xsetenv(STOP_ON_NOT_REPORTABLE, "0");
+        libreport_xsetenv(STOP_ON_NOT_REPORTABLE, "0");
 }

--- a/src/lib/is_in_comma_separated_list.c
+++ b/src/lib/is_in_comma_separated_list.c
@@ -19,7 +19,7 @@
 #include <fnmatch.h>
 #include "internal_libreport.h"
 
-bool is_in_comma_separated_list(const char *value, const char *list)
+bool libreport_is_in_comma_separated_list(const char *value, const char *list)
 {
     if (!list)
         return false;
@@ -36,14 +36,14 @@ bool is_in_comma_separated_list(const char *value, const char *list)
     return false;
 }
 
-bool is_in_comma_separated_list_of_glob_patterns(const char *value, const char *list)
+bool libreport_is_in_comma_separated_list_of_glob_patterns(const char *value, const char *list)
 {
     if (!list)
         return false;
     while (*list)
     {
         const char *comma = strchrnul(list, ',');
-        char *pattern = xstrndup(list, comma - list);
+        char *pattern = libreport_xstrndup(list, comma - list);
         int match = !fnmatch(pattern, value, /*flags:*/ 0);
         free(pattern);
         if (match)

--- a/src/lib/is_in_string_list.c
+++ b/src/lib/is_in_string_list.c
@@ -18,7 +18,7 @@
 */
 #include "internal_libreport.h"
 
-bool is_in_string_list(const char *name, const char *const *v)
+bool libreport_is_in_string_list(const char *name, const char *const *v)
 {
     while (*v)
     {
@@ -29,7 +29,7 @@ bool is_in_string_list(const char *name, const char *const *v)
     return false;
 }
 
-int index_of_string_in_list(const char *name, const char *const *v)
+int libreport_index_of_string_in_list(const char *name, const char *const *v)
 {
     for(int i = 0; v[i]; ++i)
     {

--- a/src/lib/iso_date_string.c
+++ b/src/lib/iso_date_string.c
@@ -21,7 +21,7 @@
 
 #define LIBREPORT_ISO_DATE_STRING_FORMAT "%Y-%m-%d-%H:%M:%S"
 
-char *iso_date_string(const time_t *pt)
+char *libreport_iso_date_string(const time_t *pt)
 {
     static char buf[sizeof(LIBREPORT_ISO_DATE_STRING_SAMPLE) + 4];
 
@@ -40,7 +40,7 @@ char *iso_date_string(const time_t *pt)
     return buf;
 }
 
-int iso_date_string_parse(const char *date, time_t *pt)
+int libreport_iso_date_string_parse(const char *date, time_t *pt)
 {
     struct tm local;
     const char *r = strptime(date, LIBREPORT_ISO_DATE_STRING_FORMAT, &local);

--- a/src/lib/make_descr.c
+++ b/src/lib/make_descr.c
@@ -152,7 +152,7 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
             const char *reported_to = problem_data_get_content_or_NULL(problem_data, FILENAME_REPORTED_TO);
             if (reported_to != NULL)
             {
-                GList *reports = entire_reported_to_data(reported_to);
+                GList *reports = libreport_read_entire_reported_to_data(reported_to);
 
                 /* The value part begins on 17th column */
                 /*                        0123456789ABCDEF*/

--- a/src/lib/make_descr.c
+++ b/src/lib/make_descr.c
@@ -20,7 +20,7 @@
 
 static bool rejected_name(const char *name, char **v, int flags)
 {
-    bool r = is_in_string_list(name, (const char *const *)v);
+    bool r = libreport_is_in_string_list(name, (const char *const *)v);
     if (flags & MAKEDESC_WHITELIST)
          r = !r;
     return r;
@@ -33,19 +33,19 @@ char *make_description_item_multiline(const char *name, const char *content)
     if (!eol)
         return NULL;
 
-    struct strbuf *buf = strbuf_new();
-    strbuf_append_str(buf, name);
-    strbuf_append_str(buf, ":\n");
+    struct strbuf *buf = libreport_strbuf_new();
+    libreport_strbuf_append_str(buf, name);
+    libreport_strbuf_append_str(buf, ":\n");
     for (;;)
     {
         eol = strchrnul(content, '\n');
-        strbuf_append_strf(buf, ":%.*s\n", (int)(eol - content), content);
+        libreport_strbuf_append_strf(buf, ":%.*s\n", (int)(eol - content), content);
         if (*eol == '\0' || eol[1] == '\0')
             break;
         content = eol + 1;
     }
 
-    return strbuf_free_nobuf(buf);
+    return libreport_strbuf_free_nobuf(buf);
 }
 
 static int list_cmp(const char *s1, const char *s2)
@@ -59,8 +59,8 @@ static int list_cmp(const char *s1, const char *s2)
             FILENAME_COUNT     ,
             NULL
     };
-    int s1_index = index_of_string_in_list(s1, list_order);
-    int s2_index = index_of_string_in_list(s2, list_order);
+    int s1_index = libreport_index_of_string_in_list(s1, list_order);
+    int s2_index = libreport_index_of_string_in_list(s2, list_order);
 
     if(s1_index < 0 && s2_index < 0)
         return strcmp(s1, s2);
@@ -74,12 +74,12 @@ static int list_cmp(const char *s1, const char *s2)
     return s1_index - s2_index;
 }
 
-char *make_description(problem_data_t *problem_data, char **names_to_skip,
+char *libreport_make_description(problem_data_t *problem_data, char **names_to_skip,
                        unsigned max_text_size, unsigned desc_flags)
 {
     INITIALIZE_LIBREPORT();
 
-    struct strbuf *buf_dsc = strbuf_new();
+    struct strbuf *buf_dsc = libreport_strbuf_new();
 
     const char *type = problem_data_get_content_or_NULL(problem_data,
                                                             FILENAME_TYPE);
@@ -125,18 +125,18 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
                 const char *crash_func = problem_data_get_content_or_NULL(problem_data,
                                                                           FILENAME_CRASH_FUNCTION);
                 if((done = (bool)crash_func))
-                    strbuf_append_strf(buf_dsc, "%s: %*s%s(): %s\n", key, pad, "", crash_func, output);
+                    libreport_strbuf_append_strf(buf_dsc, "%s: %*s%s(): %s\n", key, pad, "", crash_func, output);
             }
             else if (strcmp(FILENAME_UID, key) == 0)
             {
                 const char *username = problem_data_get_content_or_NULL(problem_data,
                                                                           FILENAME_USERNAME);
                 if((done = (bool)username))
-                    strbuf_append_strf(buf_dsc, "%s: %*s%s (%s)\n", key, pad, "", output, username);
+                    libreport_strbuf_append_strf(buf_dsc, "%s: %*s%s (%s)\n", key, pad, "", output, username);
             }
 
             if (!done)
-                strbuf_append_strf(buf_dsc, "%s: %*s%s\n", key, pad, "", output);
+                libreport_strbuf_append_strf(buf_dsc, "%s: %*s%s\n", key, pad, "", output);
 
             empty = false;
             free(formatted);
@@ -146,7 +146,7 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
     if (desc_flags & MAKEDESC_SHOW_URLS)
     {
         if (problem_data_get_content_or_NULL(problem_data, FILENAME_NOT_REPORTABLE) != NULL)
-            strbuf_append_strf(buf_dsc, "%s%*s%s\n", _("Reported:"), 16 - strlen(_("Reported:")), "" , _("cannot be reported"));
+            libreport_strbuf_append_strf(buf_dsc, "%s%*s%s\n", _("Reported:"), 16 - strlen(_("Reported:")), "" , _("cannot be reported"));
         else
         {
             const char *reported_to = problem_data_get_content_or_NULL(problem_data, FILENAME_REPORTED_TO);
@@ -157,7 +157,7 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
                 /* The value part begins on 17th column */
                 /*                        0123456789ABCDEF*/
                 const char *pad_prefix = "                ";
-                char *first_prefix = xasprintf("%s%*s", _("Reported:"), 16 - strlen(_("Reported:")), "");
+                char *first_prefix = libreport_xasprintf("%s%*s", _("Reported:"), 16 - strlen(_("Reported:")), "");
                 const char *prefix     = first_prefix;
                 for (GList *iter = reports; iter != NULL; iter = g_list_next(iter))
                 {
@@ -168,7 +168,7 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
                     if (url == NULL)
                         continue;
 
-                    strbuf_append_strf(buf_dsc, "%s%s\n", prefix, url);
+                    libreport_strbuf_append_strf(buf_dsc, "%s%s\n", prefix, url);
 
                     g_free(url);
 
@@ -217,7 +217,7 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
              || ((item->flags & CD_FLAG_TXT) && strlen(item->content) > max_text_size)
             ) {
                 if (append_empty_line)
-                    strbuf_append_char(buf_dsc, '\n');
+                    libreport_strbuf_append_char(buf_dsc, '\n');
                 append_empty_line = false;
 
                 unsigned long size = 0;
@@ -228,7 +228,7 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
                  */
                 int pad = 16 - (strlen(key) + 2);
                 if (pad < 0) pad = 0;
-                strbuf_append_strf(buf_dsc,
+                libreport_strbuf_append_strf(buf_dsc,
                         (!stat_err ? "%s: %*s%s file, %lu bytes\n" : "%s: %*s%s file\n"),
                         key,
                         pad, "",
@@ -277,9 +277,9 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
                 if (output)
                 {
                     if (!empty)
-                        strbuf_append_str(buf_dsc, "\n");
+                        libreport_strbuf_append_str(buf_dsc, "\n");
 
-                    strbuf_append_str(buf_dsc, output);
+                    libreport_strbuf_append_str(buf_dsc, output);
                     empty = false;
                     free(output);
                 }
@@ -291,7 +291,7 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
 
     g_list_free(list);
 
-    return strbuf_free_nobuf(buf_dsc);
+    return libreport_strbuf_free_nobuf(buf_dsc);
 }
 
 /* Items we don't want to include to bz / logger */
@@ -314,9 +314,9 @@ static const char *const blacklisted_items[] = {
     NULL
 };
 
-char* make_description_logger(problem_data_t *problem_data, unsigned max_text_size)
+char *libreport_make_description_logger(problem_data_t *problem_data, unsigned max_text_size)
 {
-    return make_description(
+    return libreport_make_description(
                 problem_data,
                 (char**)blacklisted_items,
                 max_text_size,

--- a/src/lib/make_descr.c
+++ b/src/lib/make_descr.c
@@ -152,7 +152,7 @@ char *make_description(problem_data_t *problem_data, char **names_to_skip,
             const char *reported_to = problem_data_get_content_or_NULL(problem_data, FILENAME_REPORTED_TO);
             if (reported_to != NULL)
             {
-                GList *reports = read_entire_reported_to_data(reported_to);
+                GList *reports = entire_reported_to_data(reported_to);
 
                 /* The value part begins on 17th column */
                 /*                        0123456789ABCDEF*/

--- a/src/lib/overlapping_strcpy.c
+++ b/src/lib/overlapping_strcpy.c
@@ -21,7 +21,7 @@
 #include "internal_libreport.h"
 
 /* Like strcpy but can copy overlapping strings. */
-void overlapping_strcpy(char *dst, const char *src)
+void libreport_overlapping_strcpy(char *dst, const char *src)
 {
     /* Cheap optimization for dst == src case -
      * better to have it here than in many callers.

--- a/src/lib/parse_options.c
+++ b/src/lib/parse_options.c
@@ -22,7 +22,7 @@
 #define USAGE_OPTS_WIDTH 30
 #define USAGE_GAP         2
 
-const char *g_progname;
+const char *libreport_g_progname;
 
 const char *abrt_init(char **argv)
 {
@@ -31,32 +31,32 @@ const char *abrt_init(char **argv)
 
     char *env_verbose = getenv("ABRT_VERBOSE");
     if (env_verbose)
-        g_verbose = atoi(env_verbose);
+        libreport_g_verbose = atoi(env_verbose);
 
-    g_progname = strrchr(argv[0], '/');
-    if (g_progname)
-        g_progname++;
+    libreport_g_progname = strrchr(argv[0], '/');
+    if (libreport_g_progname)
+        libreport_g_progname++;
     else
-        g_progname = argv[0];
+        libreport_g_progname = argv[0];
 
     char *pfx = getenv("ABRT_PROG_PREFIX");
-    if (pfx && string_to_bool(pfx))
-        msg_prefix = g_progname;
+    if (pfx && libreport_string_to_bool(pfx))
+        libreport_msg_prefix = libreport_g_progname;
 
-    return g_progname;
+    return libreport_g_progname;
 }
 
-void export_abrt_envvars(int pfx)
+void libreport_export_abrt_envvars(int pfx)
 {
-    putenv(xasprintf("ABRT_VERBOSE=%u", g_verbose));
+    putenv(libreport_xasprintf("ABRT_VERBOSE=%u", libreport_g_verbose));
     if (pfx)
     {
         putenv((char*)"ABRT_PROG_PREFIX=1");
-        msg_prefix = g_progname;
+        libreport_msg_prefix = libreport_g_progname;
     }
 }
 
-void show_usage_and_die(const char *usage, const struct options *opt)
+void libreport_show_usage_and_die(const char *usage, const struct options *opt)
 {
     INITIALIZE_LIBREPORT();
 
@@ -75,7 +75,7 @@ void show_usage_and_die(const char *usage, const struct options *opt)
              * with program name - all other &'s are printed literally.
              */
             if (usage[1] == '\0' || isspace(usage[1]))
-                fputs(g_progname, stderr);
+                fputs(libreport_g_progname, stderr);
             else
                 fputc('&', stderr);
             usage++;
@@ -124,7 +124,7 @@ void show_usage_and_die(const char *usage, const struct options *opt)
         fprintf(stderr, "%*s%s\n", pad + USAGE_GAP, "", opt->help);
     }
     fputc('\n', stderr);
-    xfunc_die();
+    libreport_xfunc_die();
 }
 
 static int parse_opt_size(const struct options *opt)
@@ -136,22 +136,22 @@ static int parse_opt_size(const struct options *opt)
     return size;
 }
 
-unsigned parse_opts(int argc, char **argv, const struct options *opt,
+unsigned libreport_parse_opts(int argc, char **argv, const struct options *opt,
                 const char *usage)
 {
     int help = 0;
     int size = parse_opt_size(opt);
     const int LONGOPT_OFFSET = 256;
 
-    struct strbuf *shortopts = strbuf_new();
+    struct strbuf *shortopts = libreport_strbuf_new();
 
-    struct option *longopts = xzalloc(sizeof(longopts[0]) * (size+2));
+    struct option *longopts = libreport_xzalloc(sizeof(longopts[0]) * (size+2));
     struct option *curopt = longopts;
     int ii;
     for (ii = 0; ii < size; ++ii)
     {
         curopt->name = opt[ii].long_name;
-        /*curopt->flag = 0; - xzalloc did it */
+        /*curopt->flag = 0; - libreport_xzalloc did it */
         if (opt[ii].short_name)
             curopt->val = opt[ii].short_name;
         else
@@ -162,19 +162,19 @@ unsigned parse_opts(int argc, char **argv, const struct options *opt,
             case OPTION_BOOL:
                 curopt->has_arg = no_argument;
                 if (opt[ii].short_name)
-                    strbuf_append_char(shortopts, opt[ii].short_name);
+                    libreport_strbuf_append_char(shortopts, opt[ii].short_name);
                 break;
             case OPTION_INTEGER:
             case OPTION_STRING:
             case OPTION_LIST:
                 curopt->has_arg = required_argument;
                 if (opt[ii].short_name)
-                    strbuf_append_strf(shortopts, "%c:", opt[ii].short_name);
+                    libreport_strbuf_append_strf(shortopts, "%c:", opt[ii].short_name);
                 break;
             case OPTION_OPTSTRING:
                 curopt->has_arg = optional_argument;
                 if (opt[ii].short_name)
-                    strbuf_append_strf(shortopts, "%c::", opt[ii].short_name);
+                    libreport_strbuf_append_strf(shortopts, "%c::", opt[ii].short_name);
                 break;
             case OPTION_GROUP:
             case OPTION_END:
@@ -199,7 +199,7 @@ unsigned parse_opts(int argc, char **argv, const struct options *opt,
     curopt->has_arg = no_argument;
     curopt->flag = &help;
     curopt->val = 1;
-    /* xzalloc did it already:
+    /* libreport_xzalloc did it already:
     curopt++;
     curopt->name = NULL;
     curopt->has_arg = 0;
@@ -218,9 +218,9 @@ unsigned parse_opts(int argc, char **argv, const struct options *opt,
         if (c == '?' || help)
         {
             free(longopts);
-            strbuf_free(shortopts);
-            xfunc_error_retval = 0; /* this isn't error, exit code = 0 */
-            show_usage_and_die(usage, opt);
+            libreport_strbuf_free(shortopts);
+            libreport_xfunc_error_retval = 0; /* this isn't error, exit code = 0 */
+            libreport_show_usage_and_die(usage, opt);
         }
 
         for (ii = 0; ii < size; ++ii)
@@ -236,7 +236,7 @@ unsigned parse_opts(int argc, char **argv, const struct options *opt,
                         *(int*)(opt[ii].value) += 1;
                         break;
                     case OPTION_INTEGER:
-                        *(int*)(opt[ii].value) = xatoi(optarg);
+                        *(int*)(opt[ii].value) = libreport_xatoi(optarg);
                         break;
                     case OPTION_STRING:
                     case OPTION_OPTSTRING:
@@ -255,7 +255,7 @@ unsigned parse_opts(int argc, char **argv, const struct options *opt,
     }
 
     free(longopts);
-    strbuf_free(shortopts);
+    libreport_strbuf_free(shortopts);
 
     return retval;
 }

--- a/src/lib/parse_options.c
+++ b/src/lib/parse_options.c
@@ -26,7 +26,7 @@ const char *g_progname;
 
 const char *abrt_init(char **argv)
 {
-    if (!load_global_configuration())
+    if (!libreport_load_global_configuration())
         error_msg_and_die("Cannot continue without libreport global configuration.");
 
     char *env_verbose = getenv("ABRT_VERBOSE");

--- a/src/lib/parse_release.c
+++ b/src/lib/parse_release.c
@@ -50,8 +50,8 @@ static void parse_release(const char *release, char** product, char** version, i
     /* Fedora has a single non-numeric release - Rawhide */
     if (strstr(release, "Rawhide"))
     {
-        *product = xstrdup("Fedora");
-        *version = xstrdup("rawhide");
+        *product = libreport_xstrdup("Fedora");
+        *version = libreport_xstrdup("rawhide");
         log_debug("%s: version:'%s' product:'%s'", __func__, *version, *product);
         return;
     }
@@ -64,16 +64,16 @@ static void parse_release(const char *release, char** product, char** version, i
     /*
     if (strstr(release, "Factory"))
     {
-        *product = xstrdup("openSUSE");
-        *version = xstrdup("Factory");
+        *product = libreport_xstrdup("openSUSE");
+        *version = libreport_xstrdup("Factory");
         log_debug("%s: version:'%s' product:'%s'", __func__, *version, *product);
         return;
     }
 
     if (strstr(release, "Tumbleweed"))
     {
-        *product = xstrdup("openSUSE");
-        *version = xstrdup("Tumbleweed");
+        *product = libreport_xstrdup("openSUSE");
+        *version = libreport_xstrdup("Tumbleweed");
         log_debug("%s: version:'%s' product:'%s'", __func__, *version, *product);
         return;
     }
@@ -81,31 +81,31 @@ static void parse_release(const char *release, char** product, char** version, i
 
     bool it_is_rhel = false;
 
-    struct strbuf *buf_product = strbuf_new();
+    struct strbuf *buf_product = libreport_strbuf_new();
     if (strstr(release, "Fedora"))
     {
-        strbuf_append_str(buf_product, "Fedora");
+        libreport_strbuf_append_str(buf_product, "Fedora");
     }
     else if (strstr(release, "Red Hat Enterprise Linux"))
     {
-        strbuf_append_str(buf_product, "Red Hat Enterprise Linux");
+        libreport_strbuf_append_str(buf_product, "Red Hat Enterprise Linux");
         it_is_rhel = true;
     }
     else if (strstr(release, "openSUSE"))
     {
-        strbuf_append_str(buf_product, "openSUSE");
+        libreport_strbuf_append_str(buf_product, "openSUSE");
     }
     else
     {
         /* TODO: add logic for parsing other distros' names here */
-        strbuf_append_str(buf_product, release);
+        libreport_strbuf_append_str(buf_product, release);
     }
 
     /* Examples of release strings:
      * installed system: "Red Hat Enterprise Linux Server release 6.2 Beta (Santiago)"
      * anaconda: "Red Hat Enterprise Linux 6.2"
      */
-    struct strbuf *buf_version = strbuf_new();
+    struct strbuf *buf_version = libreport_strbuf_new();
     const char *r = strstr(release, "release");
     const char *space = r ? strchr(r, ' ') : NULL;
     if (!space)
@@ -126,7 +126,7 @@ static void parse_release(const char *release, char** product, char** version, i
         while ((*space >= '0' && *space <= '9') || *space == '.')
         {
             /* Eat string like "5.2" */
-            strbuf_append_char(buf_version, *space);
+            libreport_strbuf_append_char(buf_version, *space);
             space++;
         }
 
@@ -142,7 +142,7 @@ static void parse_release(const char *release, char** product, char** version, i
                 space++;
             while (space > to_append && space[-1] == ' ') /* back to 1st non-space */
                 space--;
-            strbuf_append_strf(buf_version, "%.*s", (int)(space - to_append), to_append);
+            libreport_strbuf_append_strf(buf_version, "%.*s", (int)(space - to_append), to_append);
         }
     }
 
@@ -157,13 +157,13 @@ static void parse_release(const char *release, char** product, char** version, i
          */
         unsigned idx_dot = strchrnul(v, '.') - v;
         unsigned idx_space = strchrnul(v, ' ') - v;
-        strbuf_append_strf(buf_product, " %.*s",
+        libreport_strbuf_append_strf(buf_product, " %.*s",
                         (idx_dot < idx_space ? idx_dot : idx_space), v
         );
     }
 
-    *version = strbuf_free_nobuf(buf_version);
-    *product = strbuf_free_nobuf(buf_product);
+    *version = libreport_strbuf_free_nobuf(buf_version);
+    *product = libreport_strbuf_free_nobuf(buf_product);
 
     log_debug("%s: version:'%s' product:'%s'", __func__, *version, *product);
 }
@@ -191,7 +191,7 @@ static void unescape_osnifo_value(const char *source, char* dest)
     dest[0] = '\0';
 }
 
-void parse_osinfo(const char *osinfo_bytes, map_string_t *osinfo)
+void libreport_parse_osinfo(const char *osinfo_bytes, map_string_t *osinfo)
 {
     const char *cursor = osinfo_bytes;
     unsigned line = 0;
@@ -221,13 +221,13 @@ void parse_osinfo(const char *osinfo_bytes, map_string_t *osinfo)
             goto skip_line;
         }
 
-        char *key = xstrndup(cursor, key_end - cursor);
+        char *key = libreport_xstrndup(cursor, key_end - cursor);
         if (get_map_string_item_or_NULL(osinfo, key) != NULL)
         {
             log_notice("os-release:%u: redefines key '%s'", line, key);
         }
 
-        char *value = xstrndup(key_end + 1, value_end - key_end - 1);
+        char *value = libreport_xstrndup(key_end + 1, value_end - key_end - 1);
         unescape_osnifo_value(value, value);
 
         log_debug("os-release:%u: parsed line: '%s'='%s'", line, key, value);
@@ -252,7 +252,7 @@ void parse_osinfo(const char *osinfo_bytes, map_string_t *osinfo)
     }
 }
 
-void parse_release_for_bz(const char *release, char** product, char** version)
+void libreport_parse_release_for_bz(const char *release, char** product, char** version)
 {
     /* Fedora/RH bugzilla uses "Red Hat Enterprise Linux N" product for RHEL */
     parse_release(release, product, version, 0
@@ -260,7 +260,7 @@ void parse_release_for_bz(const char *release, char** product, char** version)
     );
 }
 
-void parse_osinfo_for_bz(map_string_t *osinfo, char** product, char** version)
+void libreport_parse_osinfo_for_bz(map_string_t *osinfo, char** product, char** version)
 {
     const char *name = get_map_string_item_or_NULL(osinfo, "REDHAT_BUGZILLA_PRODUCT");
     if (!name)
@@ -272,15 +272,15 @@ void parse_osinfo_for_bz(map_string_t *osinfo, char** product, char** version)
 
     if (name && version_id)
     {
-        *product = xstrdup(name);
-        *version = xstrdup(version_id);
+        *product = libreport_xstrdup(name);
+        *version = libreport_xstrdup(version_id);
         return;
     }
 
     const char *pretty = get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME);
     if (pretty)
     {
-        parse_release_for_bz(pretty, product, version);
+        libreport_parse_release_for_bz(pretty, product, version);
         return;
     }
 
@@ -289,12 +289,12 @@ void parse_osinfo_for_bz(map_string_t *osinfo, char** product, char** version)
     *version = NULL;
 }
 
-void parse_osinfo_for_bug_url(map_string_t *osinfo, char** url)
+void libreport_parse_osinfo_for_bug_url(map_string_t *osinfo, char** url)
 {
     const char *os_bug_report_url = get_map_string_item_or_NULL(osinfo, "BUG_REPORT_URL");
 
     if (os_bug_report_url)
-        *url = xstrdup(os_bug_report_url);
+        *url = libreport_xstrdup(os_bug_report_url);
     else
         /* unset or something bad happend */
         *url = NULL;
@@ -330,14 +330,14 @@ void parse_osinfo_for_bug_url(map_string_t *osinfo, char** url)
  *   <version>Unknown</version>
  * </versions>
  */
-void parse_release_for_rhts(const char *release, char** product, char** version)
+void libreport_parse_release_for_rhts(const char *release, char** product, char** version)
 {
     parse_release(release, product, version, 0
         | RETAIN_ALPHA_BETA_TAIL_IN_VER
     );
 }
 
-void parse_osinfo_for_rhts(map_string_t *osinfo, char** product, char** version)
+void libreport_parse_osinfo_for_rhts(map_string_t *osinfo, char** product, char** version)
 {
     const char *name = get_map_string_item_or_NULL(osinfo, "REDHAT_SUPPORT_PRODUCT");
     if (!name)
@@ -349,15 +349,15 @@ void parse_osinfo_for_rhts(map_string_t *osinfo, char** product, char** version)
 
     if (name && version_id)
     {
-        *product = xstrdup(name);
-        *version = xstrdup(version_id);
+        *product = libreport_xstrdup(name);
+        *version = libreport_xstrdup(version_id);
         return;
     }
 
     const char *pretty = get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME);
     if (pretty)
     {
-        parse_release_for_rhts(pretty, product, version);
+        libreport_parse_release_for_rhts(pretty, product, version);
         return;
     }
 

--- a/src/lib/parse_release.c
+++ b/src/lib/parse_release.c
@@ -222,7 +222,7 @@ void libreport_parse_osinfo(const char *osinfo_bytes, map_string_t *osinfo)
         }
 
         char *key = libreport_xstrndup(cursor, key_end - cursor);
-        if (get_map_string_item_or_NULL(osinfo, key) != NULL)
+        if (libreport_get_map_string_item_or_NULL(osinfo, key) != NULL)
         {
             log_notice("os-release:%u: redefines key '%s'", line, key);
         }
@@ -235,7 +235,7 @@ void libreport_parse_osinfo(const char *osinfo_bytes, map_string_t *osinfo)
         /* The difference between replace and insert is that if the key already
          * exists in the GHashTable, it gets replaced by the new key. The old
          * key and the old value are freed. */
-        replace_map_string_item(osinfo, key, value);
+        libreport_replace_map_string_item(osinfo, key, value);
 
         cursor = value_end;
         if (value_end[0] == '\0')
@@ -262,13 +262,13 @@ void libreport_parse_release_for_bz(const char *release, char** product, char** 
 
 void libreport_parse_osinfo_for_bz(map_string_t *osinfo, char** product, char** version)
 {
-    const char *name = get_map_string_item_or_NULL(osinfo, "REDHAT_BUGZILLA_PRODUCT");
+    const char *name = libreport_get_map_string_item_or_NULL(osinfo, "REDHAT_BUGZILLA_PRODUCT");
     if (!name)
-        name = get_map_string_item_or_NULL(osinfo, OSINFO_NAME);
+        name = libreport_get_map_string_item_or_NULL(osinfo, OSINFO_NAME);
 
-    const char *version_id = get_map_string_item_or_NULL(osinfo, "REDHAT_BUGZILLA_PRODUCT_VERSION");
+    const char *version_id = libreport_get_map_string_item_or_NULL(osinfo, "REDHAT_BUGZILLA_PRODUCT_VERSION");
     if (!version_id)
-        version_id = get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID);
+        version_id = libreport_get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID);
 
     if (name && version_id)
     {
@@ -277,7 +277,7 @@ void libreport_parse_osinfo_for_bz(map_string_t *osinfo, char** product, char** 
         return;
     }
 
-    const char *pretty = get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME);
+    const char *pretty = libreport_get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME);
     if (pretty)
     {
         libreport_parse_release_for_bz(pretty, product, version);
@@ -291,7 +291,7 @@ void libreport_parse_osinfo_for_bz(map_string_t *osinfo, char** product, char** 
 
 void libreport_parse_osinfo_for_bug_url(map_string_t *osinfo, char** url)
 {
-    const char *os_bug_report_url = get_map_string_item_or_NULL(osinfo, "BUG_REPORT_URL");
+    const char *os_bug_report_url = libreport_get_map_string_item_or_NULL(osinfo, "BUG_REPORT_URL");
 
     if (os_bug_report_url)
         *url = libreport_xstrdup(os_bug_report_url);
@@ -339,13 +339,13 @@ void libreport_parse_release_for_rhts(const char *release, char** product, char*
 
 void libreport_parse_osinfo_for_rhts(map_string_t *osinfo, char** product, char** version)
 {
-    const char *name = get_map_string_item_or_NULL(osinfo, "REDHAT_SUPPORT_PRODUCT");
+    const char *name = libreport_get_map_string_item_or_NULL(osinfo, "REDHAT_SUPPORT_PRODUCT");
     if (!name)
-        name = get_map_string_item_or_NULL(osinfo, OSINFO_NAME);
+        name = libreport_get_map_string_item_or_NULL(osinfo, OSINFO_NAME);
 
-    const char *version_id = get_map_string_item_or_NULL(osinfo, "REDHAT_SUPPORT_PRODUCT_VERSION");
+    const char *version_id = libreport_get_map_string_item_or_NULL(osinfo, "REDHAT_SUPPORT_PRODUCT_VERSION");
     if (!version_id)
-        version_id = get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID);
+        version_id = libreport_get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID);
 
     if (name && version_id)
     {
@@ -354,7 +354,7 @@ void libreport_parse_osinfo_for_rhts(map_string_t *osinfo, char** product, char*
         return;
     }
 
-    const char *pretty = get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME);
+    const char *pretty = libreport_get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME);
     if (pretty)
     {
         libreport_parse_release_for_rhts(pretty, product, version);

--- a/src/lib/problem_data.c
+++ b/src/lib/problem_data.c
@@ -582,7 +582,7 @@ problem_data_t *create_problem_data_for_reporting(const char *dump_dir_name)
     problem_data_t *problem_data = problem_data_new();
     problem_data_load_from_dump_dir(problem_data, dd, exclude_items);
     dd_close(dd);
-    string_vector_free(exclude_items);
+    libreport_string_vector_free(exclude_items);
     return problem_data;
 }
 

--- a/src/lib/problem_data.c
+++ b/src/lib/problem_data.c
@@ -578,7 +578,7 @@ problem_data_t *create_problem_data_for_reporting(const char *dump_dir_name)
     struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
     if (!dd)
         return NULL; /* dd_opendir already emitted error msg */
-    string_vector_ptr_t exclude_items = get_global_always_excluded_elements();
+    string_vector_ptr_t exclude_items = libreport_get_global_always_excluded_elements();
     problem_data_t *problem_data = problem_data_new();
     problem_data_load_from_dump_dir(problem_data, dd, exclude_items);
     dd_close(dd);

--- a/src/lib/proxies.c
+++ b/src/lib/proxies.c
@@ -50,7 +50,7 @@ GList *get_proxy_list(const char *url)
     /* Don't set proxy if the list contains just "direct://" */
     if (l && !g_list_next(l) && !strcmp(l->data, "direct://"))
     {
-        list_free_with_free(l);
+        libreport_list_free_with_free(l);
         l = NULL;
     }
 

--- a/src/lib/read_write.c
+++ b/src/lib/read_write.c
@@ -21,17 +21,17 @@
 #include "internal_libreport.h"
 
 /* Die with an error message if we can't read the entire buffer. */
-void xread(int fd, void *buf, size_t count)
+void libreport_xread(int fd, void *buf, size_t count)
 {
     if (count)
     {
-        ssize_t size = full_read(fd, buf, count);
+        ssize_t size = libreport_full_read(fd, buf, count);
         if ((size_t)size != count)
             error_msg_and_die("short read");
     }
 }
 
-ssize_t safe_read(int fd, void *buf, size_t count)
+ssize_t libreport_safe_read(int fd, void *buf, size_t count)
 {
     ssize_t n;
 
@@ -42,7 +42,7 @@ ssize_t safe_read(int fd, void *buf, size_t count)
     return n;
 }
 
-ssize_t safe_write(int fd, const void *buf, size_t count)
+ssize_t libreport_safe_write(int fd, const void *buf, size_t count)
 {
     ssize_t n;
 
@@ -53,7 +53,7 @@ ssize_t safe_write(int fd, const void *buf, size_t count)
     return n;
 }
 
-ssize_t full_read(int fd, void *buf, size_t len)
+ssize_t libreport_full_read(int fd, void *buf, size_t len)
 {
     ssize_t cc;
     ssize_t total;
@@ -62,7 +62,7 @@ ssize_t full_read(int fd, void *buf, size_t len)
 
     while (len)
     {
-        cc = safe_read(fd, buf, len);
+        cc = libreport_safe_read(fd, buf, len);
 
         if (cc < 0)
         {
@@ -84,7 +84,7 @@ ssize_t full_read(int fd, void *buf, size_t len)
     return total;
 }
 
-ssize_t full_write(int fd, const void *buf, size_t len)
+ssize_t libreport_full_write(int fd, const void *buf, size_t len)
 {
     ssize_t cc;
     ssize_t total;
@@ -93,7 +93,7 @@ ssize_t full_write(int fd, const void *buf, size_t len)
 
     while (len)
     {
-        cc = safe_write(fd, buf, len);
+        cc = libreport_safe_write(fd, buf, len);
 
         if (cc < 0)
         {
@@ -114,15 +114,15 @@ ssize_t full_write(int fd, const void *buf, size_t len)
     return total;
 }
 
-ssize_t full_write_str(int fd, const char *buf)
+ssize_t libreport_full_write_str(int fd, const char *buf)
 {
-    return full_write(fd, buf, strlen(buf));
+    return libreport_full_write(fd, buf, strlen(buf));
 }
 
 /* Read (potentially big) files in one go. File size is estimated
  * by stat. Extra '\0' byte is appended.
  */
-void* xmalloc_read(int fd, size_t *maxsz_p)
+void* libreport_xmalloc_read(int fd, size_t *maxsz_p)
 {
     char *buf;
     size_t size, rd_size, total;
@@ -145,8 +145,8 @@ void* xmalloc_read(int fd, size_t *maxsz_p)
     while (1) {
         if (to_read < size)
             size = to_read;
-        buf = xrealloc(buf, total + size + 1);
-        rd_size = full_read(fd, buf + total, size);
+        buf = libreport_xrealloc(buf, total + size + 1);
+        rd_size = libreport_full_read(fd, buf + total, size);
         if ((ssize_t)rd_size == (ssize_t)(-1)) { /* error */
             free(buf);
             return NULL;
@@ -162,7 +162,7 @@ void* xmalloc_read(int fd, size_t *maxsz_p)
         if (size > 64*1024)
             size = 64*1024;
     }
-    buf = xrealloc(buf, total + 1);
+    buf = libreport_xrealloc(buf, total + 1);
     buf[total] = '\0';
 
     if (maxsz_p)
@@ -170,7 +170,7 @@ void* xmalloc_read(int fd, size_t *maxsz_p)
     return buf;
 }
 
-void* xmalloc_open_read_close(const char *filename, size_t *maxsz_p)
+void *libreport_xmalloc_open_read_close(const char *filename, size_t *maxsz_p)
 {
     char *buf;
     int fd;
@@ -179,25 +179,25 @@ void* xmalloc_open_read_close(const char *filename, size_t *maxsz_p)
     if (fd < 0)
         return NULL;
 
-    buf = xmalloc_read(fd, maxsz_p);
+    buf = libreport_xmalloc_read(fd, maxsz_p);
     close(fd);
     return buf;
 }
 
-void* xmalloc_xopen_read_close(const char *filename, size_t *maxsz_p)
+void *libreport_xmalloc_xopen_read_close(const char *filename, size_t *maxsz_p)
 {
-    void *buf = xmalloc_open_read_close(filename, maxsz_p);
+    void *buf = libreport_xmalloc_open_read_close(filename, maxsz_p);
     if (!buf)
         perror_msg_and_die("Can't read '%s'", filename);
     return buf;
 }
 
-char* malloc_readlink(const char *linkname)
+char *libreport_malloc_readlink(const char *linkname)
 {
-    return malloc_readlinkat(AT_FDCWD, linkname);
+    return libreport_malloc_readlinkat(AT_FDCWD, linkname);
 }
 
-char* malloc_readlinkat(int dir_fd, const char *linkname)
+char *libreport_malloc_readlinkat(int dir_fd, const char *linkname)
 {
     char buf[PATH_MAX + 1];
     int len;
@@ -206,7 +206,7 @@ char* malloc_readlinkat(int dir_fd, const char *linkname)
     if (len >= 0)
     {
         buf[len] = '\0';
-        return xstrdup(buf);
+        return libreport_xstrdup(buf);
     }
     return NULL;
 }

--- a/src/lib/report.c
+++ b/src/lib/report.c
@@ -28,8 +28,8 @@ int report_problem_in_dir(const char *dirname, int flags)
 
     if (flags & LIBREPORT_IGNORE_NOT_REPORTABLE)
     {
-        load_global_configuration();
-        set_global_stop_on_not_reportable(false, 0);
+        libreport_load_global_configuration();
+        libreport_set_global_stop_on_not_reportable(false, 0);
     }
 
     fflush(NULL);

--- a/src/lib/report.c
+++ b/src/lib/report.c
@@ -24,7 +24,7 @@ int report_problem_in_dir(const char *dirname, int flags)
     /* Prepare it before fork, to avoid thread-unsafe setenv there */
     char *prgname = (char*) g_get_prgname();
     if (prgname)
-        prgname = xasprintf("LIBREPORT_PRGNAME=%s", prgname);
+        prgname = libreport_xasprintf("LIBREPORT_PRGNAME=%s", prgname);
 
     if (flags & LIBREPORT_IGNORE_NOT_REPORTABLE)
     {
@@ -171,7 +171,7 @@ int report_problem_in_dir(const char *dirname, int flags)
      * In both cases, we need to wait for child:
      */
     int status;
-    pid = safe_waitpid(pid, &status, 0);
+    pid = libreport_safe_waitpid(pid, &status, 0);
     if (pid <= 0)
     {
         perror_msg("waitpid");
@@ -194,7 +194,7 @@ int report_problem_in_memory(problem_data_t *pd, int flags)
     struct dump_dir *dd = create_dump_dir_from_problem_data(pd, LARGE_DATA_TMP_DIR);
     if (!dd)
         return -1;
-    char *dir_name = xstrdup(dd->dd_dirname);
+    char *dir_name = libreport_xstrdup(dd->dd_dirname);
     dd_close(dd);
     log_info("Temp problem dir: '%s'", dir_name);
 

--- a/src/lib/report_result.c
+++ b/src/lib/report_result.c
@@ -107,34 +107,34 @@ struct strbuf *report_result_to_string(report_result_t *result)
     g_return_val_if_fail(NULL != result, NULL);
     g_return_val_if_fail(NULL != result->label, NULL);
 
-    buf = strbuf_new();
+    buf = libreport_strbuf_new();
 
-    strbuf_append_strf(buf, "%s:", result->label);
+    libreport_strbuf_append_strf(buf, "%s:", result->label);
 
     if ((time_t)-1 != result->timestamp)
     {
-        strbuf_append_strf(buf, " TIME=%s", iso_date_string(&result->timestamp));
+        libreport_strbuf_append_strf(buf, " TIME=%s", libreport_iso_date_string(&result->timestamp));
     }
 
     if (NULL != result->url)
     {
-        strbuf_append_strf(buf, " URL=%s", result->url);
+        libreport_strbuf_append_strf(buf, " URL=%s", result->url);
     }
 
     if (NULL != result->bthash)
     {
-        strbuf_append_strf(buf, " BTHASH=%s", result->bthash);
+        libreport_strbuf_append_strf(buf, " BTHASH=%s", result->bthash);
     }
 
     if (NULL != result->workflow)
     {
-        strbuf_append_strf(buf, " WORKFLOW=%s", result->workflow);
+        libreport_strbuf_append_strf(buf, " WORKFLOW=%s", result->workflow);
     }
 
     /* MSG must be last because the value is delimited by new line character */
     if (NULL != result->message)
     {
-        strbuf_append_strf(buf, " MSG=%s", result->message);
+        libreport_strbuf_append_strf(buf, " MSG=%s", result->message);
     }
 
     return buf;
@@ -189,7 +189,7 @@ report_result_t *report_result_parse(const char *line,
 
     result = report_result_new();
 
-    result->label = xstrndup(line, label_length);
+    result->label = libreport_xstrndup(line, label_length);
 
     /* +1 -> : */
     line += (label_length + 1);
@@ -214,7 +214,7 @@ report_result_t *report_result_parse(const char *line,
             ++line;
         }
 
-        const char *end = skip_non_whitespace(line);
+        const char *end = libreport_skip_non_whitespace(line);
 
         prefix = "MSG=";
         prefix_length = strlen(prefix);
@@ -223,7 +223,7 @@ report_result_t *report_result_parse(const char *line,
         {
             /* MSG=... eats entire line: exiting the loop */
             end = strchrnul(end, '\n');
-            result->message = xstrndup(line + prefix_length, end - (line + prefix_length));
+            result->message = libreport_xstrndup(line + prefix_length, end - (line + prefix_length));
             break;
         }
 
@@ -232,7 +232,7 @@ report_result_t *report_result_parse(const char *line,
 
         if (strncmp(line, prefix, prefix_length) == 0)
         {
-            result->url = xstrndup(line + prefix_length, end - (line + prefix_length));
+            result->url = libreport_xstrndup(line + prefix_length, end - (line + prefix_length));
         }
 
         prefix = "BTHASH=";
@@ -240,7 +240,7 @@ report_result_t *report_result_parse(const char *line,
 
         if (strncmp(line, prefix, prefix_length) == 0)
         {
-            result->bthash = xstrndup(line + prefix_length, end - (line + prefix_length));
+            result->bthash = libreport_xstrndup(line + prefix_length, end - (line + prefix_length));
         }
 
         prefix = "WORKFLOW=";
@@ -248,7 +248,7 @@ report_result_t *report_result_parse(const char *line,
 
         if (strncmp(line, prefix, prefix_length) == 0)
         {
-            result->workflow = xstrndup(line + prefix_length, end - (line + prefix_length));
+            result->workflow = libreport_xstrndup(line + prefix_length, end - (line + prefix_length));
         }
 
         prefix = "TIME=";
@@ -258,9 +258,9 @@ report_result_t *report_result_parse(const char *line,
         {
             char *datetime;
 
-            datetime = xstrndup(line + prefix_length, end - (line + prefix_length));
+            datetime = libreport_xstrndup(line + prefix_length, end - (line + prefix_length));
 
-            if (iso_date_string_parse(datetime, &result->timestamp) != 0)
+            if (libreport_iso_date_string_parse(datetime, &result->timestamp) != 0)
             {
                 log_warning(_("Ignored invalid ISO date of report result '%s'"), result->label);
             }

--- a/src/lib/reported_to.c
+++ b/src/lib/reported_to.c
@@ -19,7 +19,7 @@
 #include "dump_dir.h"
 #include "internal_libreport.h"
 
-int add_reported_to_data(char **reported_to, const char *line)
+int libreport_add_reported_to_data(char **reported_to, const char *line)
 {
     if (*reported_to)
     {
@@ -45,7 +45,7 @@ int add_reported_to_data(char **reported_to, const char *line)
     return 1;
 }
 
-int add_reported_to_entry_data(char **reported_to, report_result_t *result)
+int libreport_add_reported_to_entry_data(char **reported_to, report_result_t *result)
 {
     struct strbuf *buf;
 
@@ -55,7 +55,7 @@ int add_reported_to_entry_data(char **reported_to, report_result_t *result)
         return -EINVAL;
     }
 
-    const int r = add_reported_to_data(reported_to, buf->buf);
+    const int r = libreport_add_reported_to_data(reported_to, buf->buf);
 
     strbuf_free(buf);
 
@@ -96,7 +96,7 @@ static void read_entire_reported_to_cb(const char *record_line, size_t label_len
     *result = g_list_prepend(*result, report);
 }
 
-GList *read_entire_reported_to_data(const char *reported_to)
+GList *libreport_read_entire_reported_to_data(const char *reported_to)
 {
     GList *result = NULL;
     foreach_reported_to_line(reported_to, read_entire_reported_to_cb, &result);
@@ -121,7 +121,7 @@ static void find_in_reported_to_cb(const char *record_line, size_t label_len, vo
     }
 }
 
-report_result_t *find_in_reported_to_data(const char *reported_to, const char *report_label)
+report_result_t *libreport_find_in_reported_to_data(const char *reported_to, const char *report_label)
 {
     struct find_in_cb_data searched;
     searched.label = report_label;

--- a/src/lib/reported_to.c
+++ b/src/lib/reported_to.c
@@ -35,12 +35,12 @@ int libreport_add_reported_to_data(char **reported_to, const char *line)
             p++;
         }
         if (p != *reported_to && p[-1] != '\n')
-            *reported_to = append_to_malloced_string(*reported_to, "\n");
-        *reported_to = append_to_malloced_string(*reported_to, line);
-        *reported_to = append_to_malloced_string(*reported_to, "\n");
+            *reported_to = libreport_append_to_malloced_string(*reported_to, "\n");
+        *reported_to = libreport_append_to_malloced_string(*reported_to, line);
+        *reported_to = libreport_append_to_malloced_string(*reported_to, "\n");
     }
     else
-        *reported_to = xasprintf("%s\n", line);
+        *reported_to = libreport_xasprintf("%s\n", line);
 
     return 1;
 }
@@ -57,7 +57,7 @@ int libreport_add_reported_to_entry_data(char **reported_to, report_result_t *re
 
     const int r = libreport_add_reported_to_data(reported_to, buf->buf);
 
-    strbuf_free(buf);
+    libreport_strbuf_free(buf);
 
     return r;
 }

--- a/src/lib/reporters.c
+++ b/src/lib/reporters.c
@@ -21,7 +21,7 @@
 #include "internal_libreport.h"
 
 int
-is_comment_dup(GList *comments, const char *comment)
+libreport_is_comment_dup(GList *comments, const char *comment)
 {
     char * const trim_comment = libreport_trim_all_whitespace(comment);
     bool same_comments = false;
@@ -39,7 +39,7 @@ is_comment_dup(GList *comments, const char *comment)
 }
 
 unsigned
-comments_find_best_bt_rating(GList *comments)
+libreport_comments_find_best_bt_rating(GList *comments)
 {
     if (comments == NULL)
         return 0;

--- a/src/lib/reporters.c
+++ b/src/lib/reporters.c
@@ -23,13 +23,13 @@
 int
 is_comment_dup(GList *comments, const char *comment)
 {
-    char * const trim_comment = trim_all_whitespace(comment);
+    char * const trim_comment = libreport_trim_all_whitespace(comment);
     bool same_comments = false;
 
     for (GList *l = comments; l && !same_comments; l = l->next)
     {
         const char * const comment_body = (const char *) l->data;
-        char * const trim_comment_body = trim_all_whitespace(comment_body);
+        char * const trim_comment_body = libreport_trim_all_whitespace(comment_body);
         same_comments = (strcmp(trim_comment_body, trim_comment) == 0);
         free(trim_comment_body);
     }

--- a/src/lib/run_event.c
+++ b/src/lib/run_event.c
@@ -843,37 +843,37 @@ GList *list_possible_events_problem_data_glist(problem_data_t *pd,
 
 void run_event_stdio_alert(const char *msg, void *param)
 {
-    alert(msg);
+    libreport_alert(msg);
 }
 
 char *run_event_stdio_ask(const char *msg, void *param)
 {
-    return ask(msg);
+    return libreport_ask(msg);
 }
 
 int run_event_stdio_ask_yes_no(const char *msg, void *param)
 {
-    return ask_yes_no(msg);
+    return libreport_ask_yes_no(msg);
 }
 
 int run_event_stdio_ask_yes_no_yesforever(const char *key, const char *msg, void *param)
 {
-    return ask_yes_no_yesforever(key, msg);
+    return libreport_ask_yes_no_yesforever(key, msg);
 }
 
 int run_event_stdio_ask_yes_no_save_result(const char *key, const char *msg, void *param)
 {
-    return ask_yes_no_save_result(key, msg);
+    return libreport_ask_yes_no_save_result(key, msg);
 }
 
 char *run_event_stdio_ask_password(const char *msg, void *param)
 {
-    return ask_password(msg);
+    return libreport_ask_password(msg);
 }
 
 static char *run_event_stdio_log(char *log_line, void *param)
 {
-    client_log(log_line);
+    libreport_client_log(log_line);
     return log_line;
 }
 

--- a/src/lib/run_event.c
+++ b/src/lib/run_event.c
@@ -882,7 +882,7 @@ static void run_event_stdio_error_and_die(const char *error_line, void *param)
     error_msg_and_die("Can't write bytes to child's stdin");
 }
 
-char *exit_status_as_string(const char *progname, int status)
+char *libreport_exit_status_as_string(const char *progname, int status)
 {
     INITIALIZE_LIBREPORT();
 

--- a/src/lib/skip_whitespace.c
+++ b/src/lib/skip_whitespace.c
@@ -18,14 +18,14 @@
  */
 #include "internal_libreport.h"
 
-char* skip_blank(const char *s)
+char *libreport_skip_blank(const char *s)
 {
 	while (isblank(*s)) ++s;
 
 	return (char *) s;
 }
 
-char* skip_whitespace(const char *s)
+char *libreport_skip_whitespace(const char *s)
 {
 	/* NB: isspace('\0') returns 0 */
 	while (isspace(*s)) ++s;
@@ -33,7 +33,7 @@ char* skip_whitespace(const char *s)
 	return (char *) s;
 }
 
-char* skip_non_whitespace(const char *s)
+char *libreport_skip_non_whitespace(const char *s)
 {
 	while (*s && !isspace(*s)) ++s;
 

--- a/src/lib/stdio_helpers.c
+++ b/src/lib/stdio_helpers.c
@@ -37,7 +37,7 @@ static char *xmalloc_fgets_internal(FILE *file, int *sizep)
 	while (1) {
 		char *r;
 
-		linebuf = xrealloc(linebuf, idx + 0x100);
+		linebuf = libreport_xrealloc(linebuf, idx + 0x100);
 		r = fgets(&linebuf[idx], 0x100, file);
 		if (!r) {
 			/* need to terminate the line */
@@ -63,16 +63,16 @@ static char *xmalloc_fgets_internal(FILE *file, int *sizep)
 	return linebuf;
 }
 
-char *xmalloc_fgets(FILE *file)
+char *libreport_xmalloc_fgets(FILE *file)
 {
 	int sz;
 	char *r = xmalloc_fgets_internal(file, &sz);
 	if (!r)
 		return r;
-	return xrealloc(r, sz + 1);
+	return libreport_xrealloc(r, sz + 1);
 }
 
-char *xmalloc_fgetline(FILE *file)
+char *libreport_xmalloc_fgetline(FILE *file)
 {
 	int sz;
 	char *r = xmalloc_fgets_internal(file, &sz);
@@ -80,16 +80,16 @@ char *xmalloc_fgetline(FILE *file)
 		return r;
 	if (r[sz - 1] == '\n')
 		r[--sz] = '\0';
-	return xrealloc(r, sz + 1);
+	return libreport_xrealloc(r, sz + 1);
 }
 
-char *xmalloc_fopen_fgetline_fclose(const char *filename)
+char *libreport_xmalloc_fopen_fgetline_fclose(const char *filename)
 {
     char *s = NULL;
     FILE *fp = fopen(filename, "r");
     if (fp)
     {
-        s = xmalloc_fgetline(fp);
+        s = libreport_xmalloc_fgetline(fp);
         fclose(fp);
     }
     return s;

--- a/src/lib/strbuf.c
+++ b/src/lib/strbuf.c
@@ -19,7 +19,7 @@
 */
 #include "internal_libreport.h"
 
-int prefixcmp(const char *str, const char *prefix)
+int libreport_prefixcmp(const char *str, const char *prefix)
 {
     for (; ; str++, prefix++)
         if (!*prefix)
@@ -28,7 +28,7 @@ int prefixcmp(const char *str, const char *prefix)
             return (unsigned char)*prefix - (unsigned char)*str;
 }
 
-int suffixcmp(const char *str, const char *suffix)
+int libreport_suffixcmp(const char *str, const char *suffix)
 {
     int len_minus_suflen = strlen(str) - strlen(suffix);
     if (len_minus_suflen < 0)
@@ -37,9 +37,9 @@ int suffixcmp(const char *str, const char *suffix)
         return strcmp(str + len_minus_suflen, suffix);
 }
 
-char *trim_all_whitespace(const char *str)
+char *libreport_trim_all_whitespace(const char *str)
 {
-    char *trim = xzalloc(sizeof(char) * strlen(str) + 1);
+    char *trim = libreport_xzalloc(sizeof(char) * strlen(str) + 1);
     int i = 0;
     while (*str)
     {
@@ -65,10 +65,9 @@ char *trim_all_whitespace(const char *str)
  *   0123456789 BCDEF -> 0123456789 ...
  *   012345 789ABCDEF -> 012345 789AB...
  */
-char *
-shorten_string_to_length(const char *str, unsigned length)
+char *libreport_shorten_string_to_length(const char *str, unsigned length)
 {
-    char *dup_str = xstrdup(str);
+    char *dup_str = libreport_xstrdup(str);
     if (strlen(str) > length)
     {
         char *max_end = dup_str + (length - strlen("..."));
@@ -101,13 +100,13 @@ shorten_string_to_length(const char *str, unsigned length)
  * Trims whitespace characters both from left and right side of a string.
  * Modifies the string in-place. Returns the trimmed string.
  */
-char *strtrim(char *str)
+char *libreport_strtrim(char *str)
 {
     if (!str)
         return NULL;
 
     /* Remove leading spaces */
-    overlapping_strcpy(str, skip_whitespace(str));
+    libreport_overlapping_strcpy(str, libreport_skip_whitespace(str));
 
     /* Remove trailing spaces */
     int i = strlen(str);
@@ -124,7 +123,7 @@ char *strtrim(char *str)
  * Trims characters both from left and right side of a string.
  * Modifies the string in-place. Returns the trimmed string.
  */
-char *strtrimch(char *str, int ch)
+char *libreport_strtrimch(char *str, int ch)
 {
     if (!str)
         return NULL;
@@ -133,7 +132,7 @@ char *strtrimch(char *str, int ch)
     char *tmp = str;
     while (*tmp == ch)
         ++tmp;
-    overlapping_strcpy(str, tmp);
+    libreport_overlapping_strcpy(str, tmp);
 
     /* Remove trailing characters */
     int i = strlen(str);
@@ -150,7 +149,7 @@ char *strtrimch(char *str, int ch)
  * Removes character from a string.
  * Modifies the string in-place. Returns the updated string.
  */
-char *strremovech(char *str, int ch)
+char *libreport_strremovech(char *str, int ch)
 {
     char *ret = str;
     char *res = str;
@@ -163,16 +162,16 @@ char *strremovech(char *str, int ch)
 }
 
 
-struct strbuf *strbuf_new(void)
+struct strbuf *libreport_strbuf_new(void)
 {
-    struct strbuf *buf = xzalloc(sizeof(*buf));
-    /*buf->len = 0; - done by xzalloc */
+    struct strbuf *buf = libreport_xzalloc(sizeof(*buf));
+    /*buf->len = 0; - done by libreport_xzalloc */
     buf->alloc = 8;
-    buf->buf = xzalloc(8);
+    buf->buf = libreport_xzalloc(8);
     return buf;
 }
 
-void strbuf_free(struct strbuf *strbuf)
+void libreport_strbuf_free(struct strbuf *strbuf)
 {
     if (!strbuf)
         return;
@@ -180,7 +179,7 @@ void strbuf_free(struct strbuf *strbuf)
     free(strbuf);
 }
 
-char *strbuf_free_nobuf(struct strbuf *strbuf)
+char *libreport_strbuf_free_nobuf(struct strbuf *strbuf)
 {
     char *ret = strbuf->buf;
     free(strbuf);
@@ -188,7 +187,7 @@ char *strbuf_free_nobuf(struct strbuf *strbuf)
 }
 
 
-void strbuf_clear(struct strbuf *strbuf)
+void libreport_strbuf_clear(struct strbuf *strbuf)
 {
     assert(strbuf->alloc > 0);
     strbuf->len = 0;
@@ -210,13 +209,13 @@ static char *strbuf_grow(struct strbuf *strbuf, unsigned increment)
         while (cur_size <= need)
             cur_size += 64 + cur_size / 8;
         strbuf->alloc = cur_size;
-        strbuf->buf = xrealloc(strbuf->buf, cur_size);
+        strbuf->buf = libreport_xrealloc(strbuf->buf, cur_size);
     }
     char *p = strbuf->buf + len;
     return p;
 }
 
-struct strbuf *strbuf_append_char(struct strbuf *strbuf, char c)
+struct strbuf *libreport_strbuf_append_char(struct strbuf *strbuf, char c)
 {
     char *p = strbuf_grow(strbuf, 1);
     *p++ = c;
@@ -224,7 +223,7 @@ struct strbuf *strbuf_append_char(struct strbuf *strbuf, char c)
     return strbuf;
 }
 
-struct strbuf *strbuf_append_str(struct strbuf *strbuf, const char *str)
+struct strbuf *libreport_strbuf_append_str(struct strbuf *strbuf, const char *str)
 {
     unsigned len = strlen(str);
     char *p = strbuf_grow(strbuf, len);
@@ -233,7 +232,7 @@ struct strbuf *strbuf_append_str(struct strbuf *strbuf, const char *str)
     return strbuf;
 }
 
-struct strbuf *strbuf_prepend_str(struct strbuf *strbuf, const char *str)
+struct strbuf *libreport_strbuf_prepend_str(struct strbuf *strbuf, const char *str)
 {
     unsigned cur_len = strbuf->len;
     unsigned inc_len = strlen(str);
@@ -244,39 +243,39 @@ struct strbuf *strbuf_prepend_str(struct strbuf *strbuf, const char *str)
     return strbuf;
 }
 
-struct strbuf *strbuf_append_strfv(struct strbuf *strbuf, const char *format, va_list p)
+struct strbuf *libreport_strbuf_append_strfv(struct strbuf *strbuf, const char *format, va_list p)
 {
-    char *string_ptr = xvasprintf(format, p);
-    strbuf_append_str(strbuf, string_ptr);
+    char *string_ptr = libreport_xvasprintf(format, p);
+    libreport_strbuf_append_str(strbuf, string_ptr);
     free(string_ptr);
     return strbuf;
 }
 
-struct strbuf *strbuf_append_strf(struct strbuf *strbuf, const char *format, ...)
+struct strbuf *libreport_strbuf_append_strf(struct strbuf *strbuf, const char *format, ...)
 {
     va_list p;
 
     va_start(p, format);
-    strbuf_append_strfv(strbuf, format, p);
+    libreport_strbuf_append_strfv(strbuf, format, p);
     va_end(p);
 
     return strbuf;
 }
 
-struct strbuf *strbuf_prepend_strfv(struct strbuf *strbuf, const char *format, va_list p)
+struct strbuf *libreport_strbuf_prepend_strfv(struct strbuf *strbuf, const char *format, va_list p)
 {
-    char *string_ptr = xvasprintf(format, p);
-    strbuf_prepend_str(strbuf, string_ptr);
+    char *string_ptr = libreport_xvasprintf(format, p);
+    libreport_strbuf_prepend_str(strbuf, string_ptr);
     free(string_ptr);
     return strbuf;
 }
 
-struct strbuf *strbuf_prepend_strf(struct strbuf *strbuf, const char *format, ...)
+struct strbuf *libreport_strbuf_prepend_strf(struct strbuf *strbuf, const char *format, ...)
 {
     va_list p;
 
     va_start(p, format);
-    strbuf_prepend_strfv(strbuf, format, p);
+    libreport_strbuf_prepend_strfv(strbuf, format, p);
     va_end(p);
 
     return strbuf;

--- a/src/lib/ureport.c
+++ b/src/lib/ureport.c
@@ -272,7 +272,7 @@ ureport_server_config_load_basic_auth(struct ureport_server_config *config,
     if (password == NULL)
     {
         char *message = xasprintf("Please provide uReport server password for user '%s':", username);
-        password = tmp_password = ask_password(message);
+        password = tmp_password = libreport_ask_password(message);
         free(message);
 
         if (strcmp(password, "") == 0)

--- a/src/lib/ureport.c
+++ b/src/lib/ureport.c
@@ -66,7 +66,7 @@ error:
 }
 
 void
-ureport_server_config_set_url(struct ureport_server_config *config,
+libreport_ureport_server_config_set_url(struct ureport_server_config *config,
                               char *server_url)
 {
     free(config->ur_url);
@@ -124,7 +124,7 @@ cert_authority_cert_exist(char *cert_name)
 }
 
 void
-ureport_server_config_set_client_auth(struct ureport_server_config *config,
+libreport_ureport_server_config_set_client_auth(struct ureport_server_config *config,
                                       const char *client_auth)
 {
     if (client_auth == NULL)
@@ -143,7 +143,7 @@ ureport_server_config_set_client_auth(struct ureport_server_config *config,
     else if (strcmp(client_auth, "rhsm") == 0)
     {
         if (config->ur_url == NULL)
-            ureport_server_config_set_url(config, libreport_xstrdup(RHSM_WEB_SERVICE_URL));
+            libreport_ureport_server_config_set_url(config, libreport_xstrdup(RHSM_WEB_SERVICE_URL));
 
         /* always returns non-NULL */
         char *rhsm_dir = rhsm_config_get_consumer_cert_dir();
@@ -216,10 +216,10 @@ ureport_server_config_set_client_auth(struct ureport_server_config *config,
 }
 
 void
-ureport_server_config_set_basic_auth(struct ureport_server_config *config,
+libreport_ureport_server_config_set_basic_auth(struct ureport_server_config *config,
                                      const char *login, const char *password)
 {
-    ureport_server_config_set_client_auth(config, "");
+    libreport_ureport_server_config_set_client_auth(config, "");
 
     free(config->ur_username);
     config->ur_username = libreport_xstrdup(login);
@@ -257,7 +257,7 @@ ureport_server_config_load_basic_auth(struct ureport_server_config *config,
         password = libreport_get_map_string_item_or_NULL(settings, "Password");
 
         if (config->ur_url == NULL)
-            ureport_server_config_set_url(config, libreport_xstrdup(RHSM_WEB_SERVICE_URL));
+            libreport_ureport_server_config_set_url(config, libreport_xstrdup(RHSM_WEB_SERVICE_URL));
     }
     else
     {
@@ -279,7 +279,7 @@ ureport_server_config_load_basic_auth(struct ureport_server_config *config,
             error_msg_and_die("Cannot continue without uReport server password!");
     }
 
-    ureport_server_config_set_basic_auth(config, username, password);
+    libreport_ureport_server_config_set_basic_auth(config, username, password);
 
     free(tmp_password);
     free(tmp_username);
@@ -287,7 +287,7 @@ ureport_server_config_load_basic_auth(struct ureport_server_config *config,
 }
 
 void
-ureport_server_config_load(struct ureport_server_config *config,
+libreport_ureport_server_config_load(struct ureport_server_config *config,
                            map_string_t *settings)
 {
     UREPORT_OPTION_VALUE_FROM_CONF(settings, "URL", config->ur_url, libreport_xstrdup);
@@ -301,7 +301,7 @@ ureport_server_config_load(struct ureport_server_config *config,
     if (http_auth_pref == NULL)
     {
         UREPORT_OPTION_VALUE_FROM_CONF(settings, "SSLClientAuth", client_auth, (const char *));
-        ureport_server_config_set_client_auth(config, client_auth);
+        libreport_ureport_server_config_set_client_auth(config, client_auth);
     }
 
     /* If SSLClientAuth is configured, include the auth items by default. */
@@ -320,7 +320,7 @@ ureport_server_config_load(struct ureport_server_config *config,
 }
 
 void
-ureport_server_config_init(struct ureport_server_config *config)
+libreport_ureport_server_config_init(struct ureport_server_config *config)
 {
     config->ur_url = NULL;
     config->ur_ssl_verify = true;
@@ -335,7 +335,7 @@ ureport_server_config_init(struct ureport_server_config *config)
 }
 
 void
-ureport_server_config_destroy(struct ureport_server_config *config)
+libreport_ureport_server_config_destroy(struct ureport_server_config *config)
 {
     free(config->ur_url);
     config->ur_url = DESTROYED_POINTER;
@@ -360,7 +360,7 @@ ureport_server_config_destroy(struct ureport_server_config *config)
 }
 
 void
-ureport_server_response_free(struct ureport_server_response *resp)
+libreport_ureport_server_response_free(struct ureport_server_response *resp)
 {
     if (!resp)
         return;
@@ -557,7 +557,7 @@ ureport_server_parse_json(json_object *json)
 }
 
 struct ureport_server_response *
-ureport_server_response_from_reply(post_state_t *post_state,
+libreport_ureport_server_response_from_reply(post_state_t *post_state,
                                    struct ureport_server_config *config)
 {
     /* Previously, the condition here was (post_state->errmsg[0] != '\0')
@@ -635,7 +635,7 @@ ureport_server_response_from_reply(post_state_t *post_state,
 }
 
 bool
-ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
+libreport_ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
                                          const char *dump_dir_path,
                                          struct ureport_server_config *config)
 {
@@ -662,7 +662,7 @@ ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
             char *url;
 
             result = report_result_new_with_label_from_env("ABRT Server");
-            url = ureport_server_response_get_report_url(resp, config);
+            url = libreport_ureport_server_response_get_report_url(resp, config);
 
             report_result_set_url(result, url);
 
@@ -703,7 +703,7 @@ ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
 }
 
 char *
-ureport_server_response_get_report_url(struct ureport_server_response *resp,
+libreport_ureport_server_response_get_report_url(struct ureport_server_response *resp,
                                        struct ureport_server_config *config)
 {
     char *bthash_url = libreport_concat_path_file(config->ur_url, BTHASH_URL_SFX);
@@ -723,7 +723,7 @@ ureport_add_str(struct json_object *ur, const char *key, const char *s)
 }
 
 char *
-ureport_from_dump_dir_ext(const char *dump_dir_path, const struct ureport_preferences *preferences)
+libreport_ureport_from_dump_dir_ext(const char *dump_dir_path, const struct ureport_preferences *preferences)
 {
     char *error_message;
     struct sr_report *report = sr_abrt_report_from_dir(dump_dir_path,
@@ -771,13 +771,13 @@ ureport_from_dump_dir_ext(const char *dump_dir_path, const struct ureport_prefer
 }
 
 char *
-ureport_from_dump_dir(const char *dump_dir_path)
+libreport_ureport_from_dump_dir(const char *dump_dir_path)
 {
-    return ureport_from_dump_dir_ext(dump_dir_path, /*no preferences*/NULL);
+    return libreport_ureport_from_dump_dir_ext(dump_dir_path, /*no preferences*/NULL);
 }
 
 struct post_state *
-ureport_do_post(const char *json, struct ureport_server_config *config,
+libreport_ureport_do_post(const char *json, struct ureport_server_config *config,
                 const char *url_sfx)
 {
     int flags = POST_WANT_BODY | POST_WANT_ERROR_MSG;
@@ -833,9 +833,9 @@ ureport_do_post(const char *json, struct ureport_server_config *config,
 }
 
 struct ureport_server_response *
-ureport_submit(const char *json, struct ureport_server_config *config)
+libreport_ureport_submit(const char *json, struct ureport_server_config *config)
 {
-    struct post_state *post_state = ureport_do_post(json, config, UREPORT_SUBMIT_ACTION);
+    struct post_state *post_state = libreport_ureport_do_post(json, config, UREPORT_SUBMIT_ACTION);
 
     if (post_state == NULL)
     {
@@ -843,7 +843,7 @@ ureport_submit(const char *json, struct ureport_server_config *config)
         return NULL;
     }
 
-    struct ureport_server_response *resp = ureport_server_response_from_reply(post_state, config);
+    struct ureport_server_response *resp = libreport_ureport_server_response_from_reply(post_state, config);
     free(post_state);
 
     return resp;
@@ -876,10 +876,10 @@ ureport_attach_string(struct ureport_server_config *config,
 
     json = ureport_json_attachment_new(bthash, type, data);
 
-    post_state_t *post_state = ureport_do_post(json, config, UREPORT_ATTACH_ACTION);
+    post_state_t *post_state = libreport_ureport_do_post(json, config, UREPORT_ATTACH_ACTION);
 
     struct ureport_server_response *resp =
-        ureport_server_response_from_reply(post_state, config);
+        libreport_ureport_server_response_from_reply(post_state, config);
     free_post_state(post_state);
     /* don't use str_bo_bool() because we require "true" string */
     const int result = !resp || resp->urr_is_error || strcmp(resp->urr_value, "true") != 0;
@@ -888,7 +888,7 @@ ureport_attach_string(struct ureport_server_config *config,
         error_msg(_("The server at '%s' responded with an error: '%s'"),
                 config->ur_url, resp->urr_value);
 
-    ureport_server_response_free(resp);
+    libreport_ureport_server_response_free(resp);
 
     return result;
 }

--- a/src/lib/ureport.c
+++ b/src/lib/ureport.c
@@ -244,7 +244,7 @@ ureport_server_config_load_basic_auth(struct ureport_server_config *config,
 
     if (strcmp(http_auth_pref, "rhts-credentials") == 0)
     {
-        settings = new_map_string();
+        settings = libreport_new_map_string();
 
         char *local_conf = libreport_xasprintf("%s"USER_HOME_CONFIG_PATH"/rhtsupport.conf", getenv("HOME"));
 
@@ -253,8 +253,8 @@ ureport_server_config_load_basic_auth(struct ureport_server_config *config,
             error_msg_and_die("Could not get RHTSupport credentials");
         free(local_conf);
 
-        username = get_map_string_item_or_NULL(settings, "Login");
-        password = get_map_string_item_or_NULL(settings, "Password");
+        username = libreport_get_map_string_item_or_NULL(settings, "Login");
+        password = libreport_get_map_string_item_or_NULL(settings, "Password");
 
         if (config->ur_url == NULL)
             ureport_server_config_set_url(config, libreport_xstrdup(RHSM_WEB_SERVICE_URL));
@@ -283,7 +283,7 @@ ureport_server_config_load_basic_auth(struct ureport_server_config *config,
 
     free(tmp_password);
     free(tmp_username);
-    free_map_string(settings);
+    libreport_free_map_string(settings);
 }
 
 void

--- a/src/lib/ureport.c
+++ b/src/lib/ureport.c
@@ -652,7 +652,7 @@ ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
 
             report_result_set_bthash(result, resp->urr_bthash);
 
-            add_reported_to_entry(dd, result);
+            libreport_add_reported_to_entry(dd, result);
 
             report_result_free(result);
         }
@@ -666,7 +666,7 @@ ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
 
             report_result_set_url(result, url);
 
-            add_reported_to_entry(dd, result);
+            libreport_add_reported_to_entry(dd, result);
 
             free(url);
             report_result_free(result);
@@ -682,7 +682,7 @@ ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
             workflow = getenv("LIBREPORT_WORKFLOW");
             if (NULL == workflow)
             {
-                add_reported_to(dd, e->data);
+                libreport_add_reported_to(dd, e->data);
             }
             else
             {
@@ -690,7 +690,7 @@ ureport_server_response_save_in_dump_dir(struct ureport_server_response *resp,
 
                 line = g_strdup_printf("%s WORKFLOW=%s", (const char *)e->data, workflow);
 
-                add_reported_to(dd, line);
+                libreport_add_reported_to(dd, line);
             }
         }
     }

--- a/src/lib/ureport.c
+++ b/src/lib/ureport.c
@@ -46,11 +46,11 @@
 static char *
 puppet_config_print(const char *key)
 {
-    char *command = xasprintf("puppet config print %s", key);
-    char *result = run_in_shell_and_save_output(0, command, NULL, NULL);
+    char *command = libreport_xasprintf("puppet config print %s", key);
+    char *result = libreport_run_in_shell_and_save_output(0, command, NULL, NULL);
     free(command);
 
-    /* run_in_shell_and_save_output always returns non-NULL */
+    /* libreport_run_in_shell_and_save_output always returns non-NULL */
     if (result[0] != '/')
         goto error;
 
@@ -78,14 +78,14 @@ rhsm_config_get_consumer_cert_dir(void)
 {
     char *result = getenv("LIBREPORT_DEBUG_RHSMCON_PEM_DIR_PATH");
     if (result != NULL)
-        return xstrdup(result);
+        return libreport_xstrdup(result);
 
-    result = run_in_shell_and_save_output(0,
+    result = libreport_run_in_shell_and_save_output(0,
             "python3 -c \"from rhsm.config import initConfig; print(initConfig().get('rhsm', 'consumerCertDir'))\"",
             NULL, NULL);
 
 
-    /* run_in_shell_and_save_output always returns non-NULL */
+    /* libreport_run_in_shell_and_save_output always returns non-NULL */
     if (result[0] != '/')
         goto error;
 
@@ -98,7 +98,7 @@ rhsm_config_get_consumer_cert_dir(void)
 error:
     free(result);
     error_msg("Failed to get 'rhsm':'consumerCertDir' from rhsm.config python module. Using "RHSMCON_PEM_DIR_PATH);
-    return xstrdup(RHSMCON_PEM_DIR_PATH);
+    return libreport_xstrdup(RHSMCON_PEM_DIR_PATH);
 }
 
 static bool
@@ -143,13 +143,13 @@ ureport_server_config_set_client_auth(struct ureport_server_config *config,
     else if (strcmp(client_auth, "rhsm") == 0)
     {
         if (config->ur_url == NULL)
-            ureport_server_config_set_url(config, xstrdup(RHSM_WEB_SERVICE_URL));
+            ureport_server_config_set_url(config, libreport_xstrdup(RHSM_WEB_SERVICE_URL));
 
         /* always returns non-NULL */
         char *rhsm_dir = rhsm_config_get_consumer_cert_dir();
 
-        char *cert_full_name = concat_path_file(rhsm_dir, RHSMCON_CERT_NAME);
-        char *key_full_name = concat_path_file(rhsm_dir, RHSMCON_KEY_NAME);
+        char *cert_full_name = libreport_concat_path_file(rhsm_dir, RHSMCON_CERT_NAME);
+        char *key_full_name = libreport_concat_path_file(rhsm_dir, RHSMCON_KEY_NAME);
 
         /* get authority certificate dir path from environment variable, if it
          * is not set, use CERT_AUTHORITY_CERT_PATH
@@ -158,7 +158,7 @@ ureport_server_config_set_client_auth(struct ureport_server_config *config,
         if (authority_cert_dir_path == NULL)
            authority_cert_dir_path = CERT_AUTHORITY_CERT_PATH;
 
-        char *cert_authority_cert_full_name = concat_path_file(authority_cert_dir_path,
+        char *cert_authority_cert_full_name = libreport_concat_path_file(authority_cert_dir_path,
                                                                  CERT_AUTHORITY_CERT_NAME);
 
         if (certificate_exist(cert_full_name) && certificate_exist(key_full_name))
@@ -193,9 +193,9 @@ ureport_server_config_set_client_auth(struct ureport_server_config *config,
     }
     else
     {
-        char *scratch = xstrdup(client_auth);
-        config->ur_client_cert = xstrdup(strtok(scratch, ":"));
-        config->ur_client_key = xstrdup(strtok(NULL, ":"));
+        char *scratch = libreport_xstrdup(client_auth);
+        config->ur_client_cert = libreport_xstrdup(strtok(scratch, ":"));
+        config->ur_client_key = libreport_xstrdup(strtok(NULL, ":"));
         free(scratch);
 
         if (config->ur_client_cert == NULL || config->ur_client_key == NULL)
@@ -222,10 +222,10 @@ ureport_server_config_set_basic_auth(struct ureport_server_config *config,
     ureport_server_config_set_client_auth(config, "");
 
     free(config->ur_username);
-    config->ur_username = xstrdup(login);
+    config->ur_username = libreport_xstrdup(login);
 
     free(config->ur_password);
-    config->ur_password = xstrdup(password);
+    config->ur_password = libreport_xstrdup(password);
 }
 
 void
@@ -246,10 +246,10 @@ ureport_server_config_load_basic_auth(struct ureport_server_config *config,
     {
         settings = new_map_string();
 
-        char *local_conf = xasprintf("%s"USER_HOME_CONFIG_PATH"/rhtsupport.conf", getenv("HOME"));
+        char *local_conf = libreport_xasprintf("%s"USER_HOME_CONFIG_PATH"/rhtsupport.conf", getenv("HOME"));
 
-        if (!load_plugin_conf_file("rhtsupport.conf", settings, /*skip key w/o values:*/ false) &&
-            !load_conf_file(local_conf, settings, /*skip key w/o values:*/ false))
+        if (!libreport_load_plugin_conf_file("rhtsupport.conf", settings, /*skip key w/o values:*/ false) &&
+            !libreport_load_conf_file(local_conf, settings, /*skip key w/o values:*/ false))
             error_msg_and_die("Could not get RHTSupport credentials");
         free(local_conf);
 
@@ -257,11 +257,11 @@ ureport_server_config_load_basic_auth(struct ureport_server_config *config,
         password = get_map_string_item_or_NULL(settings, "Password");
 
         if (config->ur_url == NULL)
-            ureport_server_config_set_url(config, xstrdup(RHSM_WEB_SERVICE_URL));
+            ureport_server_config_set_url(config, libreport_xstrdup(RHSM_WEB_SERVICE_URL));
     }
     else
     {
-        username = tmp_username = xstrdup(http_auth_pref);
+        username = tmp_username = libreport_xstrdup(http_auth_pref);
         password = strchr(tmp_username, ':');
 
         if (password != NULL)
@@ -271,7 +271,7 @@ ureport_server_config_load_basic_auth(struct ureport_server_config *config,
 
     if (password == NULL)
     {
-        char *message = xasprintf("Please provide uReport server password for user '%s':", username);
+        char *message = libreport_xasprintf("Please provide uReport server password for user '%s':", username);
         password = tmp_password = libreport_ask_password(message);
         free(message);
 
@@ -290,8 +290,8 @@ void
 ureport_server_config_load(struct ureport_server_config *config,
                            map_string_t *settings)
 {
-    UREPORT_OPTION_VALUE_FROM_CONF(settings, "URL", config->ur_url, xstrdup);
-    UREPORT_OPTION_VALUE_FROM_CONF(settings, "SSLVerify", config->ur_ssl_verify, string_to_bool);
+    UREPORT_OPTION_VALUE_FROM_CONF(settings, "URL", config->ur_url, libreport_xstrdup);
+    UREPORT_OPTION_VALUE_FROM_CONF(settings, "SSLVerify", config->ur_ssl_verify, libreport_string_to_bool);
 
     const char *http_auth_pref = NULL;
     UREPORT_OPTION_VALUE_FROM_CONF(settings, "HTTPAuth", http_auth_pref, (const char *));
@@ -306,13 +306,13 @@ ureport_server_config_load(struct ureport_server_config *config,
 
     /* If SSLClientAuth is configured, include the auth items by default. */
     bool include_auth = config->ur_client_cert != NULL || config->ur_username != NULL;
-    UREPORT_OPTION_VALUE_FROM_CONF(settings, "IncludeAuthData", include_auth, string_to_bool);
+    UREPORT_OPTION_VALUE_FROM_CONF(settings, "IncludeAuthData", include_auth, libreport_string_to_bool);
 
     if (include_auth)
     {
         const char *auth_items = NULL;
         UREPORT_OPTION_VALUE_FROM_CONF(settings, "AuthDataItems", auth_items, (const char *));
-        config->ur_prefs.urp_auth_items = parse_delimited_list(auth_items, ",");
+        config->ur_prefs.urp_auth_items = libreport_parse_delimited_list(auth_items, ",");
 
         if (config->ur_prefs.urp_auth_items == NULL)
             log_warning("IncludeAuthData set to 'yes' but AuthDataItems is empty.");
@@ -389,14 +389,14 @@ parse_solution_from_json_list(struct json_object *list,
 {
     json_object *list_elem, *struct_elem;
     const char *cause, *note, *url;
-    struct strbuf *solution_buf = strbuf_new();
+    struct strbuf *solution_buf = libreport_strbuf_new();
 
     const unsigned length = json_object_array_length(list);
 
     const char *one_format = _("Your problem seems to be caused by %s\n\n%s\n");
     if (length > 1)
     {
-        strbuf_append_str(solution_buf, _("Your problem seems to be caused by one of the following:\n"));
+        libreport_strbuf_append_str(solution_buf, _("Your problem seems to be caused by one of the following:\n"));
         one_format = "\n* %s\n\n%s\n";
     }
 
@@ -422,7 +422,7 @@ parse_solution_from_json_list(struct json_object *list,
             continue;
 
         empty = false;
-        strbuf_append_strf(solution_buf, one_format, cause, note);
+        libreport_strbuf_append_strf(solution_buf, one_format, cause, note);
 
         if (!json_object_object_get_ex(list_elem, "url", &struct_elem))
             continue;
@@ -430,18 +430,18 @@ parse_solution_from_json_list(struct json_object *list,
         url = json_object_get_string(struct_elem);
         if (url)
         {
-            char *reported_to_line = xasprintf("%s: URL=%s", cause, url);
+            char *reported_to_line = libreport_xasprintf("%s: URL=%s", cause, url);
             *reported_to = g_list_append(*reported_to, reported_to_line);
         }
     }
 
     if (empty)
     {
-        strbuf_free(solution_buf);
+        libreport_strbuf_free(solution_buf);
         return NULL;
     }
 
-    return strbuf_free_nobuf(solution_buf);
+    return libreport_strbuf_free_nobuf(solution_buf);
 }
 
 /* reported_to json element should be a list of structures
@@ -488,15 +488,15 @@ parse_reported_to_from_json_list(struct json_object *list)
         if (type)
         {
             if (strcasecmp("url", type) == 0)
-                prefix = xstrdup("URL=");
+                prefix = libreport_xstrdup("URL=");
             else if (strcasecmp("bthash", type) == 0)
-                prefix = xstrdup("BTHASH=");
+                prefix = libreport_xstrdup("BTHASH=");
         }
 
         if (!prefix)
-            prefix = xstrdup("");
+            prefix = libreport_xstrdup("");
 
-        reported_to_line = xasprintf("%s: %s%s", reporter, prefix, value);
+        reported_to_line = libreport_xasprintf("%s: %s%s", reporter, prefix, value);
         free(prefix);
 
         result = g_list_append(result, reported_to_line);
@@ -517,28 +517,28 @@ ureport_server_parse_json(json_object *json)
     json_object *obj = NULL;
     if (json_object_object_get_ex(json, "error", &obj))
     {
-        struct ureport_server_response *out_response = xzalloc(sizeof(*out_response));
+        struct ureport_server_response *out_response = libreport_xzalloc(sizeof(*out_response));
         out_response->urr_is_error = true;
         /*
          * Used to use json_object_to_json_string(obj), but it returns
          * the string in quote marks (") - IOW, json-formatted string.
          */
-        out_response->urr_value = xstrdup(json_object_get_string(obj));
+        out_response->urr_value = libreport_xstrdup(json_object_get_string(obj));
         return out_response;
     }
 
     if (json_object_object_get_ex(json, "result", &obj))
     {
-        struct ureport_server_response *out_response = xzalloc(sizeof(*out_response));
-        out_response->urr_value = xstrdup(json_object_get_string(obj));
+        struct ureport_server_response *out_response = libreport_xzalloc(sizeof(*out_response));
+        out_response->urr_value = libreport_xstrdup(json_object_get_string(obj));
 
         json_object *message = NULL;
         if (json_object_object_get_ex(json, "message", &message))
-            out_response->urr_message = xstrdup(json_object_get_string(message));
+            out_response->urr_message = libreport_xstrdup(json_object_get_string(message));
 
         json_object *bthash = NULL;
         if (json_object_object_get_ex(json, "bthash", &bthash))
-            out_response->urr_bthash = xstrdup(json_object_get_string(bthash));
+            out_response->urr_bthash = libreport_xstrdup(json_object_get_string(bthash));
 
         json_object *reported_to_list = NULL;
         if (json_object_object_get_ex(json, "reported_to", &reported_to_list))
@@ -706,8 +706,8 @@ char *
 ureport_server_response_get_report_url(struct ureport_server_response *resp,
                                        struct ureport_server_config *config)
 {
-    char *bthash_url = concat_path_file(config->ur_url, BTHASH_URL_SFX);
-    char *report_url = concat_path_file(bthash_url, resp->urr_bthash);
+    char *bthash_url = libreport_concat_path_file(config->ur_url, BTHASH_URL_SFX);
+    char *report_url = libreport_concat_path_file(bthash_url, resp->urr_bthash);
     free(bthash_url);
     return report_url;
 }
@@ -717,7 +717,7 @@ ureport_add_str(struct json_object *ur, const char *key, const char *s)
 {
     struct json_object *jstring = json_object_new_string(s);
     if (!jstring)
-        die_out_of_memory();
+        libreport_die_out_of_memory();
 
     json_object_object_add(ur, key, jstring);
 }
@@ -742,7 +742,7 @@ ureport_from_dump_dir_ext(const char *dump_dir_path, const struct ureport_prefer
     {
         struct dump_dir *dd = dd_opendir(dump_dir_path, DD_OPEN_READONLY);
         if (!dd)
-            xfunc_die(); /* dd_opendir() already printed an error message */
+            libreport_xfunc_die(); /* dd_opendir() already printed an error message */
 
         GList *iter = preferences->urp_auth_items;
         for ( ; iter != NULL; iter = g_list_next(iter))
@@ -805,7 +805,7 @@ ureport_do_post(const char *json, struct ureport_server_config *config,
         "Connection: close",
         NULL,
     };
-    char *dest_url = concat_path_file(config->ur_url, url_sfx);
+    char *dest_url = libreport_concat_path_file(config->ur_url, url_sfx);
 
     post_string_as_form_data(post_state, dest_url, "application/json",
                              headers, json);
@@ -854,13 +854,13 @@ ureport_json_attachment_new(const char *bthash, const char *type, const char *da
 {
     struct json_object *attachment = json_object_new_object();
     if (!attachment)
-        die_out_of_memory();
+        libreport_die_out_of_memory();
 
     ureport_add_str(attachment, "bthash", bthash);
     ureport_add_str(attachment, "type", type);
     ureport_add_str(attachment, "data", data);
 
-    char *result = xstrdup(json_object_to_json_string(attachment));
+    char *result = libreport_xstrdup(json_object_to_json_string(attachment));
     json_object_put(attachment);
 
     return result;

--- a/src/lib/uriparser.c
+++ b/src/lib/uriparser.c
@@ -21,7 +21,7 @@
 
 #include <regex.h>
 
-int uri_userinfo_remove(const char *uri, char **result, char **scheme, char **hostname, char **username, char **password, char **location)
+int libreport_uri_userinfo_remove(const char *uri, char **result, char **scheme, char **hostname, char **username, char **password, char **location)
 {
     /* https://www.ietf.org/rfc/rfc3986.txt
      * Appendix B.  Parsing a URI Reference with a Regular Expression
@@ -46,7 +46,7 @@ int uri_userinfo_remove(const char *uri, char **result, char **scheme, char **ho
         return -EINVAL;
     }
 
-    char *ptr = xzalloc((strlen(uri) + 1) * sizeof(char));
+    char *ptr = libreport_xzalloc((strlen(uri) + 1) * sizeof(char));
     *result = ptr;
     if (scheme != NULL)
         *scheme = NULL;
@@ -94,7 +94,7 @@ int uri_userinfo_remove(const char *uri, char **result, char **scheme, char **ho
     { \
         size_t len = 0; \
         len = matchptr[(i)].rm_eo - matchptr[(i)].rm_so; \
-        if (output) *output = xstrndup(uri + matchptr[(i)].rm_so, len); \
+        if (output) *output = libreport_xstrndup(uri + matchptr[(i)].rm_so, len); \
         strncpy(ptr, uri + matchptr[(i)].rm_so, len); \
         ptr += len; \
     }
@@ -138,13 +138,13 @@ int uri_userinfo_remove(const char *uri, char **result, char **scheme, char **ho
                 }
 
                 if (password != NULL)
-                    *password = xstrndup(authority + colon + 1, at - colon - 1);
+                    *password = libreport_xstrndup(authority + colon + 1, at - colon - 1);
 
                 break;
             }
 
             if (username != NULL)
-                *username = xstrndup(authority, colon);
+                *username = libreport_xstrndup(authority, colon);
 
             ++at;
             break;
@@ -153,7 +153,7 @@ int uri_userinfo_remove(const char *uri, char **result, char **scheme, char **ho
         len -= at;
 
         if (hostname != NULL)
-            *hostname = xstrndup(authority + at, len);
+            *hostname = libreport_xstrndup(authority + at, len);
 
         strncpy(ptr, authority + at, len);
         ptr += len;

--- a/src/lib/user_settings.c
+++ b/src/lib/user_settings.c
@@ -27,9 +27,9 @@ static char *get_user_config_file_path(const char *name, const char *suffix)
     char *conf;
 
     if (suffix != NULL)
-        s = xasprintf("%s.%s", name, suffix);
+        s = libreport_xasprintf("%s.%s", name, suffix);
 
-    conf = concat_path_file(get_user_conf_base_dir(), s != NULL ? s : name);
+    conf = libreport_concat_path_file(libreport_get_user_conf_base_dir(), s != NULL ? s : name);
     free(s);
 
     return conf;
@@ -40,46 +40,46 @@ static char *get_conf_path(const char *name)
     return get_user_config_file_path(name, "conf");
 }
 
-bool save_app_conf_file(const char* application_name, map_string_t *settings)
+bool libreport_save_app_conf_file(const char* application_name, map_string_t *settings)
 {
     char *app_conf_path = get_conf_path(application_name);
-    bool result = save_conf_file(app_conf_path, settings);
+    bool result = libreport_save_conf_file(app_conf_path, settings);
     free(app_conf_path);
 
     return result;
 }
 
-bool load_app_conf_file(const char *application_name, map_string_t *settings)
+bool libreport_load_app_conf_file(const char *application_name, map_string_t *settings)
 {
     char *app_conf_path = get_conf_path(application_name);
-    bool result = load_conf_file(app_conf_path, settings, false);
+    bool result = libreport_load_conf_file(app_conf_path, settings, false);
     free(app_conf_path);
 
     return result;
 }
 
-void set_app_user_setting(map_string_t *settings, const char *name, const char *value)
+void libreport_set_app_user_setting(map_string_t *settings, const char *name, const char *value)
 {
     if (value)
-        replace_map_string_item(settings, xstrdup(name), xstrdup(value));
+        replace_map_string_item(settings, libreport_xstrdup(name), libreport_xstrdup(value));
     else
         remove_map_string_item(settings, name);
 }
 
-const char *get_app_user_setting(map_string_t *settings, const char *name)
+const char *libreport_get_app_user_setting(map_string_t *settings, const char *name)
 {
     return get_map_string_item_or_NULL(settings, name);
 }
 
-bool save_user_settings()
+bool libreport_save_user_settings()
 {
     if (!conf_path || !user_settings)
         return true;
 
-    return save_conf_file(conf_path, user_settings);
+    return libreport_save_conf_file(conf_path, user_settings);
 }
 
-bool load_user_settings(const char *application_name)
+bool libreport_load_user_settings(const char *application_name)
 {
     if (conf_path)
         free(conf_path);
@@ -89,29 +89,29 @@ bool load_user_settings(const char *application_name)
         free_map_string(user_settings);
     user_settings = new_map_string();
 
-    return load_conf_file(conf_path, user_settings, false);
+    return libreport_load_conf_file(conf_path, user_settings, false);
 }
 
-void set_user_setting(const char *name, const char *value)
+void libreport_set_user_setting(const char *name, const char *value)
 {
     if (!user_settings)
         return;
-    set_app_user_setting(user_settings, name, value);
+    libreport_set_app_user_setting(user_settings, name, value);
 }
 
-const char *get_user_setting(const char *name)
+const char *libreport_get_user_setting(const char *name)
 {
     if (!user_settings)
         return NULL;
 
-    return get_app_user_setting(user_settings, name);
+    return libreport_get_app_user_setting(user_settings, name);
 }
 
-GList *load_words_from_file(const char* filename)
+GList *libreport_load_words_from_file(const char* filename)
 {
     GList *words_list = NULL;
     GList *file_list = NULL;
-    file_list = g_list_prepend(file_list, concat_path_file(CONF_DIR, filename));
+    file_list = g_list_prepend(file_list, libreport_concat_path_file(CONF_DIR, filename));
     file_list = g_list_prepend(file_list, get_user_config_file_path(filename, /*don't append suffix*/NULL));
     GList *file_list_cur = file_list;
 
@@ -124,7 +124,7 @@ GList *load_words_from_file(const char* filename)
             /* every line is one word
              */
             char *line;
-            while ((line = xmalloc_fgetline(fp)) != NULL)
+            while ((line = libreport_xmalloc_fgetline(fp)) != NULL)
             {
                 //FIXME: works only if the '#' is first char won't work for " #abcd#
                 if (line[0] != '#') // if it's not comment
@@ -135,7 +135,7 @@ GList *load_words_from_file(const char* filename)
             fclose(fp);
         }
         /* Don't disturb users with useless warnings about missing files. */
-        else if (errno != ENOENT || g_verbose >= 3)
+        else if (errno != ENOENT || libreport_g_verbose >= 3)
         {
             perror_msg("Can't open %s", cur_file);
         }
@@ -143,7 +143,7 @@ GList *load_words_from_file(const char* filename)
         file_list_cur = g_list_next(file_list_cur);
     }
 
-    list_free_with_free(file_list);
+    libreport_list_free_with_free(file_list);
 
     return words_list;
 }

--- a/src/lib/user_settings.c
+++ b/src/lib/user_settings.c
@@ -61,14 +61,14 @@ bool libreport_load_app_conf_file(const char *application_name, map_string_t *se
 void libreport_set_app_user_setting(map_string_t *settings, const char *name, const char *value)
 {
     if (value)
-        replace_map_string_item(settings, libreport_xstrdup(name), libreport_xstrdup(value));
+        libreport_replace_map_string_item(settings, libreport_xstrdup(name), libreport_xstrdup(value));
     else
-        remove_map_string_item(settings, name);
+        libreport_remove_map_string_item(settings, name);
 }
 
 const char *libreport_get_app_user_setting(map_string_t *settings, const char *name)
 {
-    return get_map_string_item_or_NULL(settings, name);
+    return libreport_get_map_string_item_or_NULL(settings, name);
 }
 
 bool libreport_save_user_settings()
@@ -86,8 +86,8 @@ bool libreport_load_user_settings(const char *application_name)
     conf_path = get_conf_path(application_name);
 
     if (user_settings)
-        free_map_string(user_settings);
-    user_settings = new_map_string();
+        libreport_free_map_string(user_settings);
+    user_settings = libreport_new_map_string();
 
     return libreport_load_conf_file(conf_path, user_settings, false);
 }

--- a/src/lib/utf8.c
+++ b/src/lib/utf8.c
@@ -18,7 +18,7 @@
 */
 #include "internal_libreport.h"
 
-char *sanitize_utf8(const char *src, uint32_t control_chars_to_sanitize)
+char *libreport_sanitize_utf8(const char *src, uint32_t control_chars_to_sanitize)
 {
     const char *initial_src = src;
     char *sanitized = NULL;
@@ -83,7 +83,7 @@ char *sanitize_utf8(const char *src, uint32_t control_chars_to_sanitize)
             c = (unsigned char) *src++;
             if (sanitized)
             {
-                sanitized = (char*) xrealloc(sanitized, sanitized_pos + 2);
+                sanitized = (char*) libreport_xrealloc(sanitized, sanitized_pos + 2);
                 sanitized[sanitized_pos++] = c;
                 sanitized[sanitized_pos] = '\0';
             }
@@ -94,9 +94,9 @@ char *sanitize_utf8(const char *src, uint32_t control_chars_to_sanitize)
         if (!sanitized)
         {
             sanitized_pos = src - initial_src;
-            sanitized = xstrndup(initial_src, sanitized_pos);
+            sanitized = libreport_xstrndup(initial_src, sanitized_pos);
         }
-        sanitized = (char*) xrealloc(sanitized, sanitized_pos + 5);
+        sanitized = (char*) libreport_xrealloc(sanitized, sanitized_pos + 5);
         sanitized[sanitized_pos++] = '[';
         c = (unsigned char) *src++;
         sanitized[sanitized_pos++] = "0123456789ABCDEF"[c >> 4];

--- a/src/lib/workflow.c
+++ b/src/lib/workflow.c
@@ -34,7 +34,7 @@ GHashTable *g_workflow_list;
 
 workflow_t *new_workflow(const char *name)
 {
-    workflow_t *w = xzalloc(sizeof(*w));
+    workflow_t *w = libreport_xzalloc(sizeof(*w));
     w->info = new_config_info(name);
     return w;
 }
@@ -90,7 +90,7 @@ static void load_workflow_config(const char *name,
         workflow_t *workflow = new_workflow(file->filename);
         load_workflow_description_from_file(workflow, file->fullpath);
         log_info("Adding '%s' to workflows\n", file->filename);
-        g_hash_table_insert(wf_list, xstrdup(file->filename), workflow);
+        g_hash_table_insert(wf_list, libreport_xstrdup(file->filename), workflow);
     }
 }
 
@@ -108,13 +108,13 @@ GHashTable *load_workflow_config_data_from_list(GList *wf_names,
     if (path == NULL)
         path = WORKFLOWS_DIR;
 
-    GList *workflow_files = get_file_list(path, "xml");
+    GList *workflow_files = libreport_get_file_list(path, "xml");
     while(wfs)
     {
         load_workflow_config((const char *)wfs->data, workflow_files, wf_list);
         wfs = g_list_next(wfs);
     }
-    free_file_list(workflow_files);
+    libreport_free_file_list(workflow_files);
 
     return wf_list;
 }
@@ -134,7 +134,7 @@ GHashTable *load_workflow_config_data(const char *path)
     if (path == NULL)
         path = WORKFLOWS_DIR;
 
-    GList *workflow_files = get_file_list(path, "xml");
+    GList *workflow_files = libreport_get_file_list(path, "xml");
     while (workflow_files)
     {
         file_obj_t *file = (file_obj_t *)workflow_files->data;
@@ -147,9 +147,9 @@ GHashTable *load_workflow_config_data(const char *path)
         load_workflow_description_from_file(workflow, file->fullpath);
 
         if (nw_workflow)
-            g_hash_table_replace(g_workflow_list, xstrdup(wf_get_name(workflow)), workflow);
+            g_hash_table_replace(g_workflow_list, libreport_xstrdup(wf_get_name(workflow)), workflow);
 
-        free_file_obj(file);
+        libreport_free_file_obj(file);
         workflow_files = g_list_delete_link(workflow_files, workflow_files);
     }
 
@@ -176,7 +176,7 @@ GList *wf_get_event_names(workflow_t *w)
         /* Since appending is inefficient for GLib doubly-linked lists, we prepend
          * here and reverse the list just before returning.
          */
-        event_names = g_list_prepend(event_names, xstrdup(ec_get_name(wf_event_list->data)));
+        event_names = g_list_prepend(event_names, libreport_xstrdup(ec_get_name(wf_event_list->data)));
         wf_event_list = g_list_next(wf_event_list);
     }
 

--- a/src/lib/workflow.c
+++ b/src/lib/workflow.c
@@ -119,7 +119,7 @@ GHashTable *load_workflow_config_data_from_list(GList *wf_names,
     return wf_list;
 }
 
-GHashTable *load_workflow_config_data(const char *path)
+GHashTable *libreport_load_workflow_config_data(const char *path)
 {
     if (g_workflow_list)
         return g_workflow_list;

--- a/src/lib/workflow_xml_parser.c
+++ b/src/lib/workflow_xml_parser.c
@@ -91,7 +91,7 @@ static void text(GMarkupParseContext *context,
             const gchar *event_name = expanded_events->data;
 
             event_config_t *ec = new_event_config(event_name);
-            g_autofree gchar *event_file = xasprintf(EVENTS_DIR"/%s.xml", event_name);
+            g_autofree gchar *event_file = libreport_xasprintf(EVENTS_DIR"/%s.xml", event_name);
 
             load_event_description_from_file(ec, event_file);
             if (ec_get_screen_name(ec))
@@ -194,7 +194,7 @@ void load_workflow_description_from_file(workflow_t *workflow, const char* filen
 {
     log_info("loading workflow: '%s'", filename);
     struct my_parse_data parse_data = { workflow, NULL, NULL, 0, 0, 0};
-    parse_data.cur_locale = xstrdup(setlocale(LC_ALL, NULL));
+    parse_data.cur_locale = libreport_xstrdup(setlocale(LC_ALL, NULL));
     strchrnul(parse_data.cur_locale, '.')[0] = '\0';
 
     GMarkupParser parser;

--- a/src/lib/xatonum.c
+++ b/src/lib/xatonum.c
@@ -22,7 +22,7 @@
  */
 #include "internal_libreport.h"
 
-int try_atou(const char *numstr, unsigned *value)
+int libreport_try_atou(const char *numstr, unsigned *value)
 {
     int ret = 0;
     unsigned long r;
@@ -62,23 +62,23 @@ finito:
     return ret;
 }
 
-unsigned xatou(const char *numstr)
+unsigned libreport_xatou(const char *numstr)
 {
     unsigned value = (unsigned)-1;
 
-    if (try_atou(numstr, &value) != 0)
+    if (libreport_try_atou(numstr, &value) != 0)
         error_msg_and_die("expected number in range <0, %d>: '%s'", UINT_MAX, numstr);
 
     return value;
 }
 
-int try_atoi_positive(const char *numstr, int *value)
+int libreport_try_atoi_positive(const char *numstr, int *value)
 {
     unsigned tmp;
 
     g_return_val_if_fail (NULL != numstr, -EINVAL);
 
-    int r = try_atou(numstr, &tmp);
+    int r = libreport_try_atou(numstr, &tmp);
     if (r != 0)
         return r;
 
@@ -89,25 +89,25 @@ int try_atoi_positive(const char *numstr, int *value)
     return 0;
 }
 
-int xatoi_positive(const char *numstr)
+int libreport_xatoi_positive(const char *numstr)
 {
     int value = INT_MIN;
 
-    if (try_atoi_positive(numstr, &value) != 0)
+    if (libreport_try_atoi_positive(numstr, &value) != 0)
         error_msg_and_die("expected number in range <0, %d>: '%s'", INT_MAX, numstr);
 
     return  value;
 }
 
-int try_atoi(const char *numstr, int *value)
+int libreport_try_atoi(const char *numstr, int *value)
 {
     g_return_val_if_fail (NULL != numstr, -EINVAL);
 
     if (*numstr != '-')
-        return try_atoi_positive(numstr, value);
+        return libreport_try_atoi_positive(numstr, value);
 
     unsigned tmp;
-    int r = try_atou(numstr + 1, &tmp);
+    int r = libreport_try_atou(numstr + 1, &tmp);
     if (r < 0)
         return r;
 
@@ -118,11 +118,11 @@ int try_atoi(const char *numstr, int *value)
     return 0;
 }
 
-int xatoi(const char *numstr)
+int libreport_xatoi(const char *numstr)
 {
     int value = INT_MIN;
 
-    if (try_atoi(numstr, &value))
+    if (libreport_try_atoi(numstr, &value))
         error_msg_and_die("expected number in range <%d, %d>: '%s'", INT_MIN, INT_MAX, numstr);
 
     return (int)value;

--- a/src/lib/xfuncs.c
+++ b/src/lib/xfuncs.c
@@ -19,7 +19,7 @@
 #include "internal_libreport.h"
 
 /* Turn on nonblocking I/O on a fd */
-int ndelay_on(int fd)
+int libreport_ndelay_on(int fd)
 {
     int flags = fcntl(fd, F_GETFL);
     if (flags & O_NONBLOCK)
@@ -27,7 +27,7 @@ int ndelay_on(int fd)
     return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 }
 
-int ndelay_off(int fd)
+int libreport_ndelay_off(int fd)
 {
     int flags = fcntl(fd, F_GETFL);
     if (!(flags & O_NONBLOCK))
@@ -35,41 +35,41 @@ int ndelay_off(int fd)
     return fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
 }
 
-int close_on_exec_on(int fd)
+int libreport_close_on_exec_on(int fd)
 {
     return fcntl(fd, F_SETFD, FD_CLOEXEC);
 }
 
 // Die if we can't allocate size bytes of memory.
-void* xmalloc(size_t size)
+void* libreport_xmalloc(size_t size)
 {
     void *ptr = malloc(size);
     if (ptr == NULL && size != 0)
-        die_out_of_memory();
+        libreport_die_out_of_memory();
     return ptr;
 }
 
 // Die if we can't resize previously allocated memory.  (This returns a pointer
 // to the new memory, which may or may not be the same as the old memory.
 // It'll copy the contents to a new chunk and free the old one if necessary.)
-void* xrealloc(void *ptr, size_t size)
+void* libreport_xrealloc(void *ptr, size_t size)
 {
     ptr = realloc(ptr, size);
     if (ptr == NULL && size != 0)
-        die_out_of_memory();
+        libreport_die_out_of_memory();
     return ptr;
 }
 
 // Die if we can't allocate and zero size bytes of memory.
-void* xzalloc(size_t size)
+void* libreport_xzalloc(size_t size)
 {
-    void *ptr = xmalloc(size);
+    void *ptr = libreport_xmalloc(size);
     memset(ptr, 0, size);
     return ptr;
 }
 
 // Die if we can't copy a string to freshly allocated memory.
-char* xstrdup(const char *s)
+char* libreport_xstrdup(const char *s)
 {
     char *t;
     if (s == NULL)
@@ -78,20 +78,20 @@ char* xstrdup(const char *s)
     t = strdup(s);
 
     if (t == NULL)
-        die_out_of_memory();
+        libreport_die_out_of_memory();
 
     return t;
 }
 
 // Die if we can't allocate n+1 bytes (space for the null terminator) and copy
 // the (possibly truncated to length n) string into it.
-char* xstrndup(const char *s, int n)
+char *libreport_xstrndup(const char *s, int n)
 {
     int m;
     char *t;
 
-    /* We can just xmalloc(n+1) and strncpy into it, */
-    /* but think about xstrndup("abc", 10000) wastage! */
+    /* We can just libreport_xmalloc(n+1) and strncpy into it, */
+    /* but think about libreport_xstrndup("abc", 10000) wastage! */
     m = n;
     t = (char*) s;
     while (m)
@@ -101,13 +101,13 @@ char* xstrndup(const char *s, int n)
         t++;
     }
     n -= m;
-    t = (char*) xmalloc(n + 1);
+    t = (char*) libreport_xmalloc(n + 1);
     t[n] = '\0';
 
     return (char*) memcpy(t, s, n);
 }
 
-char *xstrdup_between(const char *src, const char *open, const char *close)
+char *libreport_xstrdup_between(const char *src, const char *open, const char *close)
 {
     const char *start = strstr(src, open);
     if (start == NULL)
@@ -125,16 +125,16 @@ char *xstrdup_between(const char *src, const char *open, const char *close)
         return NULL;
     }
 
-    return xstrndup(start, stop - start);
+    return libreport_xstrndup(start, stop - start);
 }
 
-void xpipe(int filedes[2])
+void libreport_xpipe(int filedes[2])
 {
     if (pipe(filedes))
         perror_msg_and_die("Can't create pipe");
 }
 
-int xdup(int from)
+int libreport_xdup(int from)
 {
     int fd = dup(from);
     if (fd < 0)
@@ -142,38 +142,38 @@ int xdup(int from)
     return fd;
 }
 
-void xdup2(int from, int to)
+void libreport_xdup2(int from, int to)
 {
     if (dup2(from, to) != to)
         perror_msg_and_die("Can't duplicate file descriptor");
 }
 
 // "Renumber" opened fd
-void xmove_fd(int from, int to)
+void libreport_xmove_fd(int from, int to)
 {
     if (from == to)
         return;
-    xdup2(from, to);
+    libreport_xdup2(from, to);
     close(from);
 }
 
 // Die with an error message if we can't write the entire buffer.
-void xwrite(int fd, const void *buf, size_t count)
+void libreport_xwrite(int fd, const void *buf, size_t count)
 {
     if (count == 0)
         return;
-    ssize_t size = full_write(fd, buf, count);
+    ssize_t size = libreport_full_write(fd, buf, count);
     if ((size_t)size != count)
         error_msg_and_die("short write");
 }
 
-void xwrite_str(int fd, const char *str)
+void libreport_xwrite_str(int fd, const char *str)
 {
-    xwrite(fd, str, strlen(str));
+    libreport_xwrite(fd, str, strlen(str));
 }
 
 // Die with an error message if we can't lseek to the right spot.
-off_t xlseek(int fd, off_t offset, int whence)
+off_t libreport_xlseek(int fd, off_t offset, int whence)
 {
     off_t off = lseek(fd, offset, whence);
     if (off == (off_t)-1) {
@@ -184,13 +184,13 @@ off_t xlseek(int fd, off_t offset, int whence)
     return off;
 }
 
-void xchdir(const char *path)
+void libreport_xchdir(const char *path)
 {
     if (chdir(path))
         perror_msg_and_die("chdir(%s)", path);
 }
 
-char* xvasprintf(const char *format, va_list p)
+char* libreport_xvasprintf(const char *format, va_list p)
 {
     int r;
     char *string_ptr;
@@ -203,39 +203,39 @@ char* xvasprintf(const char *format, va_list p)
     va_list p2;
     va_copy(p2, p);
     r = vsnprintf(NULL, 0, format, p);
-    string_ptr = xmalloc(r+1);
+    string_ptr = libreport_xmalloc(r+1);
     r = vsnprintf(string_ptr, r+1, format, p2);
     va_end(p2);
 #endif
 
     if (r < 0)
-        die_out_of_memory();
+        libreport_die_out_of_memory();
     return string_ptr;
 }
 
 // Die with an error message if we can't malloc() enough space and do an
 // sprintf() into that space., sizeof() into that space.)
-char* xasprintf(const char *format, ...)
+char *libreport_xasprintf(const char *format, ...)
 {
     va_list p;
     char *string_ptr;
 
     va_start(p, format);
-    string_ptr = xvasprintf(format, p);
+    string_ptr = libreport_xvasprintf(format, p);
     va_end(p);
 
     return string_ptr;
 }
 
-void xsetenv(const char *key, const char *value)
+void libreport_xsetenv(const char *key, const char *value)
 {
     if (setenv(key, value, 1))
-        die_out_of_memory();
+        libreport_die_out_of_memory();
 }
 
-void safe_unsetenv(const char *var_val)
+void libreport_safe_unsetenv(const char *var_val)
 {
-    //char *name = xstrndup(var_val, strchrnul(var_val, '=') - var_val);
+    //char *name = libreport_xstrndup(var_val, strchrnul(var_val, '=') - var_val);
     //unsetenv(name);
     //free(name);
 
@@ -248,7 +248,7 @@ void safe_unsetenv(const char *var_val)
 }
 
 // Die with an error message if we can't open a new socket.
-int xsocket(int domain, int type, int protocol)
+int libreport_xsocket(int domain, int type, int protocol)
 {
     int r = socket(domain, type, protocol);
     if (r < 0)
@@ -264,14 +264,14 @@ int xsocket(int domain, int type, int protocol)
 }
 
 // Die with an error message if we can't bind a socket to an address.
-void xbind(int sockfd, struct sockaddr *my_addr, socklen_t addrlen)
+void libreport_xbind(int sockfd, struct sockaddr *my_addr, socklen_t addrlen)
 {
     if (bind(sockfd, my_addr, addrlen))
         perror_msg_and_die("bind");
 }
 
 // Die with an error message if we can't listen for connections on a socket.
-void xlisten(int s, int backlog)
+void libreport_xlisten(int s, int backlog)
 {
     if (listen(s, backlog))
         perror_msg_and_die("listen");
@@ -279,7 +279,7 @@ void xlisten(int s, int backlog)
 
 // Die with an error message if sendto failed.
 // Return bytes sent otherwise
-ssize_t xsendto(int s, const void *buf, size_t len,
+ssize_t libreport_xsendto(int s, const void *buf, size_t len,
                 const struct sockaddr *to,
                 socklen_t tolen)
 {
@@ -292,14 +292,14 @@ ssize_t xsendto(int s, const void *buf, size_t len,
     return ret;
 }
 
-// xstat() - a stat() which dies on failure with meaningful error message
-void xstat(const char *name, struct stat *stat_buf)
+// libreport_xstat() - a stat() which dies on failure with meaningful error message
+void libreport_xstat(const char *name, struct stat *stat_buf)
 {
     if (stat(name, stat_buf))
         perror_msg_and_die("Can't stat '%s'", name);
 }
 
-off_t fstat_st_size_or_die(int fd)
+off_t libreport_fstat_st_size_or_die(int fd)
 {
     struct stat statbuf;
     if (fstat(fd, &statbuf))
@@ -307,7 +307,7 @@ off_t fstat_st_size_or_die(int fd)
     return statbuf.st_size;
 }
 
-off_t stat_st_size_or_die(const char *filename)
+off_t libreport_stat_st_size_or_die(const char *filename)
 {
     struct stat statbuf;
     if (stat(filename, &statbuf))
@@ -316,7 +316,7 @@ off_t stat_st_size_or_die(const char *filename)
 }
 
 // Die if we can't open a file and return a fd
-int xopen3(const char *pathname, int flags, int mode)
+int libreport_xopen3(const char *pathname, int flags, int mode)
 {
     int ret;
     ret = open(pathname, flags, mode);
@@ -326,18 +326,18 @@ int xopen3(const char *pathname, int flags, int mode)
 }
 
 // Die if we can't open an existing file and return a fd
-int xopen(const char *pathname, int flags)
+int libreport_xopen(const char *pathname, int flags)
 {
-    return xopen3(pathname, flags, 0666);
+    return libreport_xopen3(pathname, flags, 0666);
 }
 
-void xunlinkat(int dir_fd, const char *pathname, int flags)
+void libreport_xunlinkat(int dir_fd, const char *pathname, int flags)
 {
     if (unlinkat(dir_fd, pathname, flags))
         perror_msg_and_die("Can't remove file '%s'", pathname);
 }
 
-void xunlink(const char *pathname)
+void libreport_xunlink(const char *pathname)
 {
     if (unlink(pathname))
         perror_msg_and_die("Can't remove file '%s'", pathname);
@@ -365,7 +365,7 @@ int open_or_warn(const char *pathname, int flags)
  * do not report the type, they report DT_UNKNOWN for every dirent
  * (and this is not a bug in filesystem, this is allowed by standards).
  */
-int is_regular_file_at(struct dirent *dent, int dir_fd)
+int libreport_is_regular_file_at(struct dirent *dent, int dir_fd)
 {
     if (dent->d_type == DT_REG)
         return 1;
@@ -378,19 +378,19 @@ int is_regular_file_at(struct dirent *dent, int dir_fd)
     return r == 0 && S_ISREG(statbuf.st_mode);
 }
 
-int is_regular_file(struct dirent *dent, const char *dirname)
+int libreport_is_regular_file(struct dirent *dent, const char *dirname)
 {
     int dir_fd = open(dirname, O_DIRECTORY);
     if (dir_fd < 0)
         return 0;
-    int r = is_regular_file_at(dent, dir_fd);
+    int r = libreport_is_regular_file_at(dent, dir_fd);
     close(dir_fd);
     return r;
 }
 
 /* Is it "." or ".."? */
 /* abrtlib candidate */
-bool dot_or_dotdot(const char *filename)
+bool libreport_dot_or_dotdot(const char *filename)
 {
     if (filename[0] != '.') return false;
     if (filename[1] == '\0') return true;
@@ -402,7 +402,7 @@ bool dot_or_dotdot(const char *filename)
 /* Find out if the last character of a string matches the one given.
  * Don't underrun the buffer if the string length is 0.
  */
-char *last_char_is(const char *s, int c)
+char *libreport_last_char_is(const char *s, int c)
 {
     if (s && *s)
     {
@@ -413,7 +413,7 @@ char *last_char_is(const char *s, int c)
     return NULL;
 }
 
-bool string_to_bool(const char *s)
+bool libreport_string_to_bool(const char *s)
 {
     if (s[0] == '1' && s[1] == '\0')
         return true;
@@ -426,31 +426,31 @@ bool string_to_bool(const char *s)
     return false;
 }
 
-void xseteuid(uid_t euid)
+void libreport_xseteuid(uid_t euid)
 {
     if (seteuid(euid) != 0)
         perror_msg_and_die("Can't set %cid %lu", 'u', (long)euid);
 }
 
-void xsetegid(gid_t egid)
+void libreport_xsetegid(gid_t egid)
 {
     if (setegid(egid) != 0)
         perror_msg_and_die("Can't set %cid %lu", 'g', (long)egid);
 }
 
-void xsetreuid(uid_t ruid, uid_t euid)
+void libreport_xsetreuid(uid_t ruid, uid_t euid)
 {
     if (setreuid(ruid, euid) != 0)
         perror_msg_and_die("Can't set %cid %lu", 'u', (long)ruid);
 }
 
-void xsetregid(gid_t rgid, gid_t egid)
+void libreport_xsetregid(gid_t rgid, gid_t egid)
 {
     if (setregid(rgid, egid) != 0)
         perror_msg_and_die("Can't set %cid %lu", 'g', (long)rgid);
 }
 
-FILE *xfdopen(int fd, const char *mode)
+FILE *libreport_xfdopen(int fd, const char *mode)
 {
     FILE *const r = fdopen(fd, mode);
     if (NULL == r)

--- a/src/lib/xml_parser.c
+++ b/src/lib/xml_parser.c
@@ -24,7 +24,7 @@ char *get_element_lang(struct my_parse_data *parse_data, const gchar **att_names
 {
     /* if the element has no attribute then it's a default non-localized value */
     if (att_values[0] == NULL)
-        return xstrdup("");
+        return libreport_xstrdup("");
 
     char *short_locale_end = strchr(parse_data->cur_locale, '_');
     for (int i = 0; att_names[i] != NULL; ++i)
@@ -34,7 +34,7 @@ char *get_element_lang(struct my_parse_data *parse_data, const gchar **att_names
             if (strcmp(att_values[i], parse_data->cur_locale) == 0)
             {
                 log_debug("found translation for: %s", parse_data->cur_locale);
-                return xstrdup(att_values[i]);
+                return libreport_xstrdup(att_values[i]);
             }
 
             /* try to match shorter locale
@@ -44,7 +44,7 @@ char *get_element_lang(struct my_parse_data *parse_data, const gchar **att_names
              && strncmp(att_values[i], parse_data->cur_locale, short_locale_end - parse_data->cur_locale) == 0
             ) {
                 log_debug("found translation for shortlocale: %s", parse_data->cur_locale);
-                return xstrndup(att_values[i], short_locale_end - parse_data->cur_locale);
+                return libreport_xstrndup(att_values[i], short_locale_end - parse_data->cur_locale);
             }
         }
     }

--- a/src/plugins/abrt_rh_support.c
+++ b/src/plugins/abrt_rh_support.c
@@ -130,7 +130,7 @@ reportfile_t*
 new_reportfile(void)
 {
     // create a new reportfile_t
-    reportfile_t* file = (reportfile_t*)xmalloc(sizeof(*file));
+    reportfile_t* file = (reportfile_t*)libreport_xmalloc(sizeof(*file));
 
     // set up a libxml 'buffer' and 'writer' to that buffer
     file->buf = xxmlBufferCreate();
@@ -180,7 +180,7 @@ reportfile_add_binding_from_namedfile(reportfile_t* file,
     // <binding name=NAME fileName=FILENAME type=text/binary...
     internal_reportfile_start_binding(file, binding_name, isbinary, recorded_filename);
     // ... href=content/NAME>
-    char *href_name = concat_path_file("content", binding_name);
+    char *href_name = libreport_concat_path_file("content", binding_name);
     xxmlTextWriterWriteAttribute(file->writer, "href", href_name);
     free(href_name);
 }
@@ -267,7 +267,7 @@ make_case_data(const char* summary, const char* description,
     }
 
     xxmlTextWriterEndDocument(writer);
-    retval = xstrdup((const char*)buf->content);
+    retval = libreport_xstrdup((const char*)buf->content);
     xmlFreeTextWriter(writer);
     xmlBufferFree(buf);
     return retval;
@@ -285,7 +285,7 @@ post_case_to_url(const char* url,
                 const char* description,
                 const char* component)
 {
-    rhts_result_t *result = xzalloc(sizeof(*result));
+    rhts_result_t *result = libreport_xzalloc(sizeof(*result));
     char *url_copy = NULL;
 
     char *case_data = make_case_data(summary, description,
@@ -318,7 +318,7 @@ post_case_to_url(const char* url,
          * instead of returning html-encoded body, we show short concise message,
          * and show offending URL (typos in which is a typical cause) */
         result->error = -1;
-        result->msg = xasprintf("Error in HTTP POST, "
+        result->msg = libreport_xasprintf("Error in HTTP POST, "
                         "HTTP code: 404 (Not found), URL:'%s'", url);
         break;
 
@@ -328,7 +328,7 @@ post_case_to_url(const char* url,
         if (++redirect_count < 10 && location)
         {
             free(url_copy);
-            url = url_copy = xstrdup(location);
+            url = url_copy = libreport_xstrdup(location);
             free_post_state(post_state);
             goto redirect;
         }
@@ -353,7 +353,7 @@ post_case_to_url(const char* url,
         errmsg = post_state->curl_error_msg;
         if (errmsg && errmsg[0])
         {
-            result->msg = xasprintf(_("Error in case creation at '%s': %s"),
+            result->msg = libreport_xasprintf(_("Error in case creation at '%s': %s"),
                     url, errmsg);
         }
         else
@@ -362,11 +362,11 @@ post_case_to_url(const char* url,
             if (!errmsg)
                 errmsg = post_state->body;
             if (errmsg && errmsg[0])
-                result->msg = xasprintf(_("Error in case creation at '%s',"
+                result->msg = libreport_xasprintf(_("Error in case creation at '%s',"
                         " HTTP code: %d, server says: '%s'"),
                         url, post_state->http_resp_code, errmsg);
             else
-                result->msg = xasprintf(_("Error in case creation at '%s',"
+                result->msg = libreport_xasprintf(_("Error in case creation at '%s',"
                         " HTTP code: %d"),
                         url, post_state->http_resp_code);
         }
@@ -375,7 +375,7 @@ post_case_to_url(const char* url,
     case 200:
     case 201:
         /* Created successfully */
-        result->url = xstrdup(location); /* note: xstrdup(NULL) returns NULL */
+        result->url = libreport_xstrdup(location); /* note: libreport_xstrdup(NULL) returns NULL */
     } /* switch (HTTP code) */
 
     result->http_resp_code = post_state->http_resp_code;
@@ -399,7 +399,7 @@ create_new_case(const char* base_url,
                 const char* description,
                 const char* component)
 {
-    char *url = concat_path_file(base_url, "cases");
+    char *url = libreport_concat_path_file(base_url, "cases");
     rhts_result_t *result = post_case_to_url(url,
                 username,
                 password,
@@ -417,7 +417,7 @@ create_new_case(const char* base_url,
         /* Case Creation returned valid code, but no location */
         result->error = -1;
         free(result->msg);
-        result->msg = xasprintf(_("Error in case creation at '%s':"
+        result->msg = libreport_xasprintf(_("Error in case creation at '%s':"
                 " no Location URL, HTTP code: %d"),
                 url, result->http_resp_code
         );
@@ -455,7 +455,7 @@ make_comment_data(const char *comment_text)
     xxmlTextWriterWriteElement(writer, "text", comment_text);
 
     xxmlTextWriterEndDocument(writer);
-    retval = xstrdup((const char*)buf->content);
+    retval = libreport_xstrdup((const char*)buf->content);
     xmlFreeTextWriter(writer);
     xmlBufferFree(buf);
     return retval;
@@ -469,7 +469,7 @@ post_comment_to_url(const char *url,
                 const char **additional_headers,
                 const char *comment_text)
 {
-    rhts_result_t *result = xzalloc(sizeof(*result));
+    rhts_result_t *result = libreport_xzalloc(sizeof(*result));
     char *url_copy = NULL;
 
     char *xml = make_comment_data(comment_text);
@@ -500,7 +500,7 @@ post_comment_to_url(const char *url,
          * instead of returning html-encoded body, we show short concise message,
          * and show offending URL (typos in which is a typical cause) */
         result->error = -1;
-        result->msg = xasprintf("Error in HTTP POST, "
+        result->msg = libreport_xasprintf("Error in HTTP POST, "
                         "HTTP code: 404 (Not found), URL:'%s'", url);
         break;
 
@@ -510,7 +510,7 @@ post_comment_to_url(const char *url,
         if (++redirect_count < 10 && location)
         {
             free(url_copy);
-            url = url_copy = xstrdup(location);
+            url = url_copy = libreport_xstrdup(location);
             free_post_state(post_state);
             goto redirect;
         }
@@ -521,7 +521,7 @@ post_comment_to_url(const char *url,
         errmsg = post_state->curl_error_msg;
         if (errmsg && errmsg[0])
         {
-            result->msg = xasprintf(_("Error in comment creation at '%s': %s"),
+            result->msg = libreport_xasprintf(_("Error in comment creation at '%s': %s"),
                         url, errmsg);
         }
         else
@@ -530,11 +530,11 @@ post_comment_to_url(const char *url,
             if (!errmsg)
                 errmsg = post_state->body;
             if (errmsg && errmsg[0])
-                result->msg = xasprintf(_("Error in comment creation at '%s',"
+                result->msg = libreport_xasprintf(_("Error in comment creation at '%s',"
                         " HTTP code: %d, server says: '%s'"),
                         url, post_state->http_resp_code, errmsg);
             else
-                result->msg = xasprintf(_("Error in comment creation at '%s',"
+                result->msg = libreport_xasprintf(_("Error in comment creation at '%s',"
                         " HTTP code: %d"),
                         url, post_state->http_resp_code);
         }
@@ -543,7 +543,7 @@ post_comment_to_url(const char *url,
     case 200:
     case 201:
         /* Created successfully */
-        result->url = xstrdup(location); /* note: xstrdup(NULL) returns NULL */
+        result->url = libreport_xstrdup(location); /* note: libreport_xstrdup(NULL) returns NULL */
     } /* switch (HTTP code) */
 
     result->http_resp_code = post_state->http_resp_code;
@@ -563,7 +563,7 @@ add_comment_to_case(const char* base_url,
                 bool ssl_verify,
                 const char* comment_text)
 {
-    char *url = concat_path_file(base_url, "comments");
+    char *url = libreport_concat_path_file(base_url, "comments");
     rhts_result_t *result = post_comment_to_url(url,
                 username,
                 password,
@@ -580,7 +580,7 @@ add_comment_to_case(const char* base_url,
         /* Creation returned valid code, but no location */
         result->error = -1;
         free(result->msg);
-        result->msg = xasprintf(_("Error in comment creation at '%s':"
+        result->msg = libreport_xasprintf(_("Error in comment creation at '%s':"
                 " no Location URL, HTTP code: %d"),
                 url, result->http_resp_code
         );
@@ -602,7 +602,7 @@ post_file_to_url(const char* url,
                 const char **additional_headers,
                 const char *file_name)
 {
-    rhts_result_t *result = xzalloc(sizeof(*result));
+    rhts_result_t *result = libreport_xzalloc(sizeof(*result));
     char *url_copy = NULL;
 
     int redirect_count = 0;
@@ -649,7 +649,7 @@ post_file_to_url(const char* url,
         if (++redirect_count < 10 && atch_location)
         {
             free(url_copy);
-            url = url_copy = xstrdup(atch_location);
+            url = url_copy = libreport_xstrdup(atch_location);
             free_post_state(atch_state);
             goto redirect_attach;
         }
@@ -661,18 +661,18 @@ post_file_to_url(const char* url,
         errmsg = atch_state->curl_error_msg;
         if (errmsg && errmsg[0])
         {
-            result->msg = xasprintf("Error in file upload at '%s': %s",
+            result->msg = libreport_xasprintf("Error in file upload at '%s': %s",
                     url, errmsg);
         }
         else
         {
             errmsg = atch_state->body;
             if (errmsg && errmsg[0])
-                result->msg = xasprintf("Error in file upload at '%s',"
+                result->msg = libreport_xasprintf("Error in file upload at '%s',"
                         " HTTP code: %d, server says: '%s'",
                         url, atch_state->http_resp_code, errmsg);
             else
-                result->msg = xasprintf("Error in file upload at '%s',"
+                result->msg = libreport_xasprintf("Error in file upload at '%s',"
                         " HTTP code: %d",
                         url, atch_state->http_resp_code);
         }
@@ -680,8 +680,8 @@ post_file_to_url(const char* url,
 
     case 200:
     case 201:
-        result->url = xstrdup(atch_location); /* note: xstrdup(NULL) returns NULL */
-        //result->msg = xstrdup("File uploaded successfully");
+        result->url = libreport_xstrdup(atch_location); /* note: libreport_xstrdup(NULL) returns NULL */
+        //result->msg = libreport_xstrdup("File uploaded successfully");
     } /* switch (HTTP code) */
 
     result->http_resp_code = atch_state->http_resp_code;
@@ -700,7 +700,7 @@ attach_file_to_case(const char* base_url,
                 bool ssl_verify,
                 const char *file_name)
 {
-    char *url = concat_path_file(base_url, "attachments");
+    char *url = libreport_concat_path_file(base_url, "attachments");
     rhts_result_t *result = post_file_to_url(url,
                 username,
                 password,
@@ -723,7 +723,7 @@ get_rhts_hints(const char* base_url,
                 bool ssl_verify,
                 const char* file_name)
 {
-    char *url = concat_path_file(base_url, "problems");
+    char *url = libreport_concat_path_file(base_url, "problems");
 //    rhts_result_t *result = post_case_to_url(url,
 //                username,
 //                password,

--- a/src/plugins/mantisbt.c
+++ b/src/plugins/mantisbt.c
@@ -932,7 +932,7 @@ static void
 custom_field_ask(const char *name)
 {
     char *msg = xasprintf(_("MantisBT doesn't contain custom field '%s', which is required for full functionality of the reporter. Do you still want to create a new issue?"), name);
-    int yes = ask_yes_no(msg);
+    int yes = libreport_ask_yes_no(msg);
     free(msg);
 
     if (!yes)

--- a/src/plugins/mantisbt.c
+++ b/src/plugins/mantisbt.c
@@ -1059,7 +1059,7 @@ mantisbt_get_issue_info(const mantisbt_settings_t *settings, int issue_id)
     if (add_info != NULL)
         issue_info->mii_notes = g_list_append (issue_info->mii_notes, add_info);
     issue_info->mii_attachments = response_values_at_depth_by_name(result->mr_body, "filename", -1);
-    issue_info->mii_best_bt_rating = comments_find_best_bt_rating(issue_info->mii_notes);
+    issue_info->mii_best_bt_rating = libreport_comments_find_best_bt_rating(issue_info->mii_notes);
 
     mantisbt_result_free(result);
     return issue_info;

--- a/src/plugins/report.c
+++ b/src/plugins/report.c
@@ -55,18 +55,18 @@ int main(int argc, char **argv)
     };
     /* Keep enum above and order of options below in sync! */
     struct options program_options[] = {
-        OPT__VERBOSE(&g_verbose),
+        OPT__VERBOSE(&libreport_g_verbose),
         OPT_STRING('T', "target", &target, "TARGET", _("'rhts' or 'bugzilla'")),
         OPT_STRING('t', "ticket", &ticket, "ID"    , _("Ticket/case ID")),
         OPT_END()
     };
-    /*unsigned opts =*/ parse_opts(argc, argv, program_options, program_usage_string);
+    /*unsigned opts =*/ libreport_parse_opts(argc, argv, program_options, program_usage_string);
 
-    export_abrt_envvars(0);
+    libreport_export_abrt_envvars(0);
 
     argv += optind;
     if (!*argv || !target || !ticket)
-        show_usage_and_die(program_usage_string, program_options);
+        libreport_show_usage_and_die(program_usage_string, program_options);
 
     const char *tool_name;
     if (strcmp(target, "rhts") == 0 || strcmp(target, "strata") == 0)
@@ -75,11 +75,11 @@ int main(int argc, char **argv)
     if (strcmp(target, "bugzilla") == 0)
         tool_name = "reporter-bugzilla";
     else
-        show_usage_and_die(program_usage_string, program_options);
+        libreport_show_usage_and_die(program_usage_string, program_options);
 
     argv -= 2;
     argv[0] = (char*) tool_name;
-    argv[1] = xasprintf("-t%s", ticket);
+    argv[1] = libreport_xasprintf("-t%s", ticket);
 
     execvp(argv[0], argv);
     perror_msg_and_die("Can't execute '%s'", argv[0]);

--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -493,7 +493,7 @@ int main(int argc, char **argv)
             if (!dd)
                 xfunc_die();
 
-            reported_to = find_in_reported_to(dd, "Bugzilla");
+            reported_to = libreport_find_in_reported_to(dd, "Bugzilla");
 
             dd_close(dd);
 
@@ -565,7 +565,7 @@ int main(int argc, char **argv)
         if (!dd)
             xfunc_die();
 
-        reported_to = find_in_reported_to(dd, "Bugzilla");
+        reported_to = libreport_find_in_reported_to(dd, "Bugzilla");
 
         dd_close(dd);
 
@@ -803,7 +803,7 @@ int main(int argc, char **argv)
                         email = strtok(NULL, "\n");
                     }
                 }
-                reported_to = find_in_reported_to(dd, tracker_str);
+                reported_to = libreport_find_in_reported_to(dd, tracker_str);
                 if (NULL != reported_to)
                 {
                     url = report_result_get_url(reported_to);
@@ -962,7 +962,7 @@ int main(int argc, char **argv)
 
         report_result_set_url(result, url);
 
-        add_reported_to_entry(dd, result);
+        libreport_add_reported_to_entry(dd, result);
 
         free(url);
         report_result_free(result);

--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -912,7 +912,7 @@ int main(int argc, char **argv)
 
         const char *bzcomment = problem_report_get_description(pr);
 
-        int dup_comment = is_comment_dup(bz->bi_comments, bzcomment);
+        int dup_comment = libreport_is_comment_dup(bz->bi_comments, bzcomment);
         if (!dup_comment)
         {
             log_warning(_("Adding new comment to bug %d"), bz->bi_id);

--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -89,7 +89,7 @@ struct bugzilla_struct {
 static void set_default_settings(map_string_t *osinfo, map_string_t *settings)
 {
     char *default_BugzillaURL;
-    parse_osinfo_for_bug_url(osinfo, &default_BugzillaURL);
+    libreport_parse_osinfo_for_bug_url(osinfo, &default_BugzillaURL);
     /* if BugzillaURL is defined in conf_file or env , it will replace this value */
     set_map_string_item_from_string(settings, "BugzillaURL", default_BugzillaURL);
     log_debug("Loaded BUG_REPORT_URL '%s' from os-release", default_BugzillaURL);
@@ -97,7 +97,7 @@ static void set_default_settings(map_string_t *osinfo, map_string_t *settings)
 
     char *default_Product;
     char *default_ProductVersion;
-    parse_osinfo_for_bz(osinfo, &default_Product, &default_ProductVersion);
+    libreport_parse_osinfo_for_bz(osinfo, &default_Product, &default_ProductVersion);
     /* if Product or ProductVersion is defined in conf_file or env , it will replace this value */
     set_map_string_item_from_string(settings, "Product", default_Product);
     set_map_string_item_from_string(settings, "ProductVersion", default_ProductVersion);
@@ -112,13 +112,13 @@ static void set_settings(struct bugzilla_struct *b, map_string_t *settings)
     const char *environ;
 
     environ = getenv("Bugzilla_Login");
-    b->b_login = xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "Login"));
+    b->b_login = libreport_xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "Login"));
 
     environ = getenv("Bugzilla_Password");
-    b->b_password = xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "Password"));
+    b->b_password = libreport_xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "Password"));
 
     environ = getenv("Bugzilla_BugzillaURL");
-    b->b_bugzilla_url = xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "BugzillaURL"));
+    b->b_bugzilla_url = libreport_xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "BugzillaURL"));
     if (!b->b_bugzilla_url[0])
         b->b_bugzilla_url = "https://bugzilla.redhat.com";
     else
@@ -128,35 +128,35 @@ static void set_settings(struct bugzilla_struct *b, map_string_t *settings)
         if (last_slash && last_slash[1] == '\0')
             *last_slash = '\0';
     }
-    b->b_bugzilla_xmlrpc = concat_path_file(b->b_bugzilla_url, "xmlrpc.cgi");
+    b->b_bugzilla_xmlrpc = libreport_concat_path_file(b->b_bugzilla_url, "xmlrpc.cgi");
 
     environ = getenv("Bugzilla_Product");
     if (environ)
     {
-        b->b_product = xstrdup(environ);
+        b->b_product = libreport_xstrdup(environ);
         environ = getenv("Bugzilla_ProductVersion");
         if (environ)
-            b->b_product_version = xstrdup(environ);
+            b->b_product_version = libreport_xstrdup(environ);
     }
     else
     {
         const char *option = get_map_string_item_or_NULL(settings, "Product");
         if (option)
-            b->b_product = xstrdup(option);
+            b->b_product = libreport_xstrdup(option);
         option = get_map_string_item_or_NULL(settings, "ProductVersion");
         if (option)
-            b->b_product_version = xstrdup(option);
+            b->b_product_version = libreport_xstrdup(option);
     }
 
     if (!b->b_product)
     {   /* Compat, remove it later (2014?). */
         environ = getenv("Bugzilla_OSRelease");
         if (environ)
-            parse_release_for_bz(environ, &b->b_product, &b->b_product_version);
+            libreport_parse_release_for_bz(environ, &b->b_product, &b->b_product_version);
     }
 
     environ = getenv("Bugzilla_SSLVerify");
-    b->b_ssl_verify = string_to_bool(environ ? environ : get_map_string_item_or_empty(settings, "SSLVerify"));
+    b->b_ssl_verify = libreport_string_to_bool(environ ? environ : get_map_string_item_or_empty(settings, "SSLVerify"));
 
     environ = getenv("Bugzilla_DontMatchComponents");
     b->b_DontMatchComponents = environ ? environ : get_map_string_item_or_empty(settings, "DontMatchComponents");
@@ -166,12 +166,12 @@ static void set_settings(struct bugzilla_struct *b, map_string_t *settings)
     if (!b->b_create_private)
     {
         environ = getenv("Bugzilla_CreatePrivate");
-        b->b_create_private = string_to_bool(environ ? environ : get_map_string_item_or_empty(settings, "Bugzilla_CreatePrivate"));
+        b->b_create_private = libreport_string_to_bool(environ ? environ : get_map_string_item_or_empty(settings, "Bugzilla_CreatePrivate"));
     }
     log_notice("create private bz ticket: '%s'", b->b_create_private ? "YES": "NO");
 
     environ = getenv("Bugzilla_PrivateGroups");
-    GList *groups = parse_delimited_list(environ ? environ : get_map_string_item_or_empty(settings, "Bugzilla_PrivateGroups"),
+    GList *groups = libreport_parse_delimited_list(environ ? environ : get_map_string_item_or_empty(settings, "Bugzilla_PrivateGroups"),
                                          ",");
     if (b->b_private_groups == NULL)
     {
@@ -191,7 +191,7 @@ char *ask_bz_login(const char *message)
     char *login = libreport_ask(message);
     if (login == NULL || login[0] == '\0')
     {
-        set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
+        libreport_set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
         error_msg_and_die(_("Can't continue without login"));
     }
 
@@ -204,7 +204,7 @@ char *ask_bz_password(const char *message)
     char *password = libreport_ask_password(message);
     if (password == NULL || password[0] == '\0')
     {
-        set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
+        libreport_set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
         error_msg_and_die(_("Can't continue without password"));
     }
 
@@ -221,12 +221,12 @@ void login(struct abrt_xmlrpc *client, struct bugzilla_struct *rhbz)
         char *question;
 
         free(rhbz->b_login);
-        question = xasprintf(_("Invalid password or login. Please enter your %s login:"), rhbz->b_bugzilla_url);
+        question = libreport_xasprintf(_("Invalid password or login. Please enter your %s login:"), rhbz->b_bugzilla_url);
         rhbz->b_login = ask_bz_login(question);
         free(question);
 
         free(rhbz->b_password);
-        question = xasprintf(_("Invalid password or login. Please enter the password for '%s':"), rhbz->b_login);
+        question = libreport_xasprintf(_("Invalid password or login. Please enter the password for '%s':"), rhbz->b_login);
         rhbz->b_password = ask_bz_password(question);
         free(question);
     }
@@ -320,7 +320,7 @@ int main(int argc, char **argv)
     struct bugzilla_struct rhbz = { 0 };
     /* Keep enum above and order of options below in sync! */
     struct options program_options[] = {
-        OPT__VERBOSE(&g_verbose),
+        OPT__VERBOSE(&libreport_g_verbose),
         OPT_STRING(   'd', NULL, &dump_dir_name , "DIR"    , _("Problem directory")),
         OPT_LIST(     'c', NULL, &conf_file     , "FILE"   , _("Configuration file (may be given many times)")),
         OPT_STRING(   'F', NULL, &fmt_file      , "FILE"   , _("Formatting file for initial comment")),
@@ -336,10 +336,10 @@ int main(int argc, char **argv)
         OPT_OPTSTRING('D', "debug", &debug_str  , "STR"    , _("Debug")),
         OPT_END()
     };
-    unsigned opts = parse_opts(argc, argv, program_options, program_usage_string);
+    unsigned opts = libreport_parse_opts(argc, argv, program_options, program_usage_string);
     argv += optind;
 
-    export_abrt_envvars(0);
+    libreport_export_abrt_envvars(0);
 
     map_string_t *settings = new_map_string();
     problem_data_t *problem_data = NULL;
@@ -349,7 +349,7 @@ int main(int argc, char **argv)
         /* pull in some defaults from os-release */
         problem_data = create_problem_data_for_reporting(dump_dir_name);
         if (!problem_data)
-            xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
+            libreport_xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
         else
         {
             map_string_t *osinfo = new_map_string();
@@ -364,14 +364,14 @@ int main(int argc, char **argv)
         if (!conf_file)
         {
             conf_file = g_list_append(conf_file, (char*) CONF_DIR"/plugins/bugzilla.conf");
-            local_conf = xasprintf("%s"USER_HOME_CONFIG_PATH"/bugzilla.conf", getenv("HOME"));
+            local_conf = libreport_xasprintf("%s"USER_HOME_CONFIG_PATH"/bugzilla.conf", getenv("HOME"));
             conf_file = g_list_append(conf_file, local_conf);
         }
         while (conf_file)
         {
             char *fn = (char *)conf_file->data;
             log_notice("Loading settings from '%s'", fn);
-            load_conf_file(fn, settings, /*skip key w/o values:*/ false);
+            libreport_load_conf_file(fn, settings, /*skip key w/o values:*/ false);
             log_debug("Loaded '%s'", fn);
             conf_file = g_list_delete_link(conf_file, conf_file);
         }
@@ -402,10 +402,10 @@ int main(int argc, char **argv)
     {
         log_warning(_("Looking for similar problems in bugzilla"));
         char *hash;
-        if (prefixcmp(abrt_hash, "abrt_hash:"))
-            hash = xasprintf("abrt_hash:%s", abrt_hash);
+        if (libreport_prefixcmp(abrt_hash, "abrt_hash:"))
+            hash = libreport_xasprintf("abrt_hash:%s", abrt_hash);
         else
-            hash = xstrdup(abrt_hash);
+            hash = libreport_xstrdup(abrt_hash);
 
         if (opts & OPT_p)
         {
@@ -421,9 +421,9 @@ int main(int argc, char **argv)
                 if (os_release != NULL)
                 {
                     map_string_t *os_release_map = new_map_string();
-                    parse_osinfo(os_release, os_release_map);
+                    libreport_parse_osinfo(os_release, os_release_map);
 
-                    product = xstrdup(get_map_string_item_or_NULL(os_release_map, "REDHAT_BUGZILLA_PRODUCT"));
+                    product = libreport_xstrdup(get_map_string_item_or_NULL(os_release_map, "REDHAT_BUGZILLA_PRODUCT"));
 
                     free_map_string(os_release_map);
                     free(os_release);
@@ -439,7 +439,7 @@ int main(int argc, char **argv)
         if (product == NULL)
         {
             /* Use DEFAULT_BUGZILLA_PRODUCT as default product due to backward compatibility */
-            product = xstrdup(DEFAULT_BUGZILLA_PRODUCT);
+            product = libreport_xstrdup(DEFAULT_BUGZILLA_PRODUCT);
 
             /* If parameter -p was used and product == NULL, some error occured */
             if (opts & OPT_p)
@@ -466,7 +466,7 @@ int main(int argc, char **argv)
     if (rhbz.b_login[0] == '\0')
     {
         free(rhbz.b_login);
-        char *question = xasprintf(_("Login is not provided by configuration. Please enter your %s login:"), rhbz.b_bugzilla_url);
+        char *question = libreport_xasprintf(_("Login is not provided by configuration. Please enter your %s login:"), rhbz.b_bugzilla_url);
         rhbz.b_login = ask_bz_login(question);
         free(question);
     }
@@ -474,7 +474,7 @@ int main(int argc, char **argv)
     if (rhbz.b_password[0] == '\0')
     {
         free(rhbz.b_password);
-        char *question = xasprintf(_("Password is not provided by configuration. Please enter the password for '%s':"), rhbz.b_login);
+        char *question = libreport_xasprintf(_("Password is not provided by configuration. Please enter the password for '%s':"), rhbz.b_login);
         rhbz.b_password = ask_bz_password(question);
         free(question);
     }
@@ -482,7 +482,7 @@ int main(int argc, char **argv)
     if (opts & OPT_t)
     {
         if ((!argv[0] && !(opts & OPT_w)) || (argv[0] && (opts & OPT_w)))
-            show_usage_and_die(program_usage_string, program_options);
+            libreport_show_usage_and_die(program_usage_string, program_options);
 
         if (!ticket_no)
         {
@@ -491,7 +491,7 @@ int main(int argc, char **argv)
             g_autofree char *url = NULL;
 
             if (!dd)
-                xfunc_die();
+                libreport_xfunc_die();
 
             reported_to = libreport_find_in_reported_to(dd, "Bugzilla");
 
@@ -502,7 +502,7 @@ int main(int argc, char **argv)
 
             url = report_result_get_url(reported_to);
 
-            if (prefixcmp(url, rhbz.b_bugzilla_url) != 0)
+            if (libreport_prefixcmp(url, rhbz.b_bugzilla_url) != 0)
                 error_msg_and_die(_("This problem has been reported to Bugzilla '%s' which differs from the configured Bugzilla '%s'."), url, rhbz.b_bugzilla_url);
 
             ticket_no = strrchr(url, '=');
@@ -510,14 +510,14 @@ int main(int argc, char **argv)
                 error_msg_and_die(_("Malformed url to Bugzilla '%s'."), url);
 
             /* won't ever call free on it - it simplifies the code a lot */
-            ticket_no = xstrdup(ticket_no + 1);
+            ticket_no = libreport_xstrdup(ticket_no + 1);
             log_warning(_("Using Bugzilla ID '%s'"), ticket_no);
         }
 
         login(client, &rhbz);
 
         if (opts & OPT_w)
-            rhbz_mail_to_cc(client, xatoi_positive(ticket_no), rhbz.b_login, /* require mail notify */ 0);
+            rhbz_mail_to_cc(client, libreport_xatoi_positive(ticket_no), rhbz.b_login, /* require mail notify */ 0);
         else
         {   /* Attach files to existing BZ */
             while (*argv)
@@ -563,7 +563,7 @@ int main(int argc, char **argv)
         g_autofree char *url = NULL;
 
         if (!dd)
-            xfunc_die();
+            libreport_xfunc_die();
 
         reported_to = libreport_find_in_reported_to(dd, "Bugzilla");
 
@@ -577,7 +577,7 @@ int main(int argc, char **argv)
         {
             g_autofree char *msg = NULL;
 
-            msg = xasprintf(_("This problem was already reported to Bugzilla (see '%s')."
+            msg = libreport_xasprintf(_("This problem was already reported to Bugzilla (see '%s')."
                             " Do you still want to create a new bug?"),
                             url);
 
@@ -590,7 +590,7 @@ int main(int argc, char **argv)
         problem_data = create_problem_data_for_reporting(dump_dir_name);
 
     if (!problem_data)
-        xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
+        libreport_xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
 
     const char *component = problem_data_get_content_or_die(problem_data, FILENAME_COMPONENT);
     const char *duphash   = problem_data_get_content_or_NULL(problem_data, FILENAME_DUPHASH);
@@ -603,7 +603,7 @@ int main(int argc, char **argv)
         free(rhbz.b_product_version);
         map_string_t *osinfo = new_map_string();
         problem_data_get_osinfo(problem_data, osinfo);
-        parse_osinfo_for_bz(osinfo, &rhbz.b_product, &rhbz.b_product_version);
+        libreport_parse_osinfo_for_bz(osinfo, &rhbz.b_product, &rhbz.b_product_version);
         free_map_string(osinfo);
 
         if (!rhbz.b_product || !rhbz.b_product_version)
@@ -653,7 +653,7 @@ int main(int argc, char **argv)
         char *cmd = strtok(remote_result, " \n");
         char *id = strtok(NULL, " \n");
 
-        if (!prefixcmp(cmd, "DUPLICATE"))
+        if (!libreport_prefixcmp(cmd, "DUPLICATE"))
         {
             errno = 0;
             char *e;
@@ -677,7 +677,7 @@ int main(int argc, char **argv)
             /* Figure out whether we want to match component
              * when doing dup search.
              */
-            const char *component_substitute = is_in_comma_separated_list(component, rhbz.b_DontMatchComponents) ? NULL : component;
+            const char *component_substitute = libreport_is_in_comma_separated_list(component, rhbz.b_DontMatchComponents) ? NULL : component;
 
             /* We don't do dup detection across versions (see below why),
              * but we do add a note if cross-version potential dup exists.
@@ -725,7 +725,7 @@ int main(int argc, char **argv)
 
             if (existing_id >= 0)
             {
-                char *msg = xasprintf(_(
+                char *msg = libreport_xasprintf(_(
                 "You have requested to make your data accessible only to a "
                 "specific group and this bug is a duplicate of bug: "
                 "%s/%u"
@@ -834,7 +834,7 @@ int main(int argc, char **argv)
             }
 
             bz = new_bug_info();
-            bz->bi_status = xstrdup("NEW");
+            bz->bi_status = libreport_xstrdup("NEW");
             bz->bi_id = new_id;
 
             if (existing_id >= 0)
@@ -923,7 +923,7 @@ int main(int argc, char **argv)
             const char *rating_str = problem_data_get_content_or_NULL(problem_data, FILENAME_RATING);
             /* python doesn't have rating file */
             if (rating_str)
-                rating = xatou(rating_str);
+                rating = libreport_xatou(rating_str);
             if (bt && rating > bz->bi_best_bt_rating)
             {
                 char bug_id_str[sizeof(int)*3 + 2];
@@ -958,7 +958,7 @@ int main(int argc, char **argv)
         char *url;
 
         result = report_result_new_with_label_from_env("Bugzilla");
-        url = xasprintf("%s/show_bug.cgi?id=%u", rhbz.b_bugzilla_url, bz->bi_id);
+        url = libreport_xasprintf("%s/show_bug.cgi?id=%u", rhbz.b_bugzilla_url, bz->bi_id);
 
         report_result_set_url(result, url);
 

--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -188,7 +188,7 @@ static void set_settings(struct bugzilla_struct *b, map_string_t *settings)
 static
 char *ask_bz_login(const char *message)
 {
-    char *login = ask(message);
+    char *login = libreport_ask(message);
     if (login == NULL || login[0] == '\0')
     {
         set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
@@ -201,7 +201,7 @@ char *ask_bz_login(const char *message)
 static
 char *ask_bz_password(const char *message)
 {
-    char *password = ask_password(message);
+    char *password = libreport_ask_password(message);
     if (password == NULL || password[0] == '\0')
     {
         set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
@@ -581,7 +581,7 @@ int main(int argc, char **argv)
                             " Do you still want to create a new bug?"),
                             url);
 
-            if (!ask_yes_no(msg))
+            if (!libreport_ask_yes_no(msg))
                 return 0;
         }
     }
@@ -740,7 +740,7 @@ int main(int argc, char **argv)
                 "Otherwise, the bug reporting procedure will be terminated."),
                 rhbz.b_bugzilla_url, existing_id);
 
-                int r = ask_yes_no(msg);
+                int r = libreport_ask_yes_no(msg);
                 free(msg);
 
                 if (r == 0)

--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -161,7 +161,7 @@ static void set_settings(struct bugzilla_struct *b, map_string_t *settings)
     environ = getenv("Bugzilla_DontMatchComponents");
     b->b_DontMatchComponents = environ ? environ : get_map_string_item_or_empty(settings, "DontMatchComponents");
 
-    b->b_create_private = get_global_create_private_ticket();
+    b->b_create_private = libreport_get_global_create_private_ticket();
 
     if (!b->b_create_private)
     {

--- a/src/plugins/reporter-kerneloops.c
+++ b/src/plugins/reporter-kerneloops.c
@@ -124,7 +124,7 @@ static void report_to_kerneloops(
 
         report_result_set_url(result, submitURL);
 
-        add_reported_to_entry(dd, result);
+        libreport_add_reported_to_entry(dd, result);
 
         report_result_free(result);
 

--- a/src/plugins/reporter-kerneloops.c
+++ b/src/plugins/reporter-kerneloops.c
@@ -27,7 +27,7 @@ static size_t writefunction(void *ptr, size_t size, size_t nmemb, void *stream)
     char *c, *c1, *c2;
 
     log_warning("received: '%*.*s'", (int)size, (int)size, (char*)ptr);
-    c = (char*)xzalloc(size + 1);
+    c = (char*)libreport_xzalloc(size + 1);
     memcpy(c, ptr, size);
     c1 = strstr(c, "201 ");
     if (c1)
@@ -91,7 +91,7 @@ static void report_to_kerneloops(
 {
     problem_data_t *problem_data = create_problem_data_for_reporting(dump_dir_name);
     if (!problem_data)
-        xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
+        libreport_xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
 
     const char *backtrace = problem_data_get_content_or_NULL(problem_data, FILENAME_BACKTRACE);
     if (!backtrace)
@@ -169,20 +169,20 @@ int main(int argc, char **argv)
     };
     /* Keep enum above and order of options below in sync! */
     struct options program_options[] = {
-        OPT__VERBOSE(&g_verbose),
+        OPT__VERBOSE(&libreport_g_verbose),
         OPT_STRING('d', NULL, &dump_dir_name, "DIR" , _("Problem directory")),
         OPT_LIST(  'c', NULL, &conf_file    , "FILE", _("Configuration file")),
         OPT_END()
     };
-    /*unsigned opts =*/ parse_opts(argc, argv, program_options, program_usage_string);
+    /*unsigned opts =*/ libreport_parse_opts(argc, argv, program_options, program_usage_string);
 
-    export_abrt_envvars(0);
+    libreport_export_abrt_envvars(0);
 
     while (conf_file)
     {
         char *fn = (char *)conf_file->data;
         log_notice("Loading settings from '%s'", fn);
-        load_conf_file(fn, settings, /*skip key w/o values:*/ false);
+        libreport_load_conf_file(fn, settings, /*skip key w/o values:*/ false);
         log_debug("Loaded '%s'", fn);
         conf_file = g_list_remove(conf_file, fn);
     }

--- a/src/plugins/reporter-kerneloops.c
+++ b/src/plugins/reporter-kerneloops.c
@@ -98,7 +98,7 @@ static void report_to_kerneloops(
         error_msg_and_die("Error sending kernel oops due to missing backtrace");
 
     const char *env = getenv("KerneloopsReporter_SubmitURL");
-    const char *submitURL = (env ? env : get_map_string_item_or_empty(settings, "SubmitURL"));
+    const char *submitURL = (env ? env : libreport_get_map_string_item_or_empty(settings, "SubmitURL"));
     if (!submitURL[0])
         submitURL = "http://oops.kernel.org/submitoops.php";
 
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
     textdomain(PACKAGE);
 #endif
 
-    map_string_t *settings = new_map_string();
+    map_string_t *settings = libreport_new_map_string();
     const char *dump_dir_name = ".";
     GList *conf_file = NULL;
 
@@ -189,6 +189,6 @@ int main(int argc, char **argv)
 
     report_to_kerneloops(dump_dir_name, settings);
 
-    free_map_string(settings);
+    libreport_free_map_string(settings);
     return 0;
 }

--- a/src/plugins/reporter-mailx.c
+++ b/src/plugins/reporter-mailx.c
@@ -81,14 +81,14 @@ static char** append_str_to_vector(char **vec, unsigned *size_p, const char *str
 static char *ask_email_address(const char *type, const char *def_address)
 {
     char *ask_text = xasprintf(_("Email address of %s was not specified. Would you like to do so now? If not, '%s' is to be used"), type, def_address);
-    const int ret = ask_yes_no(ask_text);
+    const int ret = libreport_ask_yes_no(ask_text);
     free(ask_text);
 
     if (!ret)
         return xstrdup(def_address);
 
     ask_text = xasprintf(_("Please, type email address of %s:"), type);
-    char *address = ask(ask_text);
+    char *address = libreport_ask(ask_text);
     free(ask_text);
 
     if (address == NULL || address[0] == '\0')

--- a/src/plugins/reporter-mailx.c
+++ b/src/plugins/reporter-mailx.c
@@ -233,7 +233,7 @@ static void create_and_send_email(
 
             report_result_set_url(result, url);
 
-            add_reported_to_entry(dd, result);
+            libreport_add_reported_to_entry(dd, result);
 
             free(url);
             report_result_free(result);

--- a/src/plugins/reporter-mailx.c
+++ b/src/plugins/reporter-mailx.c
@@ -112,18 +112,18 @@ static void create_and_send_email(
 
     char* env;
     env = getenv("Mailx_EmailFrom");
-    char *email_from = (env ? libreport_xstrdup(env) : libreport_xstrdup(get_map_string_item_or_NULL(settings, "EmailFrom")) ? : ask_email_address("sender", "ABRT Daemon <DoNotReply>"));
+    char *email_from = (env ? libreport_xstrdup(env) : libreport_xstrdup(libreport_get_map_string_item_or_NULL(settings, "EmailFrom")) ? : ask_email_address("sender", "ABRT Daemon <DoNotReply>"));
     env = getenv("Mailx_EmailTo");
-    char *email_to = (env ? libreport_xstrdup(env) : libreport_xstrdup(get_map_string_item_or_NULL(settings, "EmailTo")) ? : ask_email_address("receiver", "root@localhost"));
+    char *email_to = (env ? libreport_xstrdup(env) : libreport_xstrdup(libreport_get_map_string_item_or_NULL(settings, "EmailTo")) ? : ask_email_address("receiver", "root@localhost"));
     env = getenv("Mailx_SendBinaryData");
-    bool send_binary_data = libreport_string_to_bool(env ? env : get_map_string_item_or_empty(settings, "SendBinaryData"));
+    bool send_binary_data = libreport_string_to_bool(env ? env : libreport_get_map_string_item_or_empty(settings, "SendBinaryData"));
 
     problem_formatter_t *pf = problem_formatter_new();
     /* formatting file is not set */
     if (fmt_file == NULL)
     {
         env = getenv("Mailx_Subject");
-        const char *subject = (env ? env : get_map_string_item_or_NULL(settings, "Subject") ? : PR_DEFAULT_SUBJECT);
+        const char *subject = (env ? env : libreport_get_map_string_item_or_NULL(settings, "Subject") ? : PR_DEFAULT_SUBJECT);
 
         char *format_string = libreport_xasprintf(PR_MAILX_TEMPLATE, subject);
 
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
 
     libreport_export_abrt_envvars(0);
 
-    map_string_t *settings = new_map_string();
+    map_string_t *settings = libreport_new_map_string();
     libreport_load_conf_file(conf_file, settings, /*skip key w/o values:*/ false);
 
     int flag = 0;
@@ -308,6 +308,6 @@ int main(int argc, char **argv)
 
     create_and_send_email(dump_dir_name, settings, fmt_file, flag);
 
-    free_map_string(settings);
+    libreport_free_map_string(settings);
     return 0;
 }

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -653,7 +653,7 @@ int main(int argc, char **argv)
 
         const char *mbtcomment = problem_report_get_description(pr);
 
-        int dup_comment = is_comment_dup(ii->mii_notes, mbtcomment);
+        int dup_comment = libreport_is_comment_dup(ii->mii_notes, mbtcomment);
         if (!dup_comment)
         {
             log_warning(_("Adding new comment to issue %d"), ii->mii_id);

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -373,7 +373,7 @@ int main(int argc, char **argv)
             if (!dd)
                 xfunc_die();
 
-            reported_to = find_in_reported_to(dd, "MantisBT");
+            reported_to = libreport_find_in_reported_to(dd, "MantisBT");
 
             dd_close(dd);
 
@@ -417,7 +417,7 @@ int main(int argc, char **argv)
         if (!dd)
             xfunc_die();
 
-        reported_to = find_in_reported_to(dd, "MantisBT");
+        reported_to = libreport_find_in_reported_to(dd, "MantisBT");
 
         dd_close(dd);
 
@@ -568,7 +568,7 @@ int main(int argc, char **argv)
                 g_autoptr(report_result_t) reported_to = NULL;
                 g_autofree char *url = NULL;
 
-                reported_to = find_in_reported_to(dd, tracker_str);
+                reported_to = libreport_find_in_reported_to(dd, tracker_str);
 
                 dd_close(dd);
 
@@ -717,7 +717,7 @@ finish:
 
         report_result_set_url(result, url);
 
-        add_reported_to_entry(dd, result);
+        libreport_add_reported_to_entry(dd, result);
 
         free(url);
         report_result_free(result);

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -35,8 +35,8 @@ parse_osinfo_for_mantisbt(map_string_t *osinfo, char** project, char** version)
 
     if (name && version_id)
     {
-        *project = xstrdup(name);
-        *version = xstrdup(version_id);
+        *project = libreport_xstrdup(name);
+        *version = libreport_xstrdup(version_id);
         return;
     }
 
@@ -51,7 +51,7 @@ ask_mantisbt_login(const char *message)
     char *login = libreport_ask(message);
     if (login == NULL || login[0] == '\0')
     {
-        set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
+        libreport_set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
         error_msg_and_die(_("Can't continue without login"));
     }
 
@@ -64,7 +64,7 @@ ask_mantisbt_password(const char *message)
     char *password = libreport_ask_password(message);
     if (password == NULL || password[0] == '\0')
     {
-        set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
+        libreport_set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
         error_msg_and_die(_("Can't continue without password"));
     }
 
@@ -77,11 +77,11 @@ ask_mantisbt_credentials(mantisbt_settings_t *settings, const char *pre_message)
     free(settings->m_login);
     free(settings->m_password);
 
-    char *question = xasprintf("%s %s", pre_message, _("Please enter your MantisBT login:"));
+    char *question = libreport_xasprintf("%s %s", pre_message, _("Please enter your MantisBT login:"));
     settings->m_login = ask_mantisbt_login(question);
     free(question);
 
-    question = xasprintf("%s %s '%s':", pre_message, _("Please enter the password for"), settings->m_login);
+    question = libreport_xasprintf("%s %s '%s':", pre_message, _("Please enter the password for"), settings->m_login);
     settings->m_password = ask_mantisbt_password(question);
     free(question);
 
@@ -102,7 +102,7 @@ verify_credentials(mantisbt_settings_t *settings)
         mantisbt_result_t *result = mantisbt_soap_call(settings, req);
         soap_request_free(req);
 
-        if (g_verbose > 2)
+        if (libreport_g_verbose > 2)
         {
             GList *ids = response_get_main_ids_list(result->mr_body);
             if (ids != NULL)
@@ -126,10 +126,10 @@ set_settings(mantisbt_settings_t *m, map_string_t *settings, struct dump_dir *dd
     const char *environ;
 
     environ = getenv("Mantisbt_Login");
-    m->m_login = xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "Login"));
+    m->m_login = libreport_xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "Login"));
 
     environ = getenv("Mantisbt_Password");
-    m->m_password = xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "Password"));
+    m->m_password = libreport_xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "Password"));
 
     environ = getenv("Mantisbt_MantisbtURL");
     m->m_mantisbt_url = environ ? environ : get_map_string_item_or_empty(settings, "MantisbtURL");
@@ -142,24 +142,24 @@ set_settings(mantisbt_settings_t *m, map_string_t *settings, struct dump_dir *dd
         if (last_slash && last_slash[1] == '\0')
             *last_slash = '\0';
     }
-    m->m_mantisbt_soap_url = concat_path_file(m->m_mantisbt_url, "api/soap/mantisconnect.php");
+    m->m_mantisbt_soap_url = libreport_concat_path_file(m->m_mantisbt_url, "api/soap/mantisconnect.php");
 
     environ = getenv("Mantisbt_Project");
     if (environ)
     {
-        m->m_project = xstrdup(environ);
+        m->m_project = libreport_xstrdup(environ);
         environ = getenv("Mantisbt_ProjectVersion");
         if (environ)
-            m->m_project_version = xstrdup(environ);
+            m->m_project_version = libreport_xstrdup(environ);
     }
     else
     {
         const char *option = get_map_string_item_or_NULL(settings, "Project");
         if (option)
-            m->m_project = xstrdup(option);
+            m->m_project = libreport_xstrdup(option);
         option = get_map_string_item_or_NULL(settings, "ProjectVersion");
         if (option)
-            m->m_project_version = xstrdup(option);
+            m->m_project_version = libreport_xstrdup(option);
     }
 
     if (!m->m_project || !*m->m_project) /* if not overridden or empty... */
@@ -172,7 +172,7 @@ set_settings(mantisbt_settings_t *m, map_string_t *settings, struct dump_dir *dd
             map_string_t *osinfo = new_map_string();
 
             char *os_info_data = dd_load_text(dd, FILENAME_OS_INFO);
-            parse_osinfo(os_info_data, osinfo);
+            libreport_parse_osinfo(os_info_data, osinfo);
             free(os_info_data);
 
             parse_osinfo_for_mantisbt(osinfo, &m->m_project, &m->m_project_version);
@@ -181,7 +181,7 @@ set_settings(mantisbt_settings_t *m, map_string_t *settings, struct dump_dir *dd
     }
 
     environ = getenv("Mantisbt_SSLVerify");
-    m->m_ssl_verify = string_to_bool(environ ? environ : get_map_string_item_or_empty(settings, "SSLVerify"));
+    m->m_ssl_verify = libreport_string_to_bool(environ ? environ : get_map_string_item_or_empty(settings, "SSLVerify"));
 
     environ = getenv("Mantisbt_DontMatchComponents");
     m->m_DontMatchComponents = environ ? environ : get_map_string_item_or_empty(settings, "DontMatchComponents");
@@ -191,7 +191,7 @@ set_settings(mantisbt_settings_t *m, map_string_t *settings, struct dump_dir *dd
     if (!m->m_create_private)
     {
         environ = getenv("Mantisbt_CreatePrivate");
-        m->m_create_private = string_to_bool(environ ? environ : get_map_string_item_or_empty(settings, "CreatePrivate"));
+        m->m_create_private = libreport_string_to_bool(environ ? environ : get_map_string_item_or_empty(settings, "CreatePrivate"));
     }
     log_notice("create private MantisBT ticket: '%s'", m->m_create_private ? "YES": "NO");
 }
@@ -279,7 +279,7 @@ int main(int argc, char **argv)
     mantisbt_settings_t mbt_settings = { 0 };
     /* Keep enum above and order of options below in sync! */
     struct options program_options[] = {
-        OPT__VERBOSE(&g_verbose),
+        OPT__VERBOSE(&libreport_g_verbose),
         OPT_STRING(   'd', NULL, &dump_dir_name , "DIR"    , _("Problem directory")),
         OPT_LIST(     'c', NULL, &conf_file     , "FILE"   , _("Configuration file (may be given many times)")),
         OPT_STRING(   'F', NULL, &fmt_file      , "FILE"   , _("Formatting file for initial comment")),
@@ -293,10 +293,10 @@ int main(int argc, char **argv)
         OPT_END()
     };
 
-    unsigned opts = parse_opts(argc, argv, program_options, program_usage_string);
+    unsigned opts = libreport_parse_opts(argc, argv, program_options, program_usage_string);
     argv += optind;
 
-    export_abrt_envvars(0);
+    libreport_export_abrt_envvars(0);
 
     map_string_t *settings = new_map_string();
 
@@ -305,14 +305,14 @@ int main(int argc, char **argv)
         if (!conf_file)
         {
             conf_file = g_list_append(conf_file, (char*) CONF_DIR"/plugins/mantisbt.conf");
-            local_conf = xasprintf("%s"USER_HOME_CONFIG_PATH"/mantisbt.conf", getenv("HOME"));
+            local_conf = libreport_xasprintf("%s"USER_HOME_CONFIG_PATH"/mantisbt.conf", getenv("HOME"));
             conf_file = g_list_append(conf_file, local_conf);
         }
         while (conf_file)
         {
             char *fn = (char *)conf_file->data;
             log_notice("Loading settings from '%s'", fn);
-            load_conf_file(fn, settings, /*skip key w/o values:*/ false);
+            libreport_load_conf_file(fn, settings, /*skip key w/o values:*/ false);
             log_debug("Loaded '%s'", fn);
             conf_file = g_list_delete_link(conf_file, conf_file);
         }
@@ -362,7 +362,7 @@ int main(int argc, char **argv)
     if (opts & OPT_t)
     {
         if (!argv[0])
-            show_usage_and_die(program_usage_string, program_options);
+            libreport_show_usage_and_die(program_usage_string, program_options);
 
         if (!ticket_no)
         {
@@ -371,7 +371,7 @@ int main(int argc, char **argv)
             char *url;
 
             if (!dd)
-                xfunc_die();
+                libreport_xfunc_die();
 
             reported_to = libreport_find_in_reported_to(dd, "MantisBT");
 
@@ -382,7 +382,7 @@ int main(int argc, char **argv)
 
             url = report_result_get_url(reported_to);
 
-            if (prefixcmp(url, mbt_settings.m_mantisbt_url) != 0)
+            if (libreport_prefixcmp(url, mbt_settings.m_mantisbt_url) != 0)
                 error_msg_and_die(_("This problem has been reported to MantisBT '%s' which differs from the configured MantisBT '%s'."), url, mbt_settings.m_mantisbt_url);
 
             ticket_no = strrchr(url, '=');
@@ -390,7 +390,7 @@ int main(int argc, char **argv)
                 error_msg_and_die(_("Malformed url to MantisBT '%s'."), url);
 
             /* won't ever call free on it - it simplifies the code a lot */
-            ticket_no = xstrdup(ticket_no + 1);
+            ticket_no = libreport_xstrdup(ticket_no + 1);
             log_warning(_("Using MantisBT ID '%s'"), ticket_no);
         }
 
@@ -415,7 +415,7 @@ int main(int argc, char **argv)
         g_autofree char *url = NULL;
 
         if (!dd)
-            xfunc_die();
+            libreport_xfunc_die();
 
         reported_to = libreport_find_in_reported_to(dd, "MantisBT");
 
@@ -429,7 +429,7 @@ int main(int argc, char **argv)
         {
             g_autofree char *msg = NULL;
 
-            msg = xasprintf(_("This problem was already reported to MantisBT (see '%s')."
+            msg = libreport_xasprintf(_("This problem was already reported to MantisBT (see '%s')."
                             " Do you still want to create a new issue?"),
                             url);
 
@@ -440,7 +440,7 @@ int main(int argc, char **argv)
 
     problem_data_t *problem_data = create_problem_data_for_reporting(dump_dir_name);
     if (!problem_data)
-        xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
+        libreport_xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
 
     const char *category = problem_data_get_content_or_die(problem_data, FILENAME_COMPONENT);
     const char *duphash   = problem_data_get_content_or_die(problem_data, FILENAME_DUPHASH);
@@ -487,7 +487,7 @@ int main(int argc, char **argv)
         char *cmd = strtok(remote_result, " \n");
         char *id = strtok(NULL, " \n");
 
-        if (!prefixcmp(cmd, "DUPLICATE"))
+        if (!libreport_prefixcmp(cmd, "DUPLICATE"))
         {
             errno = 0;
             char *e;
@@ -511,7 +511,7 @@ int main(int argc, char **argv)
             /* Figure out whether we want to match category
              * when doing dup search.
              */
-            const char *category_substitute = is_in_comma_separated_list(category, mbt_settings.m_DontMatchComponents) ? NULL : category;
+            const char *category_substitute = libreport_is_in_comma_separated_list(category, mbt_settings.m_DontMatchComponents) ? NULL : category;
 
             /* We don't do dup detection across versions (see below why),
              * but we do add a note if cross-version potential dup exists.
@@ -591,7 +591,7 @@ int main(int argc, char **argv)
                 return EXIT_FAILURE;
 
             log_warning(_("Adding attachments to issue %i"), new_id);
-            char *new_id_str = xasprintf("%u", new_id);
+            char *new_id_str = libreport_xasprintf("%u", new_id);
 
             for (GList *a = problem_report_get_attachments(pr); a != NULL; a = g_list_next(a))
             {
@@ -609,7 +609,7 @@ int main(int argc, char **argv)
             problem_report_free(pr);
             ii = mantisbt_issue_info_new();
             ii->mii_id = new_id;
-            ii->mii_status = xstrdup("new");
+            ii->mii_status = libreport_xstrdup("new");
 
             goto finish;
         }
@@ -664,10 +664,10 @@ int main(int argc, char **argv)
             const char *rating_str = problem_data_get_content_or_NULL(problem_data, FILENAME_RATING);
             /* python doesn't have rating file */
             if (rating_str)
-                rating = xatou(rating_str);
+                rating = libreport_xatou(rating_str);
             if (bt && rating > ii->mii_best_bt_rating)
             {
-                char *bug_id_str = xasprintf("%i", ii->mii_id);
+                char *bug_id_str = libreport_xasprintf("%i", ii->mii_id);
 
                 log_warning(_("Attaching better backtrace"));
 
@@ -676,9 +676,9 @@ int main(int argc, char **argv)
                 for (int i = 0;; ++i)
                 {
                     if (i == 0)
-                        name = xasprintf("%s", FILENAME_BACKTRACE);
+                        name = libreport_xasprintf("%s", FILENAME_BACKTRACE);
                     else
-                        name = xasprintf("%s%d", FILENAME_BACKTRACE, i);
+                        name = libreport_xasprintf("%s%d", FILENAME_BACKTRACE, i);
 
                     if (g_list_find_custom(ii->mii_attachments, name, (GCompareFunc) strcmp) == NULL)
                         break;
@@ -713,7 +713,7 @@ finish:
         char *url;
 
         result = report_result_new_with_label_from_env("MantisBT");
-        url = xasprintf("%s/view.php?id=%u", mbt_settings.m_mantisbt_url, ii->mii_id);
+        url = libreport_xasprintf("%s/view.php?id=%u", mbt_settings.m_mantisbt_url, ii->mii_id);
 
         report_result_set_url(result, url);
 

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -48,7 +48,7 @@ parse_osinfo_for_mantisbt(map_string_t *osinfo, char** project, char** version)
 static char *
 ask_mantisbt_login(const char *message)
 {
-    char *login = ask(message);
+    char *login = libreport_ask(message);
     if (login == NULL || login[0] == '\0')
     {
         set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
@@ -61,7 +61,7 @@ ask_mantisbt_login(const char *message)
 static char *
 ask_mantisbt_password(const char *message)
 {
-    char *password = ask_password(message);
+    char *password = libreport_ask_password(message);
     if (password == NULL || password[0] == '\0')
     {
         set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
@@ -433,7 +433,7 @@ int main(int argc, char **argv)
                             " Do you still want to create a new issue?"),
                             url);
 
-            if (!ask_yes_no(msg))
+            if (!libreport_ask_yes_no(msg))
                 return 0;
         }
     }

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -186,7 +186,7 @@ set_settings(mantisbt_settings_t *m, map_string_t *settings, struct dump_dir *dd
     environ = getenv("Mantisbt_DontMatchComponents");
     m->m_DontMatchComponents = environ ? environ : get_map_string_item_or_empty(settings, "DontMatchComponents");
 
-    m->m_create_private = get_global_create_private_ticket();
+    m->m_create_private = libreport_get_global_create_private_ticket();
 
     if (!m->m_create_private)
     {

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -25,13 +25,13 @@
 static void
 parse_osinfo_for_mantisbt(map_string_t *osinfo, char** project, char** version)
 {
-    const char *name = get_map_string_item_or_NULL(osinfo, "CENTOS_MANTISBT_PROJECT");
+    const char *name = libreport_get_map_string_item_or_NULL(osinfo, "CENTOS_MANTISBT_PROJECT");
     if (!name)
-        name = get_map_string_item_or_NULL(osinfo, OSINFO_NAME);
+        name = libreport_get_map_string_item_or_NULL(osinfo, OSINFO_NAME);
 
-    const char *version_id = get_map_string_item_or_NULL(osinfo, "CENTOS_MANTISBT_PROJECT_VERSION");
+    const char *version_id = libreport_get_map_string_item_or_NULL(osinfo, "CENTOS_MANTISBT_PROJECT_VERSION");
     if (!version_id)
-        version_id = get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID);
+        version_id = libreport_get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID);
 
     if (name && version_id)
     {
@@ -126,13 +126,13 @@ set_settings(mantisbt_settings_t *m, map_string_t *settings, struct dump_dir *dd
     const char *environ;
 
     environ = getenv("Mantisbt_Login");
-    m->m_login = libreport_xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "Login"));
+    m->m_login = libreport_xstrdup(environ ? environ : libreport_get_map_string_item_or_empty(settings, "Login"));
 
     environ = getenv("Mantisbt_Password");
-    m->m_password = libreport_xstrdup(environ ? environ : get_map_string_item_or_empty(settings, "Password"));
+    m->m_password = libreport_xstrdup(environ ? environ : libreport_get_map_string_item_or_empty(settings, "Password"));
 
     environ = getenv("Mantisbt_MantisbtURL");
-    m->m_mantisbt_url = environ ? environ : get_map_string_item_or_empty(settings, "MantisbtURL");
+    m->m_mantisbt_url = environ ? environ : libreport_get_map_string_item_or_empty(settings, "MantisbtURL");
     if (!m->m_mantisbt_url[0])
         m->m_mantisbt_url = "http://localhost/mantisbt";
     else
@@ -154,10 +154,10 @@ set_settings(mantisbt_settings_t *m, map_string_t *settings, struct dump_dir *dd
     }
     else
     {
-        const char *option = get_map_string_item_or_NULL(settings, "Project");
+        const char *option = libreport_get_map_string_item_or_NULL(settings, "Project");
         if (option)
             m->m_project = libreport_xstrdup(option);
-        option = get_map_string_item_or_NULL(settings, "ProjectVersion");
+        option = libreport_get_map_string_item_or_NULL(settings, "ProjectVersion");
         if (option)
             m->m_project_version = libreport_xstrdup(option);
     }
@@ -169,29 +169,29 @@ set_settings(mantisbt_settings_t *m, map_string_t *settings, struct dump_dir *dd
 
         if (dd != NULL)
         {
-            map_string_t *osinfo = new_map_string();
+            map_string_t *osinfo = libreport_new_map_string();
 
             char *os_info_data = dd_load_text(dd, FILENAME_OS_INFO);
             libreport_parse_osinfo(os_info_data, osinfo);
             free(os_info_data);
 
             parse_osinfo_for_mantisbt(osinfo, &m->m_project, &m->m_project_version);
-            free_map_string(osinfo);
+            libreport_free_map_string(osinfo);
         }
     }
 
     environ = getenv("Mantisbt_SSLVerify");
-    m->m_ssl_verify = libreport_string_to_bool(environ ? environ : get_map_string_item_or_empty(settings, "SSLVerify"));
+    m->m_ssl_verify = libreport_string_to_bool(environ ? environ : libreport_get_map_string_item_or_empty(settings, "SSLVerify"));
 
     environ = getenv("Mantisbt_DontMatchComponents");
-    m->m_DontMatchComponents = environ ? environ : get_map_string_item_or_empty(settings, "DontMatchComponents");
+    m->m_DontMatchComponents = environ ? environ : libreport_get_map_string_item_or_empty(settings, "DontMatchComponents");
 
     m->m_create_private = libreport_get_global_create_private_ticket();
 
     if (!m->m_create_private)
     {
         environ = getenv("Mantisbt_CreatePrivate");
-        m->m_create_private = libreport_string_to_bool(environ ? environ : get_map_string_item_or_empty(settings, "CreatePrivate"));
+        m->m_create_private = libreport_string_to_bool(environ ? environ : libreport_get_map_string_item_or_empty(settings, "CreatePrivate"));
     }
     log_notice("create private MantisBT ticket: '%s'", m->m_create_private ? "YES": "NO");
 }
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
 
     libreport_export_abrt_envvars(0);
 
-    map_string_t *settings = new_map_string();
+    map_string_t *settings = libreport_new_map_string();
 
     {
         char *local_conf = NULL;
@@ -331,7 +331,7 @@ int main(int argc, char **argv)
         /* WRONG! set_settings() does not copy the strings, it merely sets up pointers
          * to settings[] dictionary:
          */
-        /*free_map_string(settings);*/
+        /*libreport_free_map_string(settings);*/
     }
 
     /* No connection is opened between client and server. Users authentication

--- a/src/plugins/reporter-print.c
+++ b/src/plugins/reporter-print.c
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
 
                 report_result_set_url(result, url);
 
-                add_reported_to_entry(dd, result);
+                libreport_add_reported_to_entry(dd, result);
 
                 free(url);
                 report_result_free(result);

--- a/src/plugins/reporter-print.c
+++ b/src/plugins/reporter-print.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
             open_mode = "a";
 
         /* We used freopen to change stdout,
-         * but ask() writes to stdout. Can't use that trick anymore.
+         * but libreport_ask() writes to stdout. Can't use that trick anymore.
          */
         char *msg = NULL;
         while (1)
@@ -87,9 +87,9 @@ int main(int argc, char **argv)
             if (msg)
             {
                 free(output_file);
-                char *response = ask(msg);
+                char *response = libreport_ask(msg);
                 if (!response)
-                    perror_msg_and_die("ask");
+                    perror_msg_and_die("libreport_ask");
                 free(msg);
 
                 if (response[0] == '\0' || response[0] == '\n')

--- a/src/plugins/reporter-print.c
+++ b/src/plugins/reporter-print.c
@@ -52,16 +52,16 @@ int main(int argc, char **argv)
     };
     /* Keep enum above and order of options below in sync! */
     struct options program_options[] = {
-        OPT__VERBOSE(&g_verbose),
+        OPT__VERBOSE(&libreport_g_verbose),
         OPT_STRING('d', NULL, &dump_dir_name, "DIR"   , _("Problem directory")),
         OPT_STRING('o', NULL, &output_file  , "FILE"  , _("Output file")),
         OPT_STRING('a', NULL, &append       , "yes/no", _("Append to, or overwrite FILE")),
         OPT_BOOL(  'r', NULL, NULL          ,           _("Create reported_to in DIR")),
         OPT_END()
     };
-    unsigned opts = parse_opts(argc, argv, program_options, program_usage_string);
+    unsigned opts = libreport_parse_opts(argc, argv, program_options, program_usage_string);
 
-    export_abrt_envvars(0);
+    libreport_export_abrt_envvars(0);
 
     if (output_file)
     {
@@ -69,12 +69,12 @@ int main(int argc, char **argv)
         if (output_file[0] == '~' && output_file[1] == '/'
          && (HOME = getenv("HOME")) != NULL
         ) {
-            output_file = concat_path_file(HOME, output_file + 2);
+            output_file = libreport_concat_path_file(HOME, output_file + 2);
         }
         else
-            output_file = xstrdup(output_file);
+            output_file = libreport_xstrdup(output_file);
 
-        if (string_to_bool(append))
+        if (libreport_string_to_bool(append))
             open_mode = "a";
 
         /* We used freopen to change stdout,
@@ -94,18 +94,18 @@ int main(int argc, char **argv)
 
                 if (response[0] == '\0' || response[0] == '\n')
                 {
-                    set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
+                    libreport_set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
                     error_msg_and_die(_("Cancelled by user."));
                 }
 
-                output_file = strtrim(response);
+                output_file = libreport_strtrim(response);
             }
 
             FILE *outstream = fopen(output_file, open_mode);
             if (!outstream)
             {
                 VERB1 pwarn_msg("fopen");
-                msg = xasprintf(_("Can't open '%s' for writing. "
+                msg = libreport_xasprintf(_("Can't open '%s' for writing. "
                                   "Please select another file:"), output_file);
                 continue;
             }
@@ -118,9 +118,9 @@ int main(int argc, char **argv)
 
     problem_data_t *problem_data = create_problem_data_for_reporting(dump_dir_name);
     if (!problem_data)
-        xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
+        libreport_xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
 
-    char *dsc = make_description_logger(problem_data, CD_TEXT_ATT_SIZE_LOGGER);
+    char *dsc = libreport_make_description_logger(problem_data, CD_TEXT_ATT_SIZE_LOGGER);
     fputs(dsc, stdout);
     if (open_mode[0] == 'a')
         fputs("\nEND:\n\n", stdout);
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
                 char *url;
 
                 result = report_result_new_with_label_from_env("file");
-                url = xasprintf("file://%s", output_file);
+                url = libreport_xasprintf("file://%s", output_file);
 
                 report_result_set_url(result, url);
 

--- a/src/plugins/reporter-rhtsupport-parse.c
+++ b/src/plugins/reporter-rhtsupport-parse.c
@@ -65,7 +65,7 @@ static void start_element(
         if (uri && type)
         {
             free(parse_data->uri); /* paranoia */
-            parse_data->uri = xstrdup(uri);
+            parse_data->uri = libreport_xstrdup(uri);
             parse_data->type = type;
         }
     }
@@ -86,7 +86,7 @@ static void text(
     if (parse_data->uri && text_len > 0)
     {
         free(parse_data->txt);
-        parse_data->txt = xstrndup(text, text_len);
+        parse_data->txt = libreport_xstrndup(text, text_len);
     }
 }
 
@@ -152,12 +152,12 @@ static void emit_url_text_pairs_to_strbuf(struct strbuf *result, GList *urllist,
             /* changed "%s%s:" -> "%s%s :" if the url ends with ':' then it
              * becomes part of the link and makes it invalid
              */
-            strbuf_append_strf(result, "%s%s : %s", prefix, urllist->data, txtlist->data);
+            libreport_strbuf_append_strf(result, "%s%s : %s", prefix, urllist->data, txtlist->data);
             free(txtlist->data);
         }
         else
         {
-            strbuf_append_strf(result, "%s%s", prefix, urllist->data);
+            libreport_strbuf_append_strf(result, "%s%s", prefix, urllist->data);
         }
         free(urllist->data);
         prefix = ", ";
@@ -169,7 +169,7 @@ static void emit_url_text_pairs_to_strbuf(struct strbuf *result, GList *urllist,
 char *parse_response_from_RHTS_hint_xml2txt(const char *string)
 {
     if (strncmp(string, "<?xml", 5) != 0)
-        return xstrdup(string);
+        return libreport_xstrdup(string);
 
     struct my_parse_data parse_data;
     memset(&parse_data, 0, sizeof(parse_data));
@@ -195,22 +195,22 @@ char *parse_response_from_RHTS_hint_xml2txt(const char *string)
     if (!parse_data.hints_uri && !parse_data.erratas_uri)
         return NULL;
 
-    struct strbuf *result = strbuf_new();
+    struct strbuf *result = libreport_strbuf_new();
 
     if (parse_data.hints_uri)
     {
-        strbuf_append_str(result, _("Documentation which might be relevant: "));
+        libreport_strbuf_append_str(result, _("Documentation which might be relevant: "));
         emit_url_text_pairs_to_strbuf(result, parse_data.hints_uri, parse_data.hints_txt);
-        strbuf_append_str(result, ". ");
+        libreport_strbuf_append_str(result, ". ");
     }
     if (parse_data.erratas_uri)
     {
         if (parse_data.hints_uri)
-            strbuf_append_str(result, " ");
-        strbuf_append_str(result, _("Updates which possibly help: "));
+            libreport_strbuf_append_str(result, " ");
+        libreport_strbuf_append_str(result, _("Updates which possibly help: "));
         emit_url_text_pairs_to_strbuf(result, parse_data.erratas_uri, parse_data.erratas_txt);
-        strbuf_append_str(result, ".");
+        libreport_strbuf_append_str(result, ".");
     }
 
-    return strbuf_free_nobuf(result);
+    return libreport_strbuf_free_nobuf(result);
 }

--- a/src/plugins/reporter-rhtsupport.c
+++ b/src/plugins/reporter-rhtsupport.c
@@ -69,7 +69,7 @@ static report_result_t *get_reported_to(const char *dump_dir_name)
     struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
     if (!dd)
         xfunc_die();
-    report_result_t *reported_to = find_in_reported_to(dd, "RHTSupport");
+    report_result_t *reported_to = libreport_find_in_reported_to(dd, "RHTSupport");
     dd_close(dd);
     return reported_to;
 }
@@ -263,7 +263,7 @@ char *submit_ureport(const char *dump_dir_name, struct ureport_server_config *co
     if (dd == NULL)
         return NULL;
 
-    rr_bthash = find_in_reported_to(dd, "uReport");
+    rr_bthash = libreport_find_in_reported_to(dd, "uReport");
 
     dd_close(dd);
 
@@ -929,7 +929,7 @@ int main(int argc, char **argv)
             report_result_set_timestamp(report_result, time(NULL));
             report_result_set_url(report_result, result->url);
 
-            add_reported_to_entry(dd, report_result);
+            libreport_add_reported_to_entry(dd, report_result);
             dd_close(dd);
             if (result->msg)
                 log_warning("%s", result->msg);

--- a/src/plugins/reporter-rhtsupport.c
+++ b/src/plugins/reporter-rhtsupport.c
@@ -228,7 +228,7 @@ struct ureport_server_response *ureport_do_post_credentials(const char *json, st
     struct post_state *post_state = NULL;
     while (1)
     {
-        post_state = ureport_do_post(json, config, action);
+        post_state = libreport_ureport_do_post(json, config, action);
 
         if (post_state == NULL)
         {
@@ -244,12 +244,12 @@ struct ureport_server_response *ureport_do_post_credentials(const char *json, st
         char *login = NULL;
         char *password = NULL;
         ask_rh_credentials(&login, &password);
-        ureport_server_config_set_basic_auth(config, login, password);
+        libreport_ureport_server_config_set_basic_auth(config, login, password);
         free(password);
         free(login);
     }
 
-    struct ureport_server_response *resp = ureport_server_response_from_reply(post_state, config);
+    struct ureport_server_response *resp = libreport_ureport_server_response_from_reply(post_state, config);
     free(post_state);
     return resp;
 }
@@ -274,7 +274,7 @@ char *submit_ureport(const char *dump_dir_name, struct ureport_server_config *co
         return report_result_get_bthash(rr_bthash);
     }
 
-    char *json = ureport_from_dump_dir(dump_dir_name);
+    char *json = libreport_ureport_from_dump_dir(dump_dir_name);
     if (json == NULL)
     {
         log_notice(_("Failed to generate microreport from the problem data"));
@@ -292,7 +292,7 @@ char *submit_ureport(const char *dump_dir_name, struct ureport_server_config *co
         if (resp->urr_bthash != NULL)
             bthash = libreport_xstrdup(resp->urr_bthash);
 
-        ureport_server_response_save_in_dump_dir(resp, dump_dir_name, conf);
+        libreport_ureport_server_response_save_in_dump_dir(resp, dump_dir_name, conf);
 
         if (resp->urr_message)
             log_warning("%s", resp->urr_message);
@@ -300,7 +300,7 @@ char *submit_ureport(const char *dump_dir_name, struct ureport_server_config *co
     else if (libreport_g_verbose > 2)
         error_msg(_("Server responded with an error: '%s'"), resp->urr_value);
 
-    ureport_server_response_free(resp);
+    libreport_ureport_server_response_free(resp);
     return bthash;
 }
 
@@ -310,7 +310,7 @@ void attach_to_ureport(struct ureport_server_config *conf,
 {
     char *json = ureport_json_attachment_new(bthash, attach_id, data);
     struct ureport_server_response *resp = ureport_do_post_credentials(json, conf, UREPORT_ATTACH_ACTION);
-    ureport_server_response_free(resp);
+    libreport_ureport_server_response_free(resp);
     free(json);
 }
 
@@ -411,7 +411,7 @@ void prepare_ureport_configuration(const char *urcfile,
         const char *portal_url, const char *login, const char *password, bool ssl_verify)
 {
     libreport_load_conf_file(urcfile, settings, false);
-    ureport_server_config_init(urconf);
+    libreport_ureport_server_config_init(urconf);
 
     /* The following lines cause that we always use URL from ureport's
      * configuration becuase the GUI reporter always exports uReport_URL env
@@ -420,13 +420,13 @@ void prepare_ureport_configuration(const char *urcfile,
      *   char *url = NULL;
      *   UREPORT_OPTION_VALUE_FROM_CONF(settings, "URL", url, libreport_xstrdup);
      *   if (url != NULL)
-     *       ureport_server_config_set_url(urconf, url);
+     *       libreport_ureport_server_config_set_url(urconf, url);
      */
 
-    ureport_server_config_set_url(urconf, libreport_concat_path_file(portal_url, "/telemetry/abrt"));
+    libreport_ureport_server_config_set_url(urconf, libreport_concat_path_file(portal_url, "/telemetry/abrt"));
     urconf->ur_ssl_verify = ssl_verify;
 
-    ureport_server_config_set_basic_auth(urconf, login, password);
+    libreport_ureport_server_config_set_basic_auth(urconf, login, password);
 
     bool include_auth = true;
     UREPORT_OPTION_VALUE_FROM_CONF(settings, "IncludeAuthData", include_auth, libreport_string_to_bool);
@@ -944,7 +944,7 @@ int main(int argc, char **argv)
             log_warning(_("Linking ABRT crash statistics record with the case"));
 
             /* Make sure we use the current credentials */
-            ureport_server_config_set_basic_auth(&urconf, login, password);
+            libreport_ureport_server_config_set_basic_auth(&urconf, login, password);
 
             /* Attach Customer Case ID*/
             attach_to_ureport(&urconf, bthash, "RHCID", result->url);
@@ -1030,7 +1030,7 @@ int main(int argc, char **argv)
     free_rhts_result(result_atch);
     free_rhts_result(result);
 
-    ureport_server_config_destroy(&urconf);
+    libreport_ureport_server_config_destroy(&urconf);
     libreport_free_map_string(ursettings);
     free(bthash);
 

--- a/src/plugins/reporter-rhtsupport.c
+++ b/src/plugins/reporter-rhtsupport.c
@@ -973,8 +973,8 @@ int main(int argc, char **argv)
     if (bigsize != 0 && tempfile_size / (1024*1024) >= bigsize)
     {
         /* Upload tarball of -d DIR to "big file" FTP */
-        /* log_warning(_("Uploading problem data to '%s'"), bigurl); - upload_file does this */
-        remote_filename = upload_file(bigurl, tempfile);
+        /* log_warning(_("Uploading problem data to '%s'"), bigurl); - libreport_upload_file does this */
+        remote_filename = libreport_upload_file(bigurl, tempfile);
     }
     if (remote_filename)
     {

--- a/src/plugins/reporter-rhtsupport.c
+++ b/src/plugins/reporter-rhtsupport.c
@@ -347,7 +347,7 @@ bool check_for_hints(const char *url, char **login, char **password, bool ssl_ve
             /*
              * 'Yes' to the create ticket question means no hints were found.
              */
-            retval = !ask_yes_no(hint);
+            retval = !libreport_ask_yes_no(hint);
 
             free(hint);
         }
@@ -360,7 +360,7 @@ bool check_for_hints(const char *url, char **login, char **password, bool ssl_ve
 static
 char *ask_rh_login(const char *message)
 {
-    char *login = ask(message);
+    char *login = libreport_ask(message);
     if (login == NULL || login[0] == '\0')
     {
         set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
@@ -373,7 +373,7 @@ char *ask_rh_login(const char *message)
 static
 char *ask_rh_password(const char *message)
 {
-    char *password = ask_password(message);
+    char *password = libreport_ask_password(message);
     if (password == NULL || password[0] == '\0')
     {
         set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
@@ -457,7 +457,7 @@ static char *create_case_url(char *url, const char *case_no)
 static char *ask_case_no_create_url(char *url)
 {
     char *msg = xasprintf(_("Please enter customer case number to which you want to attach the data:"));
-    char *case_no = ask(msg);
+    char *case_no = libreport_ask(msg);
     free(msg);
     if (case_no == NULL || case_no[0] == '\0')
     {
@@ -634,7 +634,7 @@ int main(int argc, char **argv)
                       "Do you want to attach the data to the case? "
                       "Otherwise, you will have to enter the existing "
                       "Red Hat support case number."), url);
-                int yes = ask_yes_no(msg);
+                int yes = libreport_ask_yes_no(msg);
                 free(msg);
                 if (!yes)
                 {
@@ -694,7 +694,7 @@ int main(int argc, char **argv)
             char *msg = xasprintf("This problem was already reported to RHTS (see '%s')."
                             " Do you still want to create a RHTSupport ticket?",
                             report_url);
-            int yes = ask_yes_no(msg);
+            int yes = libreport_ask_yes_no(msg);
             free(msg);
             g_free(report_url);
             if (!yes)
@@ -748,7 +748,7 @@ int main(int argc, char **argv)
         /* the 'count' file can lie */
         && get_problem_data_reproducible(problem_data) <= PROBLEM_REPRODUCIBLE_UNKNOWN)
     {
-        int r = ask_yes_no(
+        int r = libreport_ask_yes_no(
             _("The problem has only occurred once and the ability to reproduce "
               "the problem is unknown. Please ensure you will be able to "
               "provide detailed information to our Support Team. "
@@ -765,7 +765,7 @@ int main(int argc, char **argv)
             _("The crashed program was released by '%s'. "
               "Would you like to report the problem to Red Hat Support?"),
               vendor);
-        int r = ask_yes_no(message);
+        int r = libreport_ask_yes_no(message);
         free(message);
         if (!r)
             exit(EXIT_CANCEL_BY_USER);
@@ -783,7 +783,7 @@ int main(int argc, char **argv)
             _("The program '%s' does not appear to be provided by Red Hat. "
               "Would you like to report the problem to Red Hat Support?"),
               executable);
-        int r = ask_yes_no(message);
+        int r = libreport_ask_yes_no(message);
         free(message);
         if (!r)
             exit(EXIT_CANCEL_BY_USER);

--- a/src/plugins/reporter-rhtsupport.c
+++ b/src/plugins/reporter-rhtsupport.c
@@ -402,7 +402,7 @@ char *get_param_string(const char *name, map_string_t *settings, const char *dfl
     char *envname = libreport_xasprintf("RHTSupport_%s", name);
     const char *envvar = getenv(envname);
     free(envname);
-    return libreport_xstrdup(envvar ? envvar : (get_map_string_item_or_NULL(settings, name) ? : dflt));
+    return libreport_xstrdup(envvar ? envvar : (libreport_get_map_string_item_or_NULL(settings, name) ? : dflt));
 }
 
 static
@@ -547,7 +547,7 @@ int main(int argc, char **argv)
     libreport_export_abrt_envvars(0);
 
     /* Parse config, extract necessary params */
-    map_string_t *settings = new_map_string();
+    map_string_t *settings = libreport_new_map_string();
     char *local_conf = NULL;
     if (!conf_file)
     {
@@ -588,25 +588,25 @@ int main(int argc, char **argv)
     char* envvar;
     envvar = getenv("RHTSupport_SSLVerify");
     bool ssl_verify = libreport_string_to_bool(
-                envvar ? envvar : (get_map_string_item_or_NULL(settings, "SSLVerify") ? : "1")
+                envvar ? envvar : (libreport_get_map_string_item_or_NULL(settings, "SSLVerify") ? : "1")
     );
     envvar = getenv("RHTSupport_BigSizeMB");
     unsigned bigsize = libreport_xatoi_positive(
                 /* RH has a 250m limit for web attachments (as of 2013) */
-                envvar ? envvar : (get_map_string_item_or_NULL(settings, "BigSizeMB") ? : "200")
+                envvar ? envvar : (libreport_get_map_string_item_or_NULL(settings, "BigSizeMB") ? : "200")
     );
     envvar = getenv("RHTSupport_SubmitUReport");
     bool submit_ur = libreport_string_to_bool(
                 envvar ? envvar :
-                    (get_map_string_item_or_NULL(settings, "SubmitUReport") ? :
+                    (libreport_get_map_string_item_or_NULL(settings, "SubmitUReport") ? :
                         ((opts & OPT_u) ? "1" : "0"))
     );
-    free_map_string(settings);
+    libreport_free_map_string(settings);
 
     char *base_api_url = libreport_xstrdup(url);
     char *bthash = NULL;
 
-    map_string_t *ursettings = new_map_string();
+    map_string_t *ursettings = libreport_new_map_string();
     struct ureport_server_config urconf;
 
     prepare_ureport_configuration(urconf_file, ursettings, &urconf,
@@ -872,10 +872,10 @@ int main(int argc, char **argv)
 
         char *product = NULL;
         char *version = NULL;
-        map_string_t *osinfo = new_map_string();
+        map_string_t *osinfo = libreport_new_map_string();
         problem_data_get_osinfo(problem_data, osinfo);
         libreport_parse_osinfo_for_rhts(osinfo, &product, &version);
-        free_map_string(osinfo);
+        libreport_free_map_string(osinfo);
 
         if (!product)
         {   /* How can we help user sorting out this problem? */
@@ -1031,7 +1031,7 @@ int main(int argc, char **argv)
     free_rhts_result(result);
 
     ureport_server_config_destroy(&urconf);
-    free_map_string(ursettings);
+    libreport_free_map_string(ursettings);
     free(bthash);
 
     free(base_api_url);

--- a/src/plugins/reporter-systemd-journal.c
+++ b/src/plugins/reporter-systemd-journal.c
@@ -32,7 +32,7 @@ typedef struct msg_content
 
 static msg_content_t *msg_content_new()
 {
-    msg_content_t *msg_c = xmalloc(sizeof(*msg_c));
+    msg_content_t *msg_c = libreport_xmalloc(sizeof(*msg_c));
 
     msg_c->allocated = 0;
     msg_c->used = 0;
@@ -66,10 +66,10 @@ static void msg_content_add_ext(msg_content_t *msg_c, const char *key, const cha
     if (msg_c->used >= msg_c->allocated)
     {
         msg_c->allocated += 5;
-        msg_c->data = xrealloc(msg_c->data, msg_c->allocated * sizeof(*(msg_c->data)));
+        msg_c->data = libreport_xrealloc(msg_c->data, msg_c->allocated * sizeof(*(msg_c->data)));
     }
 
-    char *s = xasprintf("%s%s=%s", prefix, key, value);
+    char *s = libreport_xasprintf("%s%s=%s", prefix, key, value);
     for (char *c = s; *c != '='; ++c) *c = toupper(*c);
     msg_c->data[msg_c->used].iov_base = s;
     msg_c->data[msg_c->used].iov_len = strlen(s);
@@ -173,7 +173,7 @@ create_journal_message(problem_data_t *problem_data, problem_report_t *pr, unsig
     /* add problem report description into PROBLEM_REPORT field */
     char *description = NULL;
     if (strcmp(problem_report_get_description(pr), "") != 0)
-        description = xasprintf("\n%s", problem_report_get_description(pr));
+        description = libreport_xasprintf("\n%s", problem_report_get_description(pr));
 
     msg_content_add(msg_c, "PROBLEM_REPORT", description ? description : "");
     free(description);
@@ -198,7 +198,7 @@ create_journal_message(problem_data_t *problem_data, problem_report_t *pr, unsig
             if (item && (item->flags & CD_FLAG_TXT))
             {
                 /* elements listed in fields_default_no_prefix are added withou prefix */
-                if (is_in_string_list(elem->data, fields_default_no_prefix))
+                if (libreport_is_in_string_list(elem->data, fields_default_no_prefix))
                     msg_content_add(msg_c, elem->data, item->content);
                 else
                     msg_content_add_ext(msg_c, elem->data, item->content, FIELD_PREFIX);
@@ -246,7 +246,7 @@ int main(int argc, char **argv)
     const char *syslog_id = NULL;
     /* Keep enum above and order of options below in sync! */
     struct options program_options[] = {
-        OPT__VERBOSE(&g_verbose),
+        OPT__VERBOSE(&libreport_g_verbose),
         OPT_STRING('d', NULL          , &dump_dir_name, "DIR"   , _("Problem directory")),
         OPT_STRING('m', "message-id"  , &message_id,    "STR"   , _("Catalog message id")),
         OPT_STRING('F', NULL          , &fmt_file     , "FILE"  , _("Formatting file for catalog message")),
@@ -255,7 +255,7 @@ int main(int argc, char **argv)
         OPT_BOOL(  'D', NULL          , NULL                    , _("Debug")),
         OPT_END()
     };
-    unsigned opts = parse_opts(argc, argv, program_options, program_usage_string);
+    unsigned opts = libreport_parse_opts(argc, argv, program_options, program_usage_string);
 
     unsigned dump_opt = DUMP_NONE;
     if (opts & OPT_p)
@@ -269,15 +269,15 @@ int main(int argc, char **argv)
         else
         {
             error_msg("Parameter --dump takes NONE|ESSENTIAL|FULL values");
-            show_usage_and_die(program_usage_string, program_options);
+            libreport_show_usage_and_die(program_usage_string, program_options);
         }
     }
 
-    export_abrt_envvars(0);
+    libreport_export_abrt_envvars(0);
 
     problem_data_t *problem_data = create_problem_data_for_reporting(dump_dir_name);
     if (!problem_data)
-        xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
+        libreport_xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
 
     problem_formatter_t *pf = problem_formatter_new();
 

--- a/src/plugins/reporter-upload.c
+++ b/src/plugins/reporter-upload.c
@@ -93,7 +93,7 @@ static int create_and_upload_archive(
     tempfile = concat_path_basename(LARGE_DATA_TMP_DIR, dump_dir_name);
     tempfile = append_to_malloced_string(tempfile, ".tar.gz");
 
-    string_vector_ptr_t exclude_from_report = get_global_always_excluded_elements();
+    string_vector_ptr_t exclude_from_report = libreport_get_global_always_excluded_elements();
 
     struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
     if (!dd)

--- a/src/plugins/reporter-upload.c
+++ b/src/plugins/reporter-upload.c
@@ -22,7 +22,7 @@
 
 static char *ask_url(const char *message)
 {
-    char *url = ask(message);
+    char *url = libreport_ask(message);
     if (url == NULL || url[0] == '\0')
     {
         set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
@@ -49,7 +49,7 @@ static int interactive_upload_file(const char *url, const char *file_name,
             /* the result. User can dismiss this prompt but the upload */
             /* may work somehow??? */
             char *msg = xasprintf(_("Please enter password for uploading:"), state->username);
-            state->password = password_inp = ask_password(msg);
+            state->password = password_inp = libreport_ask_password(msg);
             free(msg);
         }
     }

--- a/src/plugins/reporter-upload.c
+++ b/src/plugins/reporter-upload.c
@@ -63,7 +63,7 @@ static int interactive_upload_file(const char *url, const char *file_name,
     if (state->client_ssh_private_keyfile != NULL)
         log_debug("Using SSH private key '%s'", state->client_ssh_private_keyfile);
 
-    char *tmp = upload_file_ext(state, url, file_name, UPLOAD_FILE_HANDLE_ACCESS_DENIALS);
+    char *tmp = libreport_upload_file_ext(state, url, file_name, UPLOAD_FILE_HANDLE_ACCESS_DENIALS);
 
     if (remote_name)
         *remote_name = tmp;

--- a/src/plugins/reporter-upload.c
+++ b/src/plugins/reporter-upload.c
@@ -246,7 +246,7 @@ int main(int argc, char **argv)
 
         report_result_set_url(result, remote_name);
 
-        add_reported_to_entry(dd, result);
+        libreport_add_reported_to_entry(dd, result);
 
         report_result_free(result);
 

--- a/src/plugins/reporter-upload.c
+++ b/src/plugins/reporter-upload.c
@@ -25,7 +25,7 @@ static char *ask_url(const char *message)
     char *url = libreport_ask(message);
     if (url == NULL || url[0] == '\0')
     {
-        set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
+        libreport_set_xfunc_error_retval(EXIT_CANCEL_BY_USER);
         error_msg_and_die(_("Can't continue without URL"));
     }
 
@@ -48,7 +48,7 @@ static int interactive_upload_file(const char *url, const char *file_name,
             /* Be permissive and nice, ask only once and don't check */
             /* the result. User can dismiss this prompt but the upload */
             /* may work somehow??? */
-            char *msg = xasprintf(_("Please enter password for uploading:"), state->username);
+            char *msg = libreport_xasprintf(_("Please enter password for uploading:"), state->username);
             state->password = password_inp = libreport_ask_password(msg);
             free(msg);
         }
@@ -90,14 +90,14 @@ static int create_and_upload_archive(
     /* SELinux guys are not happy with /tmp, using /var/run/abrt */
     /* Reverted back to /tmp for ABRT2 */
     /* Changed again to /var/tmp because of Fedora feature tmp-on-tmpfs */
-    tempfile = concat_path_basename(LARGE_DATA_TMP_DIR, dump_dir_name);
-    tempfile = append_to_malloced_string(tempfile, ".tar.gz");
+    tempfile = libreport_concat_path_basename(LARGE_DATA_TMP_DIR, dump_dir_name);
+    tempfile = libreport_append_to_malloced_string(tempfile, ".tar.gz");
 
     string_vector_ptr_t exclude_from_report = libreport_get_global_always_excluded_elements();
 
     struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
     if (!dd)
-        xfunc_die(); /* error msg is already logged by dd_opendir */
+        libreport_xfunc_die(); /* error msg is already logged by dd_opendir */
 
     /* Compressing e.g. 0.5gig coredump takes a while. Let client know what we are doing */
     log_warning(_("Compressing data"));
@@ -182,7 +182,7 @@ int main(int argc, char **argv)
     };
     /* Keep enum above and order of options below in sync! */
     struct options program_options[] = {
-        OPT__VERBOSE(&g_verbose),
+        OPT__VERBOSE(&libreport_g_verbose),
         OPT_STRING('d', NULL, &dump_dir_name, "DIR"     , _("Problem directory")),
         OPT_STRING('c', NULL, &conf_file    , "CONFFILE", _("Config file")),
         OPT_STRING('u', NULL, &url          , "URL"     , _("Base URL to upload to")),
@@ -190,9 +190,9 @@ int main(int argc, char **argv)
         OPT_STRING('r', "key",     &ssh_private_key, "FILE" , _("SSH private key file")),
         OPT_END()
     };
-    /*unsigned opts =*/ parse_opts(argc, argv, program_options, program_usage_string);
+    /*unsigned opts =*/ libreport_parse_opts(argc, argv, program_options, program_usage_string);
 
-    export_abrt_envvars(0);
+    libreport_export_abrt_envvars(0);
 
     // 2015-10-16 (jfilak):
     //   It looks like there is no demand for encryption and other archive
@@ -207,7 +207,7 @@ int main(int argc, char **argv)
 
     map_string_t *settings = new_map_string();
     if (conf_file)
-        load_conf_file(conf_file, settings, /*skip key w/o values:*/ false);
+        libreport_load_conf_file(conf_file, settings, /*skip key w/o values:*/ false);
 
     char *input_url = NULL;
     const char *conf_url = getenv("Upload_URL");

--- a/src/plugins/reporter-upload.c
+++ b/src/plugins/reporter-upload.c
@@ -36,13 +36,13 @@ static int interactive_upload_file(const char *url, const char *file_name,
                                    map_string_t *settings, char **remote_name)
 {
     post_state_t *state = new_post_state(POST_WANT_ERROR_MSG);
-    state->username = get_map_string_item_or_NULL(settings, "UploadUsername");
+    state->username = libreport_get_map_string_item_or_NULL(settings, "UploadUsername");
     char *password_inp = NULL;
     if (state->username != NULL && state->username[0] != '\0')
     {
         /* Load Password only if Username is configured, it doesn't make */
         /* much sense to load Password without Username. */
-        state->password = get_map_string_item_or_NULL(settings, "UploadPassword");
+        state->password = libreport_get_map_string_item_or_NULL(settings, "UploadPassword");
         if (state->password == NULL)
         {
             /* Be permissive and nice, ask only once and don't check */
@@ -55,8 +55,8 @@ static int interactive_upload_file(const char *url, const char *file_name,
     }
 
     /* set SSH keys */
-    state->client_ssh_public_keyfile = get_map_string_item_or_NULL(settings, "SSHPublicKey");
-    state->client_ssh_private_keyfile = get_map_string_item_or_NULL(settings, "SSHPrivateKey");
+    state->client_ssh_public_keyfile = libreport_get_map_string_item_or_NULL(settings, "SSHPublicKey");
+    state->client_ssh_private_keyfile = libreport_get_map_string_item_or_NULL(settings, "SSHPrivateKey");
 
     if (state->client_ssh_public_keyfile != NULL)
         log_debug("Using SSH public key '%s'", state->client_ssh_public_keyfile);
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
     //TODO:
     //ExcludeFiles = foo,bar*,b*z
 
-    map_string_t *settings = new_map_string();
+    map_string_t *settings = libreport_new_map_string();
     if (conf_file)
         libreport_load_conf_file(conf_file, settings, /*skip key w/o values:*/ false);
 
@@ -214,23 +214,23 @@ int main(int argc, char **argv)
     if (!conf_url || conf_url[0] == '\0')
         conf_url = url;
     if (!conf_url || conf_url[0] == '\0')
-        conf_url = get_map_string_item_or_empty(settings, "URL");
+        conf_url = libreport_get_map_string_item_or_empty(settings, "URL");
     if (!conf_url || conf_url[0] == '\0')
         conf_url = input_url = ask_url(_("Please enter a URL (scp, ftp, etc.) where the problem data is to be exported:"));
 
-    set_map_string_item_from_string(settings, "UploadUsername", getenv("Upload_Username"));
-    set_map_string_item_from_string(settings, "UploadPassword", getenv("Upload_Password"));
+    libreport_set_map_string_item_from_string(settings, "UploadUsername", getenv("Upload_Username"));
+    libreport_set_map_string_item_from_string(settings, "UploadPassword", getenv("Upload_Password"));
 
     /* set SSH keys */
     if (ssh_public_key)
-        set_map_string_item_from_string(settings, "SSHPublicKey", ssh_public_key);
+        libreport_set_map_string_item_from_string(settings, "SSHPublicKey", ssh_public_key);
     else if (getenv("Upload_SSHPublicKey") != NULL)
-        set_map_string_item_from_string(settings, "SSHPublicKey", getenv("Upload_SSHPublicKey"));
+        libreport_set_map_string_item_from_string(settings, "SSHPublicKey", getenv("Upload_SSHPublicKey"));
 
     if (ssh_private_key)
-        set_map_string_item_from_string(settings, "SSHPrivateKey", ssh_private_key);
+        libreport_set_map_string_item_from_string(settings, "SSHPrivateKey", ssh_private_key);
     else if (getenv("Upload_SSHPrivateKey") != NULL)
-        set_map_string_item_from_string(settings, "SSHPrivateKey", getenv("Upload_SSHPrivateKey"));
+        libreport_set_map_string_item_from_string(settings, "SSHPrivateKey", getenv("Upload_SSHPrivateKey"));
 
     char *remote_name = NULL;
     const int result = create_and_upload_archive(dump_dir_name, conf_url, settings, &remote_name);
@@ -256,6 +256,6 @@ int main(int argc, char **argv)
 
 finito:
     free(input_url);
-    free_map_string(settings);
+    libreport_free_map_string(settings);
     return result;
 }

--- a/src/plugins/reporter-ureport.c
+++ b/src/plugins/reporter-ureport.c
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
             g_autoptr(report_result_t) result = NULL;
             char *bthash;
 
-            result = find_in_reported_to(dd, "uReport");
+            result = libreport_find_in_reported_to(dd, "uReport");
             if (NULL == result)
             {
                 error_msg_and_die(_("This problem does not have an uReport assigned."));
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
             g_autoptr(report_result_t) result = NULL;
             g_autofree char *url = NULL;
 
-            result = find_in_reported_to(dd, "Bugzilla");
+            result = libreport_find_in_reported_to(dd, "Bugzilla");
             if (NULL == result)
             {
                 error_msg_and_die(_("This problem has not been reported to Bugzilla."));
@@ -237,7 +237,7 @@ int main(int argc, char **argv)
             g_autoptr(report_result_t) result = NULL;
             char *url;
 
-            result = find_in_reported_to(dd, report_result_type);
+            result = libreport_find_in_reported_to(dd, report_result_type);
             if (NULL == result)
             {
                 error_msg_and_die(_("This problem has not been reported to '%s'."), report_result_type);

--- a/src/plugins/reporter-ureport.c
+++ b/src/plugins/reporter-ureport.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
 
     unsigned opts = libreport_parse_opts(argc, argv, program_options, program_usage_string);
 
-    map_string_t *settings = new_map_string();
+    map_string_t *settings = libreport_new_map_string();
     libreport_load_conf_file(conf_file, settings, /*skip key w/o values:*/ false);
 
     ureport_server_config_load(&config, settings);
@@ -347,7 +347,7 @@ finalize:
     if (config.ur_prefs.urp_auth_items == auth_items)
         config.ur_prefs.urp_auth_items = NULL;
 
-    free_map_string(settings);
+    libreport_free_map_string(settings);
     ureport_server_config_destroy(&config);
 
     return ret;

--- a/src/plugins/reporter-ureport.c
+++ b/src/plugins/reporter-ureport.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
     abrt_init(argv);
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     enum {
         OPT_v = 1 << 0,
@@ -126,14 +126,14 @@ int main(int argc, char **argv)
     map_string_t *settings = libreport_new_map_string();
     libreport_load_conf_file(conf_file, settings, /*skip key w/o values:*/ false);
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
     if (opts & OPT_u)
-        ureport_server_config_set_url(&config, libreport_xstrdup(arg_server_url));
+        libreport_ureport_server_config_set_url(&config, libreport_xstrdup(arg_server_url));
     if (opts & OPT_k)
         config.ur_ssl_verify = !insecure;
     if (opts & OPT_t)
-        ureport_server_config_set_client_auth(&config, client_auth);
+        libreport_ureport_server_config_set_client_auth(&config, client_auth);
     if (opts & OPT_h)
         ureport_server_config_load_basic_auth(&config, http_auth);
     if (opts & OPT_i)
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
     }
 
     if (!config.ur_url)
-        ureport_server_config_set_url(&config, libreport_xstrdup(DEFAULT_WEB_SERVICE_URL));
+        libreport_ureport_server_config_set_url(&config, libreport_xstrdup(DEFAULT_WEB_SERVICE_URL));
 
     if (ureport_hash && ureport_hash_from_rt)
         error_msg_and_die("You need to pass either -a bthash or -A");
@@ -305,14 +305,14 @@ int main(int argc, char **argv)
     struct ureport_preferences *prefs = &(config.ur_prefs);
     prefs->urp_flags |= UREPORT_PREF_FLAG_RETURN_ON_FAILURE;
 
-    char *json_ureport = ureport_from_dump_dir_ext(dump_dir_path, prefs);
+    char *json_ureport = libreport_ureport_from_dump_dir_ext(dump_dir_path, prefs);
     if (!json_ureport)
     {
         error_msg(_("Failed to generate microreport from the problem data"));
         goto finalize;
     }
 
-    struct ureport_server_response *response = ureport_submit(json_ureport, &config);
+    struct ureport_server_response *response = libreport_ureport_submit(json_ureport, &config);
     free(json_ureport);
 
     if (!response)
@@ -323,7 +323,7 @@ int main(int argc, char **argv)
         log_notice("is known: %s", response->urr_value);
         ret = 0; /* "success" */
 
-        if (!ureport_server_response_save_in_dump_dir(response, dump_dir_path, &config))
+        if (!libreport_ureport_server_response_save_in_dump_dir(response, dump_dir_path, &config))
             libreport_xfunc_die();
 
         /* If a reported problem is not known then emit NEEDMORE */
@@ -339,7 +339,7 @@ int main(int argc, char **argv)
     else
         error_msg(_("Server responded with an error: '%s'"), response->urr_value);
 
-    ureport_server_response_free(response);
+    libreport_ureport_server_response_free(response);
 
 finalize:
     free(attach_value_from_rt_data);
@@ -348,7 +348,7 @@ finalize:
         config.ur_prefs.urp_auth_items = NULL;
 
     libreport_free_map_string(settings);
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     return ret;
 }

--- a/src/plugins/reporter-ureport.c
+++ b/src/plugins/reporter-ureport.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
     char *attach_type = NULL;
     struct dump_dir *dd = NULL;
     struct options program_options[] = {
-        OPT__VERBOSE(&g_verbose),
+        OPT__VERBOSE(&libreport_g_verbose),
         OPT__DUMP_DIR(&dump_dir_path),
         OPT_STRING('u', "url", &arg_server_url, "URL", _("Specify server URL")),
         OPT_BOOL('k', "insecure", &insecure,
@@ -121,15 +121,15 @@ int main(int argc, char **argv)
         "Reads the default configuration from "UREPORT_CONF_FILE_PATH
     );
 
-    unsigned opts = parse_opts(argc, argv, program_options, program_usage_string);
+    unsigned opts = libreport_parse_opts(argc, argv, program_options, program_usage_string);
 
     map_string_t *settings = new_map_string();
-    load_conf_file(conf_file, settings, /*skip key w/o values:*/ false);
+    libreport_load_conf_file(conf_file, settings, /*skip key w/o values:*/ false);
 
     ureport_server_config_load(&config, settings);
 
     if (opts & OPT_u)
-        ureport_server_config_set_url(&config, xstrdup(arg_server_url));
+        ureport_server_config_set_url(&config, libreport_xstrdup(arg_server_url));
     if (opts & OPT_k)
         config.ur_ssl_verify = !insecure;
     if (opts & OPT_t)
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
     }
 
     if (!config.ur_url)
-        ureport_server_config_set_url(&config, xstrdup(DEFAULT_WEB_SERVICE_URL));
+        ureport_server_config_set_url(&config, libreport_xstrdup(DEFAULT_WEB_SERVICE_URL));
 
     if (ureport_hash && ureport_hash_from_rt)
         error_msg_and_die("You need to pass either -a bthash or -A");
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
     {
         dd = dd_opendir(dump_dir_path, DD_OPEN_READONLY);
         if (!dd)
-            xfunc_die();
+            libreport_xfunc_die();
 
         if (ureport_hash_from_rt)
         {
@@ -324,7 +324,7 @@ int main(int argc, char **argv)
         ret = 0; /* "success" */
 
         if (!ureport_server_response_save_in_dump_dir(response, dump_dir_path, &config))
-            xfunc_die();
+            libreport_xfunc_die();
 
         /* If a reported problem is not known then emit NEEDMORE */
         if (strcmp("true", response->urr_value) == 0)

--- a/src/plugins/rhbz.c
+++ b/src/plugins/rhbz.c
@@ -524,7 +524,7 @@ int rhbz_new_bug(struct abrt_xmlrpc *ax,
     libreport_strbuf_append_strf(status_whiteboard, "abrt_hash:%s;", duphash);
 
     {   /* Add fields from /etc/os-release to Whiteboard for simple metrics. */
-        map_string_t *osinfo = new_map_string();
+        map_string_t *osinfo = libreport_new_map_string();
         problem_data_get_osinfo(problem_data, osinfo);
 
         /* This is the highest abstraction level I am willing to introduce now.
@@ -537,7 +537,7 @@ int rhbz_new_bug(struct abrt_xmlrpc *ax,
         const char *const opts[] = { "VARIANT_ID", NULL };
         for (const char *const *iter = opts; *iter != NULL; ++iter)
         {
-            const char *v = get_map_string_item_or_NULL(osinfo, *iter);
+            const char *v = libreport_get_map_string_item_or_NULL(osinfo, *iter);
             if (v != NULL)
             {
                 /* semi-colon (;) is the delimiter because /etc/os-release *_ID
@@ -547,7 +547,7 @@ int rhbz_new_bug(struct abrt_xmlrpc *ax,
             }
         }
 
-        free_map_string(osinfo);
+        libreport_free_map_string(osinfo);
     }
 
     xmlrpc_env env;

--- a/src/report-newt/report-newt.c
+++ b/src/report-newt/report-newt.c
@@ -104,10 +104,10 @@ static int configure_reporter(struct reporter *r, bool skip_if_valid)
             (!skip_if_valid && first && r->config))
     {
         text = newtTextboxReflowed(0, 0, ec_get_screen_name(r->config) ?
-                xstrdup(ec_get_screen_name(r->config)) : r->name, 35, 5, 5, 0);
+                libreport_xstrdup(ec_get_screen_name(r->config)) : r->name, 35, 5, 5, 0);
 
         num_opts = g_list_length(r->config->options);
-        options = xmalloc(sizeof (newtComponent) * num_opts);
+        options = libreport_xmalloc(sizeof (newtComponent) * num_opts);
         ogrid = newtCreateGrid(2, num_opts);
 
         for (option = r->config->options, i = 0; option && i < num_opts;
@@ -230,7 +230,7 @@ static char *save_log_line(char *log_line, void *param)
     {
         /* Append the log line */
         len = strlen(log->text) + 1 + strlen(log_line) + 1;
-        new = xmalloc(len);
+        new = libreport_xmalloc(len);
         snprintf(new, len, "%s\n%s", log->text, log_line);
         free(log->text);
         free(log_line);
@@ -272,11 +272,11 @@ static void run_reporter(const char *dump_dir_name, struct reporter *r)
     /* Export overridden settings as environment variables */
     env_list = export_event_config(r->name);
 
-    save_log_line(xasprintf(_("--- Running %s ---"), r->name), &log);
+    save_log_line(libreport_xasprintf(_("--- Running %s ---"), r->name), &log);
 
     x = run_event_on_dir_name(run_state, dump_dir_name, r->name);
     if (x)
-        save_log_line(xasprintf("(exited with %d)", x), &log);
+        save_log_line(libreport_xasprintf("(exited with %d)", x), &log);
 
     newtFormSetCurrent(form, button);
     newtRunForm(form);
@@ -327,7 +327,7 @@ static int report(const char *dump_dir_name)
     {
         char *reason = dd_load_text_ext(dd, FILENAME_REASON, 0
                                         | DD_LOAD_TEXT_RETURN_NULL_ON_FAILURE);
-        char *t = xasprintf("%s %s",
+        char *t = libreport_xasprintf("%s %s",
                             not_reportable,
                             reason ? : _("(no description)"));
 
@@ -397,15 +397,15 @@ int main(int argc, char **argv)
         OPT_BOOL('V', "version", NULL,     _("Display version and exit")),
         OPT_END()
     };
-    unsigned opts = parse_opts(argc, argv, program_options, program_usage_string);
+    unsigned opts = libreport_parse_opts(argc, argv, program_options, program_usage_string);
     argv += optind;
     /* >0 arguments with -V */
     if (((opts & OPT_V) && argv[0]) || !argv[0])
-        show_usage_and_die(program_usage_string, program_options);
+        libreport_show_usage_and_die(program_usage_string, program_options);
 
     if (opts & OPT_V)
     {
-        printf("%s "VERSION"\n", g_progname);
+        printf("%s "VERSION"\n", libreport_g_progname);
         return 0;
     }
 

--- a/src/report-newt/report-newt.c
+++ b/src/report-newt/report-newt.c
@@ -336,7 +336,7 @@ static int report(const char *dump_dir_name)
         free(not_reportable);
         free(reason);
 
-        if (get_global_stop_on_not_reportable())
+        if (libreport_get_global_stop_on_not_reportable())
         {
             dd_close(dd);
             return -1;

--- a/src/report-python/report/dump_dir.c
+++ b/src/report-python/report/dump_dir.c
@@ -260,7 +260,7 @@ static PyMethodDef p_dump_dir_methods[] = {
     { "load_text"  , p_dd_load_text, METH_VARARGS, NULL },
     { "save_text"  , p_dd_save_text, METH_VARARGS, NULL },
     { "save_binary", p_dd_save_binary, METH_VARARGS, NULL },
-    { "copy_file"  , p_dd_copy_file, METH_VARARGS, NULL },
+    { "libreport_copy_file", p_dd_copy_file, METH_VARARGS, NULL },
     { "delete_item", p_dd_delete_item, METH_VARARGS, NULL },
     { NULL }
 };

--- a/tests/client.at
+++ b/tests/client.at
@@ -133,7 +133,7 @@ int main (void)
     }
 
     int status;
-    if (safe_waitpid(pid, &status, 0) < 0) {
+    if (libreport_safe_waitpid(pid, &status, 0) < 0) {
         perror_msg_and_die("waitpid failed.");
     }
 

--- a/tests/client.at
+++ b/tests/client.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([Client])
 
-## ---------------- ##
-##     set_echo     ##
-## ---------------- ##
+## -------------------------- ##
+##     libreport_set_echo     ##
+## -------------------------- ##
 
-AT_TESTFUN([set_echo],
+AT_TESTFUN([libreport_set_echo],
 [[
 #include <assert.h>
 #include "client.h"
@@ -40,7 +40,7 @@ int main (void)
         assert(check == 0);
 
         changed = 0;
-        result = set_echo(changed);
+        result = libreport_set_echo(changed);
         check = tcgetattr(STDIN_FILENO, &new_mode);
         assert(check == 0);
         assert(result != changed);
@@ -48,7 +48,7 @@ int main (void)
         assert(ECHONL_TEST == 0);
 
         changed = 1;
-        result = set_echo(changed);
+        result = libreport_set_echo(changed);
         check = tcgetattr(STDIN_FILENO, &new_mode);
         assert(check == 0);
         assert(result == changed);
@@ -61,7 +61,7 @@ int main (void)
         assert(check == 0);
 
         changed = 0;
-        result = set_echo(changed);
+        result = libreport_set_echo(changed);
         check = tcgetattr(STDIN_FILENO, &new_mode);
         assert(result == changed);
         assert(ECHO_TEST == 1);
@@ -73,7 +73,7 @@ int main (void)
         assert(check == 0);
 
         changed = 1;
-        result = set_echo(changed);
+        result = libreport_set_echo(changed);
         check = tcgetattr(STDIN_FILENO, &new_mode);
         assert(result != changed);
         assert(ECHO_TEST == 0);
@@ -84,7 +84,7 @@ int main (void)
         assert(check == 0);
 
         changed = 0;
-        result = set_echo(changed);
+        result = libreport_set_echo(changed);
         check = tcgetattr(STDIN_FILENO, &new_mode);
         assert(result != changed);
         assert(ECHO_TEST == 1);
@@ -95,7 +95,7 @@ int main (void)
         assert(check == 0);
 
         changed = 1;
-        result = set_echo(changed);
+        result = libreport_set_echo(changed);
         check = tcgetattr(STDIN_FILENO, &new_mode);
         assert(check == 0);
         assert(result == changed);
@@ -107,7 +107,7 @@ int main (void)
         assert(check == 0);
 
         changed = 0;
-        result = set_echo(changed);
+        result = libreport_set_echo(changed);
         check = tcgetattr(STDIN_FILENO, &new_mode);
         assert(check == 0);
         assert(result != changed);
@@ -119,7 +119,7 @@ int main (void)
         assert(check == 0);
 
         changed = 1;
-        result = set_echo(changed);
+        result = libreport_set_echo(changed);
         check = tcgetattr(STDIN_FILENO, &new_mode);
         assert(check == 0);
         assert(result == changed);

--- a/tests/compress.at
+++ b/tests/compress.at
@@ -49,7 +49,7 @@ TS_MAIN
 
     for (size_t i = 0; i < PLAIN_CHUNKS; ++i)
     {
-        const int wrote = safe_write(pipes[1], BASE64, sizeof(BASE64) - 1);
+        const int wrote = libreport_safe_write(pipes[1], BASE64, sizeof(BASE64) - 1);
         if (wrote != sizeof(BASE64) - 1)
             err(EXIT_FAILURE, "Failed to write to temp file");
     }
@@ -79,7 +79,7 @@ TS_MAIN
     if (fdi < 0)
         err(EXIT_FAILURE, "Failed to open compressed file %s", compressedfilename);
 
-    TS_ASSERT_FUNCTION(decompress_fd(fdi, fdo));
+    TS_ASSERT_FUNCTION(libreport_decompress_fd(fdi, fdo));
     close(fdi);
 
     if (0 > lseek(fdo, 0L, SEEK_SET))
@@ -88,7 +88,7 @@ TS_MAIN
     int c = 0;
     size_t sz = 0;
     char buf[sizeof(BASE64)];
-    while ((r = safe_read(fdo, buf, sizeof(BASE64) - 1)) != EOF && r != 0)
+    while ((r = libreport_safe_read(fdo, buf, sizeof(BASE64) - 1)) != EOF && r != 0)
     {
         c++;
         sz += r;

--- a/tests/configuration_files.at
+++ b/tests/configuration_files.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([Configuration files])
 
-## ---------------##
-## load_conf_file ##
-## ---------------##
+## -------------------------##
+## libreport_load_conf_file ##
+## -------------------------##
 
-AT_TESTFUN([load_conf_file],
+AT_TESTFUN([libreport_load_conf_file],
 [[
 #include "internal_libreport.h"
 #include "stdlib.h"
@@ -60,7 +60,7 @@ equal_result_t map_string_equals(map_string_t *f, map_string_t *s)
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     {
         /* Self check */
@@ -70,30 +70,30 @@ int main(int argc, char **argv)
         assert(EQUAL == map_string_equals(first, first));
         assert(EQUAL == map_string_equals(first, second));
 
-        insert_map_string(first, xstrdup("first"), xstrdup("1"));
-        insert_map_string(first, xstrdup("second"), xstrdup("2"));
-        insert_map_string(first, xstrdup("third"), xstrdup("3"));
+        insert_map_string(first, libreport_xstrdup("first"), libreport_xstrdup("1"));
+        insert_map_string(first, libreport_xstrdup("second"), libreport_xstrdup("2"));
+        insert_map_string(first, libreport_xstrdup("third"), libreport_xstrdup("3"));
 
         assert(EQUAL == map_string_equals(first, first));
 
         assert(DIFF_SIZE == map_string_equals(first, second));
         assert(DIFF_SIZE == map_string_equals(second, first));
 
-        insert_map_string(second, xstrdup("first"), xstrdup("1"));
-        insert_map_string(second, xstrdup("second"), xstrdup("2"));
-        insert_map_string(second, xstrdup("third"), xstrdup("3"));
+        insert_map_string(second, libreport_xstrdup("first"), libreport_xstrdup("1"));
+        insert_map_string(second, libreport_xstrdup("second"), libreport_xstrdup("2"));
+        insert_map_string(second, libreport_xstrdup("third"), libreport_xstrdup("3"));
 
         assert(EQUAL == map_string_equals(first, second));
         assert(EQUAL == map_string_equals(second, first));
 
-        insert_map_string(first, xstrdup("fifth"), xstrdup("5"));
-        insert_map_string(second, xstrdup("fourth"), xstrdup("4"));
+        insert_map_string(first, libreport_xstrdup("fifth"), libreport_xstrdup("5"));
+        insert_map_string(second, libreport_xstrdup("fourth"), libreport_xstrdup("4"));
 
         assert(MISS_KEY == map_string_equals(first, second));
         assert(MISS_KEY == map_string_equals(second, first));
 
-        insert_map_string(first, xstrdup("fourth"), xstrdup("4"));
-        insert_map_string(second, xstrdup("fifth"), xstrdup("6"));
+        insert_map_string(first, libreport_xstrdup("fourth"), libreport_xstrdup("4"));
+        insert_map_string(second, libreport_xstrdup("fifth"), libreport_xstrdup("6"));
 
         assert(DIFF_VALUE == map_string_equals(first, second));
         assert(DIFF_VALUE == map_string_equals(second, first));
@@ -104,14 +104,14 @@ int main(int argc, char **argv)
 
     {
         map_string_t *first = new_map_string();
-        insert_map_string(first, xstrdup("success"), xstrdup("\"total\""));
-        insert_map_string(first, xstrdup("failure"), xstrdup("\"none\""));
-        insert_map_string(first, xstrdup("effort"), xstrdup("\"minimal\""));
-        insert_map_string(first, xstrdup("state"), xstrdup("\"done\""));
+        insert_map_string(first, libreport_xstrdup("success"), libreport_xstrdup("\"total\""));
+        insert_map_string(first, libreport_xstrdup("failure"), libreport_xstrdup("\"none\""));
+        insert_map_string(first, libreport_xstrdup("effort"), libreport_xstrdup("\"minimal\""));
+        insert_map_string(first, libreport_xstrdup("state"), libreport_xstrdup("\"done\""));
 
         map_string_t *second = new_map_string();
 
-        assert(load_conf_file(CONF_PATH, second, 0));
+        assert(libreport_load_conf_file(CONF_PATH, second, 0));
 
         assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the expected");
 
@@ -125,11 +125,11 @@ int main(int argc, char **argv)
 
 
 
-## ------------------------ ##
-## load_conf_file_from_dirs ##
-## ------------------------ ##
+## ---------------------------------- ##
+## libreport_load_conf_file_from_dirs ##
+## ---------------------------------- ##
 
-AT_TESTFUN([load_conf_file_from_dirs],
+AT_TESTFUN([libreport_load_conf_file_from_dirs],
 [[
 #include "internal_libreport.h"
 
@@ -184,7 +184,7 @@ equal_result_t map_string_equals(map_string_t *f, map_string_t *s)
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     {
         /* Self check */
@@ -194,30 +194,30 @@ int main(int argc, char **argv)
         assert(EQUAL == map_string_equals(first, first));
         assert(EQUAL == map_string_equals(first, second));
 
-        insert_map_string(first, xstrdup("first"), xstrdup("1"));
-        insert_map_string(first, xstrdup("second"), xstrdup("2"));
-        insert_map_string(first, xstrdup("third"), xstrdup("3"));
+        insert_map_string(first, libreport_xstrdup("first"), libreport_xstrdup("1"));
+        insert_map_string(first, libreport_xstrdup("second"), libreport_xstrdup("2"));
+        insert_map_string(first, libreport_xstrdup("third"), libreport_xstrdup("3"));
 
         assert(EQUAL == map_string_equals(first, first));
 
         assert(DIFF_SIZE == map_string_equals(first, second));
         assert(DIFF_SIZE == map_string_equals(second, first));
 
-        insert_map_string(second, xstrdup("first"), xstrdup("1"));
-        insert_map_string(second, xstrdup("second"), xstrdup("2"));
-        insert_map_string(second, xstrdup("third"), xstrdup("3"));
+        insert_map_string(second, libreport_xstrdup("first"), libreport_xstrdup("1"));
+        insert_map_string(second, libreport_xstrdup("second"), libreport_xstrdup("2"));
+        insert_map_string(second, libreport_xstrdup("third"), libreport_xstrdup("3"));
 
         assert(EQUAL == map_string_equals(first, second));
         assert(EQUAL == map_string_equals(second, first));
 
-        insert_map_string(first, xstrdup("fifth"), xstrdup("5"));
-        insert_map_string(second, xstrdup("fourth"), xstrdup("4"));
+        insert_map_string(first, libreport_xstrdup("fifth"), libreport_xstrdup("5"));
+        insert_map_string(second, libreport_xstrdup("fourth"), libreport_xstrdup("4"));
 
         assert(MISS_KEY == map_string_equals(first, second));
         assert(MISS_KEY == map_string_equals(second, first));
 
-        insert_map_string(first, xstrdup("fourth"), xstrdup("4"));
-        insert_map_string(second, xstrdup("fifth"), xstrdup("6"));
+        insert_map_string(first, libreport_xstrdup("fourth"), libreport_xstrdup("4"));
+        insert_map_string(second, libreport_xstrdup("fifth"), libreport_xstrdup("6"));
 
         assert(DIFF_VALUE == map_string_equals(first, second));
         assert(DIFF_VALUE == map_string_equals(second, first));
@@ -230,7 +230,7 @@ int main(int argc, char **argv)
         map_string_t *first = new_map_string();
         map_string_t *second = new_map_string();
 
-        assert(!load_conf_file_from_dirs(CONF_NAME, NULL, second, 0));
+        assert(!libreport_load_conf_file_from_dirs(CONF_NAME, NULL, second, 0));
 
         assert(EQUAL == map_string_equals(first, second) || !"Not empty");
 
@@ -246,7 +246,7 @@ int main(int argc, char **argv)
         map_string_t *first = new_map_string();
         map_string_t *second = new_map_string();
 
-        assert(!load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
+        assert(!libreport_load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
 
         assert(EQUAL == map_string_equals(first, second) || !"Not empty");
 
@@ -261,10 +261,10 @@ int main(int argc, char **argv)
         };
 
         map_string_t *first = new_map_string();
-        load_conf_file(DEFAULT_DIR"/"CONF_NAME, first, 0);
+        libreport_load_conf_file(DEFAULT_DIR"/"CONF_NAME, first, 0);
 
         map_string_t *second = new_map_string();
-        assert(load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
+        assert(libreport_load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
 
         assert(EQUAL == map_string_equals(first, second));
 
@@ -281,12 +281,12 @@ int main(int argc, char **argv)
         };
 
         map_string_t *first = new_map_string();
-        load_conf_file(DEFAULT_DIR"/"CONF_NAME, first, 0);
-        load_conf_file(FIRST_DIR"/"CONF_NAME, first, 0);
-        load_conf_file(SECOND_DIR"/"CONF_NAME, first, 0);
+        libreport_load_conf_file(DEFAULT_DIR"/"CONF_NAME, first, 0);
+        libreport_load_conf_file(FIRST_DIR"/"CONF_NAME, first, 0);
+        libreport_load_conf_file(SECOND_DIR"/"CONF_NAME, first, 0);
 
         map_string_t *second = new_map_string();
-        assert(load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
+        assert(libreport_load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
 
         assert(EQUAL == map_string_equals(first, second));
 
@@ -304,12 +304,12 @@ int main(int argc, char **argv)
         };
 
         map_string_t *first = new_map_string();
-        load_conf_file(DEFAULT_DIR"/"CONF_NAME, first, 0);
-        load_conf_file(FIRST_DIR"/"CONF_NAME, first, 0);
-        load_conf_file(SECOND_DIR"/"CONF_NAME, first, 0);
+        libreport_load_conf_file(DEFAULT_DIR"/"CONF_NAME, first, 0);
+        libreport_load_conf_file(FIRST_DIR"/"CONF_NAME, first, 0);
+        libreport_load_conf_file(SECOND_DIR"/"CONF_NAME, first, 0);
 
         map_string_t *second = new_map_string();
-        assert(!load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
+        assert(!libreport_load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
 
         assert(EQUAL == map_string_equals(first, second));
 
@@ -321,11 +321,11 @@ int main(int argc, char **argv)
 }
 ]])
 
-## ---------------------------- ##
-## load_conf_file_from_dirs_ext ##
-## ---------------------------- ##
+## -------------------------------------- ##
+## libreport_load_conf_file_from_dirs_ext ##
+## -------------------------------------- ##
 
-AT_TESTFUN([load_conf_file_from_dirs_ext],
+AT_TESTFUN([libreport_load_conf_file_from_dirs_ext],
 [[
 #include "internal_libreport.h"
 
@@ -333,7 +333,7 @@ AT_TESTFUN([load_conf_file_from_dirs_ext],
 
 int main(void)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     {
         const char *const dir_vec[] = {
@@ -350,7 +350,7 @@ int main(void)
 
         map_string_t *settings = new_map_string();
 
-        assert(load_conf_file_from_dirs_ext(CONF_NAME, dir_vec, dir_flags_vec, settings, 0));
+        assert(libreport_load_conf_file_from_dirs_ext(CONF_NAME, dir_vec, dir_flags_vec, settings, 0));
 
         free_map_string(settings);
     }
@@ -359,11 +359,11 @@ int main(void)
 
 
 
-## ---------------##
-## save_conf_file ##
-## ---------------##
+## -------------------------##
+## libreport_save_conf_file ##
+## -------------------------##
 
-AT_TESTFUN([save_conf_file],
+AT_TESTFUN([libreport_save_conf_file],
 [[
 #include "internal_libreport.h"
 
@@ -416,7 +416,7 @@ equal_result_t map_string_equals(map_string_t *f, map_string_t *s)
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     {
         /* Self check */
@@ -426,30 +426,30 @@ int main(int argc, char **argv)
         assert(EQUAL == map_string_equals(first, first));
         assert(EQUAL == map_string_equals(first, second));
 
-        insert_map_string(first, xstrdup("first"), xstrdup("1"));
-        insert_map_string(first, xstrdup("second"), xstrdup("2"));
-        insert_map_string(first, xstrdup("third"), xstrdup("3"));
+        insert_map_string(first, libreport_xstrdup("first"), libreport_xstrdup("1"));
+        insert_map_string(first, libreport_xstrdup("second"), libreport_xstrdup("2"));
+        insert_map_string(first, libreport_xstrdup("third"), libreport_xstrdup("3"));
 
         assert(EQUAL == map_string_equals(first, first));
 
         assert(DIFF_SIZE == map_string_equals(first, second));
         assert(DIFF_SIZE == map_string_equals(second, first));
 
-        insert_map_string(second, xstrdup("first"), xstrdup("1"));
-        insert_map_string(second, xstrdup("second"), xstrdup("2"));
-        insert_map_string(second, xstrdup("third"), xstrdup("3"));
+        insert_map_string(second, libreport_xstrdup("first"), libreport_xstrdup("1"));
+        insert_map_string(second, libreport_xstrdup("second"), libreport_xstrdup("2"));
+        insert_map_string(second, libreport_xstrdup("third"), libreport_xstrdup("3"));
 
         assert(EQUAL == map_string_equals(first, second));
         assert(EQUAL == map_string_equals(second, first));
 
-        insert_map_string(first, xstrdup("fifth"), xstrdup("5"));
-        insert_map_string(second, xstrdup("fourth"), xstrdup("4"));
+        insert_map_string(first, libreport_xstrdup("fifth"), libreport_xstrdup("5"));
+        insert_map_string(second, libreport_xstrdup("fourth"), libreport_xstrdup("4"));
 
         assert(MISS_KEY == map_string_equals(first, second));
         assert(MISS_KEY == map_string_equals(second, first));
 
-        insert_map_string(first, xstrdup("fourth"), xstrdup("4"));
-        insert_map_string(second, xstrdup("fifth"), xstrdup("6"));
+        insert_map_string(first, libreport_xstrdup("fourth"), libreport_xstrdup("4"));
+        insert_map_string(second, libreport_xstrdup("fifth"), libreport_xstrdup("6"));
 
         assert(DIFF_VALUE == map_string_equals(first, second));
         assert(DIFF_VALUE == map_string_equals(second, first));
@@ -460,29 +460,29 @@ int main(int argc, char **argv)
 
     {
         map_string_t *first = new_map_string();
-        insert_map_string(first, xstrdup("success"), xstrdup("total"));
-        insert_map_string(first, xstrdup("failure"), xstrdup("none"));
-        insert_map_string(first, xstrdup("effort"), xstrdup("minimal"));
-        insert_map_string(first, xstrdup("state"), xstrdup("done"));
+        insert_map_string(first, libreport_xstrdup("success"), libreport_xstrdup("total"));
+        insert_map_string(first, libreport_xstrdup("failure"), libreport_xstrdup("none"));
+        insert_map_string(first, libreport_xstrdup("effort"), libreport_xstrdup("minimal"));
+        insert_map_string(first, libreport_xstrdup("state"), libreport_xstrdup("done"));
 
         /* These commands must fail */
-        assert(!save_conf_file("/proc/cpuinfo/foo/blah/file.conf", first));
-        assert(!save_conf_file("../../../../../../../../../../../../../../../proc/cpuinfo/foo/blah/file.conf", first));
-        assert(!save_conf_file("/proc/cpuinfo/root/file.conf", first));
+        assert(!libreport_save_conf_file("/proc/cpuinfo/foo/blah/file.conf", first));
+        assert(!libreport_save_conf_file("../../../../../../../../../../../../../../../proc/cpuinfo/foo/blah/file.conf", first));
+        assert(!libreport_save_conf_file("/proc/cpuinfo/root/file.conf", first));
 
         char tmpdir[] = "/tmp/libreport_save_conf_file.XXXXXX";
 
         /* OK, I know that I should not use tmpnam() but I want to check */
-        /* that save_conf_file() creates the directory */
+        /* that libreport_save_conf_file() creates the directory */
         assert(tmpnam(tmpdir) != NULL);
 
-        char *conf_path = concat_path_file(tmpdir, CONF_NAME);
+        char *conf_path = libreport_concat_path_file(tmpdir, CONF_NAME);
 
-        assert(save_conf_file(conf_path, first) || !"Save in not existing directory");
+        assert(libreport_save_conf_file(conf_path, first) || !"Save in not existing directory");
 
         {
             map_string_t *second = new_map_string();
-            assert(load_conf_file(conf_path, second, 0) || !"Loaded from not existing directory");
+            assert(libreport_load_conf_file(conf_path, second, 0) || !"Loaded from not existing directory");
 
             assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the saved configuration");
 
@@ -493,8 +493,8 @@ int main(int argc, char **argv)
             map_string_t *second = new_map_string();
 
             unlink(CUSTOM_CONF);
-            assert(save_conf_file(CUSTOM_CONF, first) || !"Saved at relative path");
-            assert(load_conf_file(CUSTOM_CONF, second, 0) || !"Load the saved at relative path");
+            assert(libreport_save_conf_file(CUSTOM_CONF, first) || !"Saved at relative path");
+            assert(libreport_load_conf_file(CUSTOM_CONF, second, 0) || !"Load the saved at relative path");
 
             unlink(CUSTOM_CONF);
 
@@ -508,20 +508,20 @@ int main(int argc, char **argv)
 
     {   /* Test that keys removed from the conf map are also removed from the corresponding file */
         map_string_t *first = new_map_string();
-        insert_map_string(first, xstrdup("success"), xstrdup("total"));
-        insert_map_string(first, xstrdup("failure"), xstrdup("none"));
-        insert_map_string(first, xstrdup("effort"), xstrdup("minimal"));
-        insert_map_string(first, xstrdup("state"), xstrdup("done"));
+        insert_map_string(first, libreport_xstrdup("success"), libreport_xstrdup("total"));
+        insert_map_string(first, libreport_xstrdup("failure"), libreport_xstrdup("none"));
+        insert_map_string(first, libreport_xstrdup("effort"), libreport_xstrdup("minimal"));
+        insert_map_string(first, libreport_xstrdup("state"), libreport_xstrdup("done"));
 
         unlink(CUSTOM_CONF);
-        assert(save_conf_file(CUSTOM_CONF, first) || !"Saved at relative path");
+        assert(libreport_save_conf_file(CUSTOM_CONF, first) || !"Saved at relative path");
 
         remove_map_string_item(first, "failure");
         remove_map_string_item(first, "state");
-        assert(save_conf_file(CUSTOM_CONF, first) || !"Saved updated configuration");
+        assert(libreport_save_conf_file(CUSTOM_CONF, first) || !"Saved updated configuration");
 
         map_string_t *second = new_map_string();
-        assert(load_conf_file(CUSTOM_CONF, second, 0) || !"Load the updated conf from relative path");
+        assert(libreport_load_conf_file(CUSTOM_CONF, second, 0) || !"Load the updated conf from relative path");
 
         assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the saved configuration");
 
@@ -529,10 +529,10 @@ int main(int argc, char **argv)
 
         remove_map_string_item(first, "success");
         remove_map_string_item(first, "effort");
-        assert(save_conf_file(CUSTOM_CONF, first) || !"Saved empty configuration");
+        assert(libreport_save_conf_file(CUSTOM_CONF, first) || !"Saved empty configuration");
 
         second = new_map_string();
-        assert(load_conf_file(CUSTOM_CONF, second, 0) || !"Load the empty conf from relative path");
+        assert(libreport_load_conf_file(CUSTOM_CONF, second, 0) || !"Load the empty conf from relative path");
 
         assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the empty configuration");
 

--- a/tests/configuration_files.at
+++ b/tests/configuration_files.at
@@ -36,8 +36,8 @@ equal_result_t map_string_equals(map_string_t *f, map_string_t *s)
     gpointer fkey = NULL;
     gpointer fvalue = NULL;
 
-    init_map_string_iter(&iter, f);
-    while(next_map_string_iter(&iter, (const char **)&fkey, (const char **)&fvalue))
+    libreport_init_map_string_iter(&iter, f);
+    while(libreport_next_map_string_iter(&iter, (const char **)&fkey, (const char **)&fvalue))
     {
         gpointer skey = NULL;
         gpointer svalue = NULL;
@@ -64,8 +64,8 @@ int main(int argc, char **argv)
 
     {
         /* Self check */
-        map_string_t *first = new_map_string();
-        map_string_t *second = new_map_string();
+        map_string_t *first = libreport_new_map_string();
+        map_string_t *second = libreport_new_map_string();
 
         assert(EQUAL == map_string_equals(first, first));
         assert(EQUAL == map_string_equals(first, second));
@@ -98,25 +98,25 @@ int main(int argc, char **argv)
         assert(DIFF_VALUE == map_string_equals(first, second));
         assert(DIFF_VALUE == map_string_equals(second, first));
 
-        free_map_string(first);
-        free_map_string(second);
+        libreport_free_map_string(first);
+        libreport_free_map_string(second);
     }
 
     {
-        map_string_t *first = new_map_string();
+        map_string_t *first = libreport_new_map_string();
         insert_map_string(first, libreport_xstrdup("success"), libreport_xstrdup("\"total\""));
         insert_map_string(first, libreport_xstrdup("failure"), libreport_xstrdup("\"none\""));
         insert_map_string(first, libreport_xstrdup("effort"), libreport_xstrdup("\"minimal\""));
         insert_map_string(first, libreport_xstrdup("state"), libreport_xstrdup("\"done\""));
 
-        map_string_t *second = new_map_string();
+        map_string_t *second = libreport_new_map_string();
 
         assert(libreport_load_conf_file(CONF_PATH, second, 0));
 
         assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the expected");
 
-        free_map_string(first);
-        free_map_string(second);
+        libreport_free_map_string(first);
+        libreport_free_map_string(second);
     }
 
     return 0;
@@ -160,8 +160,8 @@ equal_result_t map_string_equals(map_string_t *f, map_string_t *s)
     gpointer fkey = NULL;
     gpointer fvalue = NULL;
 
-    init_map_string_iter(&iter, f);
-    while(next_map_string_iter(&iter, (const char **)&fkey, (const char **)&fvalue))
+    libreport_init_map_string_iter(&iter, f);
+    while(libreport_next_map_string_iter(&iter, (const char **)&fkey, (const char **)&fvalue))
     {
         gpointer skey = NULL;
         gpointer svalue = NULL;
@@ -188,8 +188,8 @@ int main(int argc, char **argv)
 
     {
         /* Self check */
-        map_string_t *first = new_map_string();
-        map_string_t *second = new_map_string();
+        map_string_t *first = libreport_new_map_string();
+        map_string_t *second = libreport_new_map_string();
 
         assert(EQUAL == map_string_equals(first, first));
         assert(EQUAL == map_string_equals(first, second));
@@ -222,20 +222,20 @@ int main(int argc, char **argv)
         assert(DIFF_VALUE == map_string_equals(first, second));
         assert(DIFF_VALUE == map_string_equals(second, first));
 
-        free_map_string(first);
-        free_map_string(second);
+        libreport_free_map_string(first);
+        libreport_free_map_string(second);
     }
 
     {
-        map_string_t *first = new_map_string();
-        map_string_t *second = new_map_string();
+        map_string_t *first = libreport_new_map_string();
+        map_string_t *second = libreport_new_map_string();
 
         assert(!libreport_load_conf_file_from_dirs(CONF_NAME, NULL, second, 0));
 
         assert(EQUAL == map_string_equals(first, second) || !"Not empty");
 
-        free_map_string(first);
-        free_map_string(second);
+        libreport_free_map_string(first);
+        libreport_free_map_string(second);
     }
 
     {
@@ -243,15 +243,15 @@ int main(int argc, char **argv)
             NULL,
         };
 
-        map_string_t *first = new_map_string();
-        map_string_t *second = new_map_string();
+        map_string_t *first = libreport_new_map_string();
+        map_string_t *second = libreport_new_map_string();
 
         assert(!libreport_load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
 
         assert(EQUAL == map_string_equals(first, second) || !"Not empty");
 
-        free_map_string(first);
-        free_map_string(second);
+        libreport_free_map_string(first);
+        libreport_free_map_string(second);
     }
 
     {
@@ -260,16 +260,16 @@ int main(int argc, char **argv)
             NULL,
         };
 
-        map_string_t *first = new_map_string();
+        map_string_t *first = libreport_new_map_string();
         libreport_load_conf_file(DEFAULT_DIR"/"CONF_NAME, first, 0);
 
-        map_string_t *second = new_map_string();
+        map_string_t *second = libreport_new_map_string();
         assert(libreport_load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
 
         assert(EQUAL == map_string_equals(first, second));
 
-        free_map_string(first);
-        free_map_string(second);
+        libreport_free_map_string(first);
+        libreport_free_map_string(second);
     }
 
     {
@@ -280,18 +280,18 @@ int main(int argc, char **argv)
             NULL,
         };
 
-        map_string_t *first = new_map_string();
+        map_string_t *first = libreport_new_map_string();
         libreport_load_conf_file(DEFAULT_DIR"/"CONF_NAME, first, 0);
         libreport_load_conf_file(FIRST_DIR"/"CONF_NAME, first, 0);
         libreport_load_conf_file(SECOND_DIR"/"CONF_NAME, first, 0);
 
-        map_string_t *second = new_map_string();
+        map_string_t *second = libreport_new_map_string();
         assert(libreport_load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
 
         assert(EQUAL == map_string_equals(first, second));
 
-        free_map_string(first);
-        free_map_string(second);
+        libreport_free_map_string(first);
+        libreport_free_map_string(second);
     }
 
     {
@@ -303,18 +303,18 @@ int main(int argc, char **argv)
             NULL,
         };
 
-        map_string_t *first = new_map_string();
+        map_string_t *first = libreport_new_map_string();
         libreport_load_conf_file(DEFAULT_DIR"/"CONF_NAME, first, 0);
         libreport_load_conf_file(FIRST_DIR"/"CONF_NAME, first, 0);
         libreport_load_conf_file(SECOND_DIR"/"CONF_NAME, first, 0);
 
-        map_string_t *second = new_map_string();
+        map_string_t *second = libreport_new_map_string();
         assert(!libreport_load_conf_file_from_dirs(CONF_NAME, dir_vec, second, 0));
 
         assert(EQUAL == map_string_equals(first, second));
 
-        free_map_string(first);
-        free_map_string(second);
+        libreport_free_map_string(first);
+        libreport_free_map_string(second);
     }
 
     return 0;
@@ -348,11 +348,11 @@ int main(void)
             -1,
         };
 
-        map_string_t *settings = new_map_string();
+        map_string_t *settings = libreport_new_map_string();
 
         assert(libreport_load_conf_file_from_dirs_ext(CONF_NAME, dir_vec, dir_flags_vec, settings, 0));
 
-        free_map_string(settings);
+        libreport_free_map_string(settings);
     }
 }
 ]])
@@ -392,8 +392,8 @@ equal_result_t map_string_equals(map_string_t *f, map_string_t *s)
     gpointer fkey = NULL;
     gpointer fvalue = NULL;
 
-    init_map_string_iter(&iter, f);
-    while(next_map_string_iter(&iter, (const char **)&fkey, (const char **)&fvalue))
+    libreport_init_map_string_iter(&iter, f);
+    while(libreport_next_map_string_iter(&iter, (const char **)&fkey, (const char **)&fvalue))
     {
         gpointer skey = NULL;
         gpointer svalue = NULL;
@@ -420,8 +420,8 @@ int main(int argc, char **argv)
 
     {
         /* Self check */
-        map_string_t *first = new_map_string();
-        map_string_t *second = new_map_string();
+        map_string_t *first = libreport_new_map_string();
+        map_string_t *second = libreport_new_map_string();
 
         assert(EQUAL == map_string_equals(first, first));
         assert(EQUAL == map_string_equals(first, second));
@@ -454,12 +454,12 @@ int main(int argc, char **argv)
         assert(DIFF_VALUE == map_string_equals(first, second));
         assert(DIFF_VALUE == map_string_equals(second, first));
 
-        free_map_string(first);
-        free_map_string(second);
+        libreport_free_map_string(first);
+        libreport_free_map_string(second);
     }
 
     {
-        map_string_t *first = new_map_string();
+        map_string_t *first = libreport_new_map_string();
         insert_map_string(first, libreport_xstrdup("success"), libreport_xstrdup("total"));
         insert_map_string(first, libreport_xstrdup("failure"), libreport_xstrdup("none"));
         insert_map_string(first, libreport_xstrdup("effort"), libreport_xstrdup("minimal"));
@@ -481,16 +481,16 @@ int main(int argc, char **argv)
         assert(libreport_save_conf_file(conf_path, first) || !"Save in not existing directory");
 
         {
-            map_string_t *second = new_map_string();
+            map_string_t *second = libreport_new_map_string();
             assert(libreport_load_conf_file(conf_path, second, 0) || !"Loaded from not existing directory");
 
             assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the saved configuration");
 
-            free_map_string(second);
+            libreport_free_map_string(second);
         }
 
         {
-            map_string_t *second = new_map_string();
+            map_string_t *second = libreport_new_map_string();
 
             unlink(CUSTOM_CONF);
             assert(libreport_save_conf_file(CUSTOM_CONF, first) || !"Saved at relative path");
@@ -500,14 +500,14 @@ int main(int argc, char **argv)
 
             assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the saved configuration");
 
-            free_map_string(second);
+            libreport_free_map_string(second);
         }
 
-        free_map_string(first);
+        libreport_free_map_string(first);
     }
 
     {   /* Test that keys removed from the conf map are also removed from the corresponding file */
-        map_string_t *first = new_map_string();
+        map_string_t *first = libreport_new_map_string();
         insert_map_string(first, libreport_xstrdup("success"), libreport_xstrdup("total"));
         insert_map_string(first, libreport_xstrdup("failure"), libreport_xstrdup("none"));
         insert_map_string(first, libreport_xstrdup("effort"), libreport_xstrdup("minimal"));
@@ -516,30 +516,30 @@ int main(int argc, char **argv)
         unlink(CUSTOM_CONF);
         assert(libreport_save_conf_file(CUSTOM_CONF, first) || !"Saved at relative path");
 
-        remove_map_string_item(first, "failure");
-        remove_map_string_item(first, "state");
+        libreport_remove_map_string_item(first, "failure");
+        libreport_remove_map_string_item(first, "state");
         assert(libreport_save_conf_file(CUSTOM_CONF, first) || !"Saved updated configuration");
 
-        map_string_t *second = new_map_string();
+        map_string_t *second = libreport_new_map_string();
         assert(libreport_load_conf_file(CUSTOM_CONF, second, 0) || !"Load the updated conf from relative path");
 
         assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the saved configuration");
 
-        free_map_string(second);
+        libreport_free_map_string(second);
 
-        remove_map_string_item(first, "success");
-        remove_map_string_item(first, "effort");
+        libreport_remove_map_string_item(first, "success");
+        libreport_remove_map_string_item(first, "effort");
         assert(libreport_save_conf_file(CUSTOM_CONF, first) || !"Saved empty configuration");
 
-        second = new_map_string();
+        second = libreport_new_map_string();
         assert(libreport_load_conf_file(CUSTOM_CONF, second, 0) || !"Load the empty conf from relative path");
 
         assert(EQUAL == map_string_equals(first, second) || !"The loaded configuration equals to the empty configuration");
 
         unlink(CUSTOM_CONF);
 
-        free_map_string(second);
-        free_map_string(first);
+        libreport_free_map_string(second);
+        libreport_free_map_string(first);
     }
 
     return 0;

--- a/tests/dump_dir.at
+++ b/tests/dump_dir.at
@@ -198,7 +198,7 @@ AT_TESTFUN([dd_create_open_delete],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX/dump_dir";
 
@@ -270,7 +270,7 @@ AT_TESTFUN([dd_sanitize_mode_and_owner],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX/dump_dir";
 
@@ -374,7 +374,7 @@ AT_TESTFUN([dd_owner],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX/dump_dir";
 
@@ -479,7 +479,7 @@ AT_TESTFUN([dd_stat],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX/dump_dir";
 
@@ -570,12 +570,12 @@ AT_TESTFUN([recursive_lock],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char *path = tmpnam(NULL);
     struct dump_dir *dd = dd_create(path, -1L, DEFAULT_DUMP_DIR_MODE);
 
-    char *lock_path = concat_path_file(path, ".lock");
+    char *lock_path = libreport_concat_path_file(path, ".lock");
     struct stat buf;
 
     assert(dd);
@@ -606,53 +606,53 @@ int main(int argc, char **argv)
 }
 ]])
 
-## ----------------------- ##
-## str_is_correct_filename ##
-## ----------------------- ##
+## --------------------------------- ##
+## libreport_str_is_correct_filename ##
+## --------------------------------- ##
 
-AT_TESTFUN([str_is_correct_filename],
+AT_TESTFUN([libreport_str_is_correct_filename],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
 #
 int main(void)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
-    assert(str_is_correct_filename("") == false);
-    assert(str_is_correct_filename("/") == false);
-    assert(str_is_correct_filename("//") == false);
-    assert(str_is_correct_filename("/a") == false);
-    assert(str_is_correct_filename("a/") == false);
-    assert(str_is_correct_filename(".") == false);
-    assert(str_is_correct_filename("..") == false);
-    assert(str_is_correct_filename("/.") == false);
-    assert(str_is_correct_filename("//.") == false);
-    assert(str_is_correct_filename("./") == false);
-    assert(str_is_correct_filename(".//") == false);
-    assert(str_is_correct_filename("/./") == false);
-    assert(str_is_correct_filename("/..") == false);
-    assert(str_is_correct_filename("//..") == false);
-    assert(str_is_correct_filename("../") == false);
-    assert(str_is_correct_filename("..//") == false);
-    assert(str_is_correct_filename("/../") == false);
-    assert(str_is_correct_filename("/.././") == false);
+    assert(libreport_str_is_correct_filename("") == false);
+    assert(libreport_str_is_correct_filename("/") == false);
+    assert(libreport_str_is_correct_filename("//") == false);
+    assert(libreport_str_is_correct_filename("/a") == false);
+    assert(libreport_str_is_correct_filename("a/") == false);
+    assert(libreport_str_is_correct_filename(".") == false);
+    assert(libreport_str_is_correct_filename("..") == false);
+    assert(libreport_str_is_correct_filename("/.") == false);
+    assert(libreport_str_is_correct_filename("//.") == false);
+    assert(libreport_str_is_correct_filename("./") == false);
+    assert(libreport_str_is_correct_filename(".//") == false);
+    assert(libreport_str_is_correct_filename("/./") == false);
+    assert(libreport_str_is_correct_filename("/..") == false);
+    assert(libreport_str_is_correct_filename("//..") == false);
+    assert(libreport_str_is_correct_filename("../") == false);
+    assert(libreport_str_is_correct_filename("..//") == false);
+    assert(libreport_str_is_correct_filename("/../") == false);
+    assert(libreport_str_is_correct_filename("/.././") == false);
 
-    assert(str_is_correct_filename("looks-good-but-evil/") == false);
-    assert(str_is_correct_filename("looks-good-but-evil/../../") == false);
+    assert(libreport_str_is_correct_filename("looks-good-but-evil/") == false);
+    assert(libreport_str_is_correct_filename("looks-good-but-evil/../../") == false);
 
-    assert(str_is_correct_filename(".meta-data") == true);
-    assert(str_is_correct_filename("..meta-meta-data") == true);
-    assert(str_is_correct_filename("meta-..-data") == true);
+    assert(libreport_str_is_correct_filename(".meta-data") == true);
+    assert(libreport_str_is_correct_filename("..meta-meta-data") == true);
+    assert(libreport_str_is_correct_filename("meta-..-data") == true);
 
-    assert(str_is_correct_filename("a") == true);
-    assert(str_is_correct_filename(".a") == true);
-    assert(str_is_correct_filename("a.") == true);
-    assert(str_is_correct_filename("ab") == true);
-    assert(str_is_correct_filename("abc") == true);
-    assert(str_is_correct_filename("abcd") == true);
-    assert(str_is_correct_filename("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+-") == true);
-    assert(str_is_correct_filename("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+-=") == false);
+    assert(libreport_str_is_correct_filename("a") == true);
+    assert(libreport_str_is_correct_filename(".a") == true);
+    assert(libreport_str_is_correct_filename("a.") == true);
+    assert(libreport_str_is_correct_filename("ab") == true);
+    assert(libreport_str_is_correct_filename("abc") == true);
+    assert(libreport_str_is_correct_filename("abcd") == true);
+    assert(libreport_str_is_correct_filename("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+-") == true);
+    assert(libreport_str_is_correct_filename("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+-=") == false);
 
     return 0;
 }
@@ -859,7 +859,7 @@ void test(const char buffer[], const size_t buffer_size)
 
     char tmpfile[] = "/tmp/libreport-attestsuite-dd_copy_fd.XXXXXX";
     int tmpfd = mkstemp(tmpfile);
-    full_write(tmpfd, buffer, buffer_size);
+    libreport_full_write(tmpfd, buffer, buffer_size);
 
     {
         assert((-1) != lseek(tmpfd, 0, SEEK_SET));
@@ -991,7 +991,7 @@ AT_TESTFUN([dd_load_int32],
 #
 int main(void)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX";
 
@@ -1069,7 +1069,7 @@ AT_TESTFUN([dd_load_uint32],
 #
 int main(void)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX";
 
@@ -1136,7 +1136,7 @@ AT_TESTFUN([dd_load_int64],
 
 int main(void)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX";
 
@@ -1202,7 +1202,7 @@ AT_TESTFUN([dd_load_uint64],
 
 int main(void)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX";
 
@@ -1271,10 +1271,10 @@ void verify_archive(struct dump_dir *dd, const char *file_name,
     unsigned c = 0;
     for (const_string_vector_const_ptr_t i = included_files; i && *i; ++i)
         ++c;
-    int *check_array = xzalloc(c * sizeof(int));
+    int *check_array = libreport_xzalloc(c * sizeof(int));
 
     int pipe_from_parent_to_child[2];
-    xpipe(pipe_from_parent_to_child);
+    libreport_xpipe(pipe_from_parent_to_child);
     pid_t child = fork();
     if (child < 0)
         perror_msg_and_die("vfork");
@@ -1283,14 +1283,14 @@ void verify_archive(struct dump_dir *dd, const char *file_name,
     {
         /* child */
         close(pipe_from_parent_to_child[0]);
-        xmove_fd(xopen(file_name, O_RDONLY), 0);
-        xmove_fd(pipe_from_parent_to_child[1], 1);
+        libreport_xmove_fd(libreport_xopen(file_name, O_RDONLY), 0);
+        libreport_xmove_fd(pipe_from_parent_to_child[1], 1);
         execlp("gzip", "gzip", "-d", NULL);
         perror_msg_and_die("Can't execute '%s'", "gzip");
     }
     close(pipe_from_parent_to_child[1]);
 
-    /* If child died (say, in xopen), then parent might get SIGPIPE.
+    /* If child died (say, in libreport_xopen), then parent might get SIGPIPE.
      * We want to properly unlock dd, therefore we must not die on SIGPIPE:
      */
     signal(SIGPIPE, SIG_IGN);
@@ -1329,7 +1329,7 @@ void verify_archive(struct dump_dir *dd, const char *file_name,
             check_array[c] += 1;
 
             unlink(real_file);
-            if(tar_extract_regfile(tar, xstrdup(real_file)) != 0)
+            if(tar_extract_regfile(tar, libreport_xstrdup(real_file)) != 0)
             {
                 fprintf(stderr, "TAR failed to extract '%s' to '%s': %s\n", path, real_file, strerror(errno));
                 abort();
@@ -1339,7 +1339,7 @@ void verify_archive(struct dump_dir *dd, const char *file_name,
             assert(original != NULL);
             assert(original[0] != '\0');
 
-            char *extracted = xmalloc_xopen_read_close("/tmp/libreport-attest-extracted", NULL);
+            char *extracted = libreport_xmalloc_xopen_read_close("/tmp/libreport-attest-extracted", NULL);
             assert(extracted != NULL);
 
             if (strcmp(extracted, original) != 0)
@@ -1379,7 +1379,7 @@ void verify_archive(struct dump_dir *dd, const char *file_name,
     tar_close(tar);
 
     int status;
-    safe_waitpid(child, &status, 0);
+    libreport_safe_waitpid(child, &status, 0);
     if (status != 0)
     {
         fprintf(stderr, "gzip status code '%d'\n", status);
@@ -1414,7 +1414,7 @@ void verify_archive(struct dump_dir *dd, const char *file_name,
 
 int main(void)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX";
 
@@ -1471,7 +1471,7 @@ int main(void)
 
         assert(dd_create_archive(dd, file_name, NULL, 0) == -EEXIST || !"Exists");
 
-        char *canary = xmalloc_xopen_read_close(file_name, NULL);
+        char *canary = libreport_xmalloc_xopen_read_close(file_name, NULL);
         assert(canary != NULL);
         assert(strcmp(canary, file_contents) == 0);
     }
@@ -1587,10 +1587,10 @@ TS_MAIN
     struct dump_dir *dd = testsuite_dump_dir_create(-1, -1, 0);
     dd_create_basic_files(dd, geteuid(), NULL);
 
-    char *base_dir = xstrndup(dd->dd_dirname, strrchr(dd->dd_dirname, '/') - dd->dd_dirname);
+    char *base_dir = libreport_xstrndup(dd->dd_dirname, strrchr(dd->dd_dirname, '/') - dd->dd_dirname);
     assert(base_dir != NULL);
 
-    char *test_file_full_path = concat_path_file(base_dir, "libreport-test");
+    char *test_file_full_path = libreport_concat_path_file(base_dir, "libreport-test");
     FILE *test_file = fopen(test_file_full_path, "w");
     assert(test_file != NULL);
     fprintf(test_file, "dd_items_handling");
@@ -1826,7 +1826,7 @@ TS_MAIN
     const int fd_wronly_noent = dd_open_item(dd, "nofile", O_RDWR);
     TS_ASSERT_SIGNED_GE(fd_wronly_noent, 0);
     if (g_testsuite_last_ok) {
-        full_write_str(fd_wronly_noent, "fd_wronly_noent");
+        libreport_full_write_str(fd_wronly_noent, "fd_wronly_noent");
         close(fd_wronly_noent);
 
         char *const noent_contents = dd_load_text(dd, "nofile");
@@ -1843,7 +1843,7 @@ TS_MAIN
         TS_ASSERT_PTR_IS_NOT_NULL(time);
 
         char rdonly_time_contents[16];
-        int bytes_rdonly_time = full_read(fd_rdonly_time, rdonly_time_contents, sizeof(rdonly_time_contents));
+        int bytes_rdonly_time = libreport_full_read(fd_rdonly_time, rdonly_time_contents, sizeof(rdonly_time_contents));
         TS_ASSERT_SIGNED_GT(bytes_rdonly_time, 0);
         if (bytes_rdonly_time > 0) {
             rdonly_time_contents[bytes_rdonly_time] = '\0';
@@ -1861,12 +1861,12 @@ TS_MAIN
     const int fd_rdwr_time = dd_open_item(dd, "time", O_RDWR);
     TS_ASSERT_SIGNED_GE(fd_rdwr_time, 0);
     if (g_testsuite_last_ok) {
-        full_write_str(fd_rdwr_time, "7654321");
+        libreport_full_write_str(fd_rdwr_time, "7654321");
 
         TS_ASSERT_FUNCTION(lseek(fd_rdwr_time, 0, SEEK_SET));
 
         char rdwr_time_contents[16];
-        int bytes_rdwr_time = full_read(fd_rdwr_time, rdwr_time_contents, sizeof(rdwr_time_contents));
+        int bytes_rdwr_time = libreport_full_read(fd_rdwr_time, rdwr_time_contents, sizeof(rdwr_time_contents));
         close(fd_rdwr_time);
 
         TS_ASSERT_SIGNED_GT(bytes_rdwr_time, 0);

--- a/tests/event_config.at
+++ b/tests/event_config.at
@@ -24,12 +24,12 @@ TS_MAIN
     TS_ASSERT_PTR_IS_NULL(ect->ec_restricted_access_option);
     TS_ASSERT_FALSE(ec_restricted_access_enabled(ect));
 
-    ect->ec_restricted_access_option = xstrdup("PrivateTicket");
+    ect->ec_restricted_access_option = libreport_xstrdup("PrivateTicket");
 
     TS_ASSERT_FALSE(ec_restricted_access_enabled(ect));
 
     event_option_t *eot = new_event_option();
-    eot->eo_name = xstrdup("PrivateTicket");
+    eot->eo_name = libreport_xstrdup("PrivateTicket");
     eot->eo_value = NULL;
 
     ect->options = g_list_prepend(ect->options, eot);
@@ -37,12 +37,12 @@ TS_MAIN
     TS_ASSERT_FALSE(ec_restricted_access_enabled(ect));
 
     eot->eo_type = OPTION_TYPE_BOOL;
-    eot->eo_value = xstrdup("no");
+    eot->eo_value = libreport_xstrdup("no");
 
     TS_ASSERT_FALSE(ec_restricted_access_enabled(ect));
 
     free(eot->eo_value);
-    eot->eo_value = xstrdup("yes");
+    eot->eo_value = libreport_xstrdup("yes");
 
     TS_ASSERT_TRUE(ec_restricted_access_enabled(ect));
 
@@ -70,10 +70,10 @@ AT_TESTFUN([get_options_with_err_msg], [[
 event_option_t* create_new_option(const char *n, const char *v, option_type_t t, int ae)
 {
     event_option_t *op = new_event_option();
-    op->eo_name = xstrdup(n);
+    op->eo_name = libreport_xstrdup(n);
     op->eo_value = NULL;
     if(v != NULL)
-        op->eo_value = xstrdup(v);
+        op->eo_value = libreport_xstrdup(v);
 
     op->eo_type = t;
     op->eo_allow_empty = ae;
@@ -100,7 +100,7 @@ TS_MAIN
         evnt->options = g_list_append(evnt->options, opt_login);
         evnt->options = g_list_append(evnt->options, opt_passwd);
         evnt->options = g_list_append(evnt->options, opt_url);
-        g_hash_table_insert(g_event_config_list, xstrdup("Bugster0"), evnt);
+        g_hash_table_insert(g_event_config_list, libreport_xstrdup("Bugster0"), evnt);
 
         errors = get_options_with_err_msg("Bugster0");
         e_op = (invalid_option_t *)errors->data;
@@ -125,7 +125,7 @@ TS_MAIN
         evnt->options = g_list_append(evnt->options, opt_passwd);
         evnt->options = g_list_append(evnt->options, opt_login);
         evnt->options = g_list_append(evnt->options, opt_url);
-        g_hash_table_insert(g_event_config_list, xstrdup("Bugster1"), evnt);
+        g_hash_table_insert(g_event_config_list, libreport_xstrdup("Bugster1"), evnt);
 
         errors = get_options_with_err_msg("Bugster1");
         e_op = (invalid_option_t *)errors->data;
@@ -150,7 +150,7 @@ TS_MAIN
         evnt->options = g_list_append(evnt->options, opt_login);
         evnt->options = g_list_append(evnt->options, opt_passwd);
         evnt->options = g_list_append(evnt->options, opt_url);
-        g_hash_table_insert(g_event_config_list, xstrdup("Bugster2"), evnt);
+        g_hash_table_insert(g_event_config_list, libreport_xstrdup("Bugster2"), evnt);
 
         errors = get_options_with_err_msg("Bugster2");
 

--- a/tests/forbidden_words.at
+++ b/tests/forbidden_words.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([Forbidden words])
 
-## -------------------- ##
-## load_words_from_file ##
-## -------------------- ##
+## ------------------------------ ##
+## libreport_load_words_from_file ##
+## ------------------------------ ##
 
-AT_TESTFUN([load_words_from_file],
+AT_TESTFUN([libreport_load_words_from_file],
 [[
 #include "testsuite.h"
 
@@ -18,9 +18,9 @@ TS_MAIN
 
     TS_ASSERT_STDERR_EQ_BEGIN
     {
-        g_verbose = 0;
-        dynamic_words = load_words_from_file("certainly_missing_file.conf");
-        g_verbose = 3;
+        libreport_g_verbose = 0;
+        dynamic_words = libreport_load_words_from_file("certainly_missing_file.conf");
+        libreport_g_verbose = 3;
     }
     TS_ASSERT_STDERR_EQ_END("", "No error messages produced!");
 
@@ -28,11 +28,11 @@ TS_MAIN
     g_list_free_full(dynamic_words, (GDestroyNotify)free);
 
     const char *static_words[] = { "one", "two", "three", "four", NULL };
-    xsetenv("LIBREPORT_DEBUG_USER_CONF_BASE_DIR", CONF_DIR_PATH);
+    libreport_xsetenv("LIBREPORT_DEBUG_USER_CONF_BASE_DIR", CONF_DIR_PATH);
 
     TS_ASSERT_STDERR_EQ_BEGIN
     {
-        dynamic_words = load_words_from_file("test_ignored.conf");
+        dynamic_words = libreport_load_words_from_file("test_ignored.conf");
     }
     TS_ASSERT_STDERR_EQ_END("Can't open " CONF_DIR "/test_ignored.conf: No such file or directory\n", "User notified about errors!");
 

--- a/tests/glib_helpers.at
+++ b/tests/glib_helpers.at
@@ -6,14 +6,14 @@ AT_BANNER([glib helpers])
 ## parse a list ##
 ## ------------ ##
 
-AT_TESTFUN([parse_delimited_list],
+AT_TESTFUN([libreport_parse_delimited_list],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
 
 int test(const char *list, const char *delimiter, const char *strings[])
 {
-    GList *l = parse_delimited_list(list, delimiter);
+    GList *l = libreport_parse_delimited_list(list, delimiter);
 
     char **tmp = (char **)strings;
     int retval = 0;

--- a/tests/global_config.at
+++ b/tests/global_config.at
@@ -33,11 +33,11 @@ int main(int argc, char **argv)
     assert(lrf != NULL);
     fclose(lrf);
 
-    assert(load_global_configuration_from_dirs(dirs, dir_flags));
+    assert(libreport_load_global_configuration_from_dirs(dirs, dir_flags));
 
     {
         unsetenv("EXCLUDE_FROM_REPORT");
-        string_vector_ptr_t excluded = get_global_always_excluded_elements();
+        string_vector_ptr_t excluded = libreport_get_global_always_excluded_elements();
 
         assert(excluded != NULL);
         assert(excluded[0] == NULL);
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
 
     {
         setenv("EXCLUDE_FROM_REPORT", "hostname, environ, uid", 1);
-        string_vector_ptr_t excluded = get_global_always_excluded_elements();
+        string_vector_ptr_t excluded = libreport_get_global_always_excluded_elements();
 
         assert(excluded != NULL);
         assert(strcmp(excluded[0], "hostname") == 0);
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
         string_vector_free(excluded);
     }
 
-    free_global_configuration();
+    libreport_free_global_configuration();
 
     unlink("libreport.conf");
     lrf = fopen("libreport.conf", "wx");
@@ -66,11 +66,11 @@ int main(int argc, char **argv)
     fprintf(lrf, "AlwaysExcludedElements = maps, var_log_messages, proc_pid_status");
     fclose(lrf);
 
-    assert(load_global_configuration_from_dirs(dirs, dir_flags));
+    assert(libreport_load_global_configuration_from_dirs(dirs, dir_flags));
 
     {
         unsetenv("EXCLUDE_FROM_REPORT");
-        string_vector_ptr_t excluded = get_global_always_excluded_elements();
+        string_vector_ptr_t excluded = libreport_get_global_always_excluded_elements();
 
         assert(excluded != NULL);
         assert(strcmp(excluded[0], "maps") == 0);
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
 
     {
         setenv("EXCLUDE_FROM_REPORT", "hostname, environ, uid", 1);
-        string_vector_ptr_t excluded = get_global_always_excluded_elements();
+        string_vector_ptr_t excluded = libreport_get_global_always_excluded_elements();
 
         assert(excluded != NULL);
         assert(strcmp(excluded[0], "hostname") == 0);
@@ -131,42 +131,42 @@ TS_MAIN
     assert(lrf != NULL);
     fclose(lrf);
 
-    assert(load_global_configuration_from_dirs(dirs, dir_flags));
+    assert(libreport_load_global_configuration_from_dirs(dirs, dir_flags));
 
-    TS_ASSERT_FALSE_MESSAGE(get_global_create_private_ticket(), "False by default");
+    TS_ASSERT_FALSE_MESSAGE(libreport_get_global_create_private_ticket(), "False by default");
 
-    set_global_create_private_ticket(false, 0);
+    libreport_set_global_create_private_ticket(false, 0);
 
-    TS_ASSERT_FALSE_MESSAGE(get_global_create_private_ticket(), "Still false");
+    TS_ASSERT_FALSE_MESSAGE(libreport_get_global_create_private_ticket(), "Still false");
 
-    set_global_create_private_ticket(true, 0);
+    libreport_set_global_create_private_ticket(true, 0);
 
-    TS_ASSERT_TRUE_MESSAGE(get_global_create_private_ticket(), "Configuration accepted");
+    TS_ASSERT_TRUE_MESSAGE(libreport_get_global_create_private_ticket(), "Configuration accepted");
     TS_ASSERT_STRING_EQ(getenv(CREATE_PRIVATE_TICKET), "1", "Correct ENVIRONMENT value");
 
-    set_global_create_private_ticket(true, 0);
+    libreport_set_global_create_private_ticket(true, 0);
 
-    TS_ASSERT_TRUE_MESSAGE(get_global_create_private_ticket(), "Configuration sanity");
+    TS_ASSERT_TRUE_MESSAGE(libreport_get_global_create_private_ticket(), "Configuration sanity");
     TS_ASSERT_STRING_EQ(getenv(CREATE_PRIVATE_TICKET), "1", "Correct ENVIRONMENT value");
 
-    set_global_create_private_ticket(false, 0);
+    libreport_set_global_create_private_ticket(false, 0);
 
-    TS_ASSERT_FALSE_MESSAGE(get_global_create_private_ticket(), "Reverted back to False");
+    TS_ASSERT_FALSE_MESSAGE(libreport_get_global_create_private_ticket(), "Reverted back to False");
     TS_ASSERT_STRING_NULL_OR_EMPTY(getenv(CREATE_PRIVATE_TICKET), "Correct ENVIRONMENT value");
 
     xsetenv(CREATE_PRIVATE_TICKET, "1");
 
-    TS_ASSERT_TRUE_MESSAGE(get_global_create_private_ticket(), "Loaded from environment");
+    TS_ASSERT_TRUE_MESSAGE(libreport_get_global_create_private_ticket(), "Loaded from environment");
 
     unsetenv(CREATE_PRIVATE_TICKET);
 
-    TS_ASSERT_FALSE_MESSAGE(get_global_create_private_ticket(), "Reflects environment");
+    TS_ASSERT_FALSE_MESSAGE(libreport_get_global_create_private_ticket(), "Reflects environment");
 
     xsetenv(CREATE_PRIVATE_TICKET, "0");
 
-    TS_ASSERT_FALSE_MESSAGE(get_global_create_private_ticket(), "Zero is false");
+    TS_ASSERT_FALSE_MESSAGE(libreport_get_global_create_private_ticket(), "Zero is false");
 
-    free_global_configuration();
+    libreport_free_global_configuration();
 }
 TS_RETURN_MAIN
 ]])
@@ -198,42 +198,42 @@ TS_MAIN
     assert(lrf != NULL);
     fclose(lrf);
 
-    assert(load_global_configuration_from_dirs(dirs, dir_flags));
+    assert(libreport_load_global_configuration_from_dirs(dirs, dir_flags));
 
-    TS_ASSERT_TRUE_MESSAGE(get_global_stop_on_not_reportable(), "True by default");
+    TS_ASSERT_TRUE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "True by default");
 
-    set_global_stop_on_not_reportable(true, 0);
+    libreport_set_global_stop_on_not_reportable(true, 0);
 
-    TS_ASSERT_TRUE_MESSAGE(get_global_stop_on_not_reportable(), "Still true");
+    TS_ASSERT_TRUE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Still true");
 
-    set_global_stop_on_not_reportable(false, 0);
+    libreport_set_global_stop_on_not_reportable(false, 0);
 
-    TS_ASSERT_FALSE_MESSAGE(get_global_stop_on_not_reportable(), "Configuration accepted");
+    TS_ASSERT_FALSE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Configuration accepted");
     TS_ASSERT_STRING_EQ(getenv(STOP_ON_NOT_REPORTABLE), "0", "Correct ENVIRONMENT value");
 
-    set_global_stop_on_not_reportable(true, 0);
+    libreport_set_global_stop_on_not_reportable(true, 0);
 
-    TS_ASSERT_TRUE_MESSAGE(get_global_stop_on_not_reportable(), "Configuration sanity");
+    TS_ASSERT_TRUE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Configuration sanity");
     TS_ASSERT_STRING_EQ(getenv(STOP_ON_NOT_REPORTABLE), "1", "Correct ENVIRONMENT value");
 
-    set_global_stop_on_not_reportable(false, 0);
+    libreport_set_global_stop_on_not_reportable(false, 0);
 
-    TS_ASSERT_FALSE_MESSAGE(get_global_stop_on_not_reportable(), "Reverted back to False");
+    TS_ASSERT_FALSE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Reverted back to False");
     TS_ASSERT_STRING_EQ(getenv(STOP_ON_NOT_REPORTABLE), "0", "Correct ENVIRONMENT value");
 
     xsetenv(STOP_ON_NOT_REPORTABLE, "1");
 
-    TS_ASSERT_TRUE_MESSAGE(get_global_stop_on_not_reportable(), "Loaded from environment");
+    TS_ASSERT_TRUE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Loaded from environment");
 
     unsetenv(STOP_ON_NOT_REPORTABLE);
 
-    TS_ASSERT_TRUE_MESSAGE(get_global_stop_on_not_reportable(), "Reflects environment");
+    TS_ASSERT_TRUE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Reflects environment");
 
     xsetenv(STOP_ON_NOT_REPORTABLE, "0");
 
-    TS_ASSERT_FALSE_MESSAGE(get_global_stop_on_not_reportable(), "Zero is false");
+    TS_ASSERT_FALSE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Zero is false");
 
-    free_global_configuration();
+    libreport_free_global_configuration();
 }
 TS_RETURN_MAIN
 ]])

--- a/tests/global_config.at
+++ b/tests/global_config.at
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
         assert(excluded != NULL);
         assert(excluded[0] == NULL);
 
-        string_vector_free(excluded);
+        libreport_string_vector_free(excluded);
     }
 
     {
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
         assert(strcmp(excluded[2], "uid") == 0);
         assert(excluded[3] == NULL);
 
-        string_vector_free(excluded);
+        libreport_string_vector_free(excluded);
     }
 
     libreport_free_global_configuration();
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
         assert(strcmp(excluded[2], "proc_pid_status") == 0);
         assert(excluded[3] == NULL);
 
-        string_vector_free(excluded);
+        libreport_string_vector_free(excluded);
     }
 
     {
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
         assert(strcmp(excluded[5], "proc_pid_status") == 0);
         assert(excluded[6] == NULL);
 
-        string_vector_free(excluded);
+        libreport_string_vector_free(excluded);
     }
 
     unlink("libreport.conf");

--- a/tests/global_config.at
+++ b/tests/global_config.at
@@ -14,7 +14,7 @@ AT_TESTFUN([always_excluded_elements],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
     char cwd_buf[PATH_MAX + 1];
 
     static const char *dirs[] = {
@@ -154,7 +154,7 @@ TS_MAIN
     TS_ASSERT_FALSE_MESSAGE(libreport_get_global_create_private_ticket(), "Reverted back to False");
     TS_ASSERT_STRING_NULL_OR_EMPTY(getenv(CREATE_PRIVATE_TICKET), "Correct ENVIRONMENT value");
 
-    xsetenv(CREATE_PRIVATE_TICKET, "1");
+    libreport_xsetenv(CREATE_PRIVATE_TICKET, "1");
 
     TS_ASSERT_TRUE_MESSAGE(libreport_get_global_create_private_ticket(), "Loaded from environment");
 
@@ -162,7 +162,7 @@ TS_MAIN
 
     TS_ASSERT_FALSE_MESSAGE(libreport_get_global_create_private_ticket(), "Reflects environment");
 
-    xsetenv(CREATE_PRIVATE_TICKET, "0");
+    libreport_xsetenv(CREATE_PRIVATE_TICKET, "0");
 
     TS_ASSERT_FALSE_MESSAGE(libreport_get_global_create_private_ticket(), "Zero is false");
 
@@ -221,7 +221,7 @@ TS_MAIN
     TS_ASSERT_FALSE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Reverted back to False");
     TS_ASSERT_STRING_EQ(getenv(STOP_ON_NOT_REPORTABLE), "0", "Correct ENVIRONMENT value");
 
-    xsetenv(STOP_ON_NOT_REPORTABLE, "1");
+    libreport_xsetenv(STOP_ON_NOT_REPORTABLE, "1");
 
     TS_ASSERT_TRUE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Loaded from environment");
 
@@ -229,7 +229,7 @@ TS_MAIN
 
     TS_ASSERT_TRUE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Reflects environment");
 
-    xsetenv(STOP_ON_NOT_REPORTABLE, "0");
+    libreport_xsetenv(STOP_ON_NOT_REPORTABLE, "0");
 
     TS_ASSERT_FALSE_MESSAGE(libreport_get_global_stop_on_not_reportable(), "Zero is false");
 

--- a/tests/helpers/testsuite.h
+++ b/tests/helpers/testsuite.h
@@ -84,7 +84,7 @@
 #ifndef LIBREPORT_TESTSUITE_H
 #define LIBREPORT_TESTSUITE_H
 
-/* For g_verbose */
+/* For libreport_g_verbose */
 #include "internal_libreport.h"
 
 /* For convenience */
@@ -113,7 +113,7 @@ FILE *g_testsuite_output_stream = 0;
  */
 
 #define TS_MAIN \
-    int main(int argc, char *argv[]) { g_verbose = 3; do
+    int main(int argc, char *argv[]) { libreport_g_verbose = 3; do
 
 #define TS_RETURN_MAIN \
     while (0) ;\
@@ -366,15 +366,15 @@ FILE *g_testsuite_output_stream = 0;
 #define TS_ASSERT_STREAM_FD_CONTENTS_EQ_BEGIN(cfd) \
     do { \
         const int ts_bck_fd = cfd; \
-        const int ts_old_fd = xdup(ts_bck_fd); \
+        const int ts_old_fd = libreport_xdup(ts_bck_fd); \
         int ts_pipefd[2]; \
         pipe(ts_pipefd); \
         fcntl(ts_pipefd[0], F_SETFL, O_NONBLOCK); \
-        xmove_fd(ts_pipefd[1], ts_bck_fd); \
+        libreport_xmove_fd(ts_pipefd[1], ts_bck_fd); \
 
 #define TS_ASSERT_STREAM_FD_CONTENTS_EQ_END(expected, message) \
-        xmove_fd(ts_old_fd, ts_bck_fd); \
-        char *ts_fd_contents = xmalloc_read(ts_pipefd[0], NULL); \
+        libreport_xmove_fd(ts_old_fd, ts_bck_fd); \
+        char *ts_fd_contents = libreport_xmalloc_read(ts_pipefd[0], NULL); \
         close(ts_pipefd[0]); \
         TS_ASSERT_STRING_EQ(ts_fd_contents, expected, message); \
         free(ts_fd_contents); \

--- a/tests/helpers/testsuite_tools.h
+++ b/tests/helpers/testsuite_tools.h
@@ -76,7 +76,7 @@ static struct dump_dir *testsuite_dump_dir_create(uid_t uid, mode_t mode, int ts
  */
 static void testsuite_dump_dir_delete(struct dump_dir *dd)
 {
-    char *tmp_dir = xstrndup(dd->dd_dirname, strrchr(dd->dd_dirname, '/') - dd->dd_dirname);
+    char *tmp_dir = libreport_xstrndup(dd->dd_dirname, strrchr(dd->dd_dirname, '/') - dd->dd_dirname);
     assert(dd_delete(dd) == 0);
 
     if(rmdir(tmp_dir) != 0)

--- a/tests/iso_date.at
+++ b/tests/iso_date.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([ISO_date])
 
-## --------------- ##
-## iso_date_string ##
-## --------------- ##
+## ------------------------- ##
+## libreport_iso_date_string ##
+## ------------------------- ##
 
-AT_TESTFUN([iso_date_string],
+AT_TESTFUN([libreport_iso_date_string],
 [[#include "internal_libreport.h"
 #include <assert.h>
 #include <string.h>
@@ -23,7 +23,7 @@ bool string_cmp(const char *orig, const char *other)
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     setenv("TZ", "", 1);
     setenv("LC_ALL", "C", 1);
@@ -31,30 +31,30 @@ int main(void)
     time_t local[3];
 
     time(&local[0]);
-    char *date = xstrdup(iso_date_string(NULL));
+    char *date = libreport_xstrdup(libreport_iso_date_string(NULL));
 
     local[1] = local[0] + 1;
     local[2] = local[0] + 2;
     size_t i = 0;
     for (; ARRAY_SIZE(local); ++i)
     {
-        if (string_cmp(date, iso_date_string(local + i)))
+        if (string_cmp(date, libreport_iso_date_string(local + i)))
             break;
     }
     assert((i != ARRAY_SIZE(local)) || !"None of attempts hit result date");
     free(date);
 
     time_t y2k = 946684800;
-    assert(string_cmp("2000-01-01-00:00:00", iso_date_string(&y2k)));
+    assert(string_cmp("2000-01-01-00:00:00", libreport_iso_date_string(&y2k)));
 
     return 0;
 }
 
 ]])
 
-## --------------------- ##
-## iso_date_string_parse ##
-## --------------------- ##
+## ------------------------------- ##
+## libreport_iso_date_string_parse ##
+## ------------------------------- ##
 
 AT_TESTFUN([parse_numbers],
 [[#include "internal_libreport.h"
@@ -64,41 +64,41 @@ AT_TESTFUN([parse_numbers],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     setenv("TZ", "", 1);
     setenv("LC_ALL", "C", 1);
 
     {
         time_t result = 0;
-        assert(iso_date_string_parse("", &result) == -EINVAL);
+        assert(libreport_iso_date_string_parse("", &result) == -EINVAL);
     }
 
     {
         time_t result = 0;
-        assert(iso_date_string_parse("foo", &result) == -EINVAL);
+        assert(libreport_iso_date_string_parse("foo", &result) == -EINVAL);
     }
 
     {
         time_t result = 0;
-        assert(iso_date_string_parse("1969-12-31-23:59:59", &result) == -EINVAL);
+        assert(libreport_iso_date_string_parse("1969-12-31-23:59:59", &result) == -EINVAL);
     }
 
     {
         time_t result = 0;
-        assert(iso_date_string_parse("1970-01-01-00:00:00", &result) == 0);
+        assert(libreport_iso_date_string_parse("1970-01-01-00:00:00", &result) == 0);
         assert(result == 0);
     }
 
     {
         time_t result = 0;
-        assert(iso_date_string_parse("2000-01-01-00:00:00", &result) == 0);
+        assert(libreport_iso_date_string_parse("2000-01-01-00:00:00", &result) == 0);
         assert(result == 946684800 || !"Y2k");
     }
 
     {
         time_t result = 0;
-        assert(iso_date_string_parse("2000-01-01-00:00:00fooo", &result) == -EINVAL);
+        assert(libreport_iso_date_string_parse("2000-01-01-00:00:00fooo", &result) == -EINVAL);
     }
 
     return 0;

--- a/tests/libreport_types.at
+++ b/tests/libreport_types.at
@@ -16,24 +16,24 @@ int main(int argc, char **argv)
     libreport_g_verbose = 3;
 
     const char *const raw_value = "foo, blah, bang";
-    string_vector_ptr_t vector = string_vector_new_from_string(raw_value);
+    string_vector_ptr_t vector = libreport_string_vector_new_from_string(raw_value);
 
     assert(strcmp("foo", vector[0]) == 0 || !"The first item");
     assert(strcmp("blah", vector[1]) == 0 || !"The second item");
     assert(strcmp("bang", vector[2]) == 0 || !"The third item");
     assert(NULL == vector[3] || !"NULL-terminated");
 
-    string_vector_free(vector);
+    libreport_string_vector_free(vector);
 
-    vector = string_vector_new_from_string(NULL);
+    vector = libreport_string_vector_new_from_string(NULL);
     assert(NULL == vector[0] || !"NULL-terminated");
 
-    string_vector_free(vector);
+    libreport_string_vector_free(vector);
 
-    vector = string_vector_new_from_string("");
+    vector = libreport_string_vector_new_from_string("");
     assert(NULL == vector[0] || !"NULL-terminated");
 
-    string_vector_free(vector);
+    libreport_string_vector_free(vector);
 }
 ]])
 
@@ -52,174 +52,174 @@ int main(int argc, char **argv)
 
     {
         const char *const key = "my_bool";
-        map_string_t *map = new_map_string();
+        map_string_t *map = libreport_new_map_string();
 
         int retval = 0;
 
-        assert(!try_get_map_string_item_as_bool(map, key, &retval) || !"Returns bool(0) even if option does not exist");
+        assert(!libreport_try_get_map_string_item_as_bool(map, key, &retval) || !"Returns bool(0) even if option does not exist");
         assert(retval == 0 || !"Modifies bool(0) return value on failure");
 
         retval = 1;
 
-        assert(!try_get_map_string_item_as_bool(map, key, &retval) || !"Returns bool(1) even if option does not exist");
+        assert(!libreport_try_get_map_string_item_as_bool(map, key, &retval) || !"Returns bool(1) even if option does not exist");
         assert(retval == 1 || !"Modifies bool(1) return value on failure");
 
-        set_map_string_item_from_bool(map, key, 1);
-        assert(get_map_string_item_or_NULL(map, key) || !"Set bool(1)");
-        assert(strcmp("yes", get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for bool(1)");
-        assert(try_get_map_string_item_as_bool(map, key, &retval) || !"Failed to return bool(1)");
+        libreport_set_map_string_item_from_bool(map, key, 1);
+        assert(libreport_get_map_string_item_or_NULL(map, key) || !"Set bool(1)");
+        assert(strcmp("yes", libreport_get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for bool(1)");
+        assert(libreport_try_get_map_string_item_as_bool(map, key, &retval) || !"Failed to return bool(1)");
         assert(retval || !"Failed to convert 'yes' to bool(1)");
 
-        set_map_string_item_from_bool(map, key, 0);
-        assert(get_map_string_item_or_NULL(map, key) || !"Set bool(0)");
-        assert(strcmp("no", get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for bool(0)");
+        libreport_set_map_string_item_from_bool(map, key, 0);
+        assert(libreport_get_map_string_item_or_NULL(map, key) || !"Set bool(0)");
+        assert(strcmp("no", libreport_get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for bool(0)");
         retval = 1;
-        assert(try_get_map_string_item_as_bool(map, key, &retval) || !"Failed to return bool(0)");
+        assert(libreport_try_get_map_string_item_as_bool(map, key, &retval) || !"Failed to return bool(0)");
         assert(!retval || !"Failed to convert 'no' to bool(0)");
 
-        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("foo"));
+        libreport_replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("foo"));
         retval = 1;
-        assert(try_get_map_string_item_as_bool(map, key, &retval) || !"Can not convert a random string to bool(0)");
+        assert(libreport_try_get_map_string_item_as_bool(map, key, &retval) || !"Can not convert a random string to bool(0)");
         assert(!retval || !"Failed to convert a random string to bool(0)");
 
-        free_map_string(map);
+        libreport_free_map_string(map);
     }
 
     {
         const char *const key = "my_int";
-        map_string_t *map = new_map_string();
+        map_string_t *map = libreport_new_map_string();
 
         int retval = INT_MIN;
 
-        assert(!try_get_map_string_item_as_int(map, key, &retval) || !"Returns INT_MIN even if option does not exist");
+        assert(!libreport_try_get_map_string_item_as_int(map, key, &retval) || !"Returns INT_MIN even if option does not exist");
         assert(retval == INT_MIN || !"Modifies INT_MIN value on failure");
 
         retval = INT_MAX;
 
-        assert(!try_get_map_string_item_as_int(map, key, &retval) || !"Returns INT_MAX even if option does not exist");
+        assert(!libreport_try_get_map_string_item_as_int(map, key, &retval) || !"Returns INT_MAX even if option does not exist");
         assert(retval == INT_MAX || !"Modifies INT_MAX value on failure");
 
-        set_map_string_item_from_int(map, key, 12345);
-        assert(get_map_string_item_or_NULL(map, key) || !"Set int(12345)");
-        assert(strcmp("12345", get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for int(12345)");
-        assert(try_get_map_string_item_as_int(map, key, &retval) || !"Failed to return int(12345)");
+        libreport_set_map_string_item_from_int(map, key, 12345);
+        assert(libreport_get_map_string_item_or_NULL(map, key) || !"Set int(12345)");
+        assert(strcmp("12345", libreport_get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for int(12345)");
+        assert(libreport_try_get_map_string_item_as_int(map, key, &retval) || !"Failed to return int(12345)");
         assert(12345 == retval || !"Failed to convert '12345' to int(12345)");
 
-        set_map_string_item_from_int(map, key, -12345);
-        assert(get_map_string_item_or_NULL(map, key) || !"Set int(-12345)");
-        assert(strcmp("-12345", get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for int(-12345)");
-        assert(try_get_map_string_item_as_int(map, key, &retval) || !"Failed to return int(-12345)");
+        libreport_set_map_string_item_from_int(map, key, -12345);
+        assert(libreport_get_map_string_item_or_NULL(map, key) || !"Set int(-12345)");
+        assert(strcmp("-12345", libreport_get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for int(-12345)");
+        assert(libreport_try_get_map_string_item_as_int(map, key, &retval) || !"Failed to return int(-12345)");
         assert(-12345 == retval || !"Failed to convert '-12345' to int(-12345)");
 
-        set_map_string_item_from_int(map, key, INT_MAX);
-        assert(try_get_map_string_item_as_int(map, key, &retval) || !"Cannot return INT_MAX");
+        libreport_set_map_string_item_from_int(map, key, INT_MAX);
+        assert(libreport_try_get_map_string_item_as_int(map, key, &retval) || !"Cannot return INT_MAX");
         assert(retval == INT_MAX || !"Garbled INT_MAX");
 
-        set_map_string_item_from_int(map, key, INT_MIN);
-        assert(try_get_map_string_item_as_int(map, key, &retval) || !"Cannot return INT_MIN");
+        libreport_set_map_string_item_from_int(map, key, INT_MIN);
+        assert(libreport_try_get_map_string_item_as_int(map, key, &retval) || !"Cannot return INT_MIN");
         assert(retval == INT_MIN || !"Garbled INT_MIN");
 
         retval = 69;
-        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup(""));
-        assert(!try_get_map_string_item_as_int(map, key, &retval) || !"Converts '' to number");
+        libreport_replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup(""));
+        assert(!libreport_try_get_map_string_item_as_int(map, key, &retval) || !"Converts '' to number");
         assert(retval == 69 || !"Modifies int(69) on ''");
 
-        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("foo"));
-        assert(!try_get_map_string_item_as_int(map, key, &retval) || !"Converts 'foo' to number");
+        libreport_replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("foo"));
+        assert(!libreport_try_get_map_string_item_as_int(map, key, &retval) || !"Converts 'foo' to number");
         assert(retval == 69 || !"Modifies int(69) on 'foo'");
 
-        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("777foo"));
-        assert(!try_get_map_string_item_as_int(map, key, &retval) || !"Converts '777foo' to number");
+        libreport_replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("777foo"));
+        assert(!libreport_try_get_map_string_item_as_int(map, key, &retval) || !"Converts '777foo' to number");
         assert(retval == 69 || !"Modifies int(69) on '777foo'");
 
                                                  /*0123456789ABCDEF*/
-        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("77777777777777777777777777777777"));
-        assert(!try_get_map_string_item_as_int(map, key, &retval) || !"Converts '77777777777777777777777777777777' to number");
+        libreport_replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("77777777777777777777777777777777"));
+        assert(!libreport_try_get_map_string_item_as_int(map, key, &retval) || !"Converts '77777777777777777777777777777777' to number");
         assert(retval == 69 || !"Modifies int(69) on '77777777777777777777777777777777'");
 
-        free_map_string(map);
+        libreport_free_map_string(map);
     }
 
     {
         const char *const key = "my_uint";
-        map_string_t *map = new_map_string();
+        map_string_t *map = libreport_new_map_string();
 
         unsigned int retval = 0;
 
-        assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Returns 0 even if option does not exist");
+        assert(!libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Returns 0 even if option does not exist");
         assert(retval == 0 || !"Modifies 0 value on failure");
 
         retval = UINT_MAX;
 
-        assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Returns UINT_MAX even if option does not exist");
+        assert(!libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Returns UINT_MAX even if option does not exist");
         assert(retval == UINT_MAX || !"Modifies UINT_MAX value on failure");
 
-        set_map_string_item_from_uint(map, key, 12345);
-        assert(get_map_string_item_or_NULL(map, key) || !"Set uint(12345)");
-        assert(strcmp("12345", get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for uint(12345)");
-        assert(try_get_map_string_item_as_uint(map, key, &retval) || !"Failed to return uint(12345)");
+        libreport_set_map_string_item_from_uint(map, key, 12345);
+        assert(libreport_get_map_string_item_or_NULL(map, key) || !"Set uint(12345)");
+        assert(strcmp("12345", libreport_get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for uint(12345)");
+        assert(libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Failed to return uint(12345)");
         assert(12345 == retval || !"Failed to convert '12345' to uint(12345)");
 
-        set_map_string_item_from_uint(map, key, INT_MAX + 1);
-        assert(get_map_string_item_or_NULL(map, key) || !"Set INT_MAX + 1");
-        assert(try_get_map_string_item_as_uint(map, key, &retval) || !"Failed to return int(INT_MAX + 1)");
+        libreport_set_map_string_item_from_uint(map, key, INT_MAX + 1);
+        assert(libreport_get_map_string_item_or_NULL(map, key) || !"Set INT_MAX + 1");
+        assert(libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Failed to return int(INT_MAX + 1)");
         assert(INT_MAX + 1 == retval || !"Failed to convert 'INT_MAX + 1' to int(INT_MAX + 1)");
 
-        set_map_string_item_from_uint(map, key, UINT_MAX);
-        assert(try_get_map_string_item_as_uint(map, key, &retval) || !"Cannot return UINT_MAX");
+        libreport_set_map_string_item_from_uint(map, key, UINT_MAX);
+        assert(libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Cannot return UINT_MAX");
         assert(retval == UINT_MAX || !"Garbled UINT_MAX");
 
-        set_map_string_item_from_uint(map, key, 0);
-        assert(try_get_map_string_item_as_uint(map, key, &retval) || !"Cannot return 0");
+        libreport_set_map_string_item_from_uint(map, key, 0);
+        assert(libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Cannot return 0");
         assert(retval == 0 || !"Garbled 0");
 
         retval = 69;
-        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup(""));
-        assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '' to number");
+        libreport_replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup(""));
+        assert(!libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '' to number");
         assert(retval == 69 || !"Modifies int(69) on ''");
 
-        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("foo"));
-        assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Converts 'foo' to number");
+        libreport_replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("foo"));
+        assert(!libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Converts 'foo' to number");
         assert(retval == 69 || !"Modifies int(69) on 'foo'");
 
-        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("777foo"));
-        assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '777foo' to number");
+        libreport_replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("777foo"));
+        assert(!libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '777foo' to number");
         assert(retval == 69 || !"Modifies int(69) on '777foo'");
 
-        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("77777777777777777777777777777777"));
-        assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '77777777777777777777777777777777' to number");
+        libreport_replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("77777777777777777777777777777777"));
+        assert(!libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '77777777777777777777777777777777' to number");
         assert(retval == 69 || !"Modifies int(69) on '77777777777777777777777777777777'");
 
-        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("-1"));
-        assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '-1' to unsigned number");
+        libreport_replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("-1"));
+        assert(!libreport_try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '-1' to unsigned number");
         assert(retval == 69 || !"Modifies int(69) on '-1'");
 
-        free_map_string(map);
+        libreport_free_map_string(map);
     }
 
     {
         const char *const key = "my_string";
-        map_string_t *map = new_map_string();
+        map_string_t *map = libreport_new_map_string();
 
         char *retval = NULL;
 
-        assert(!try_get_map_string_item_as_string(map, key, &retval) || !"Returns string(NULL) even if option does not exist");
+        assert(!libreport_try_get_map_string_item_as_string(map, key, &retval) || !"Returns string(NULL) even if option does not exist");
         assert(retval == NULL || !"Modifies string(NULL) return value on failure");
 
         char *bck = libreport_xstrdup("test");
         retval = bck;
 
-        assert(!try_get_map_string_item_as_string(map, key, &retval) || !"Returns string('test') even if option does not exist");
+        assert(!libreport_try_get_map_string_item_as_string(map, key, &retval) || !"Returns string('test') even if option does not exist");
         assert(retval == bck || !"Modifies string('test') return value on failure");
 
         retval = libreport_xstrdup(bck);
-        set_map_string_item_from_string(map, key, bck);
+        libreport_set_map_string_item_from_string(map, key, bck);
 
         free(bck);
         bck = retval;
         retval = NULL;
 
-        assert(try_get_map_string_item_as_string(map, key, &retval) || !"Cannot return string('test')");
+        assert(libreport_try_get_map_string_item_as_string(map, key, &retval) || !"Cannot return string('test')");
         assert(NULL != retval || !"The return value is not assigned to the return variable");
         assert(strcmp(bck, retval) == 0 || !"Garbled string('test') after freeing the original pointer");
 
@@ -228,40 +228,40 @@ int main(int argc, char **argv)
 
         bck = libreport_xstrdup(key);
 
-        set_map_string_item_from_string(map, bck, "test");
+        libreport_set_map_string_item_from_string(map, bck, "test");
         free(bck);
 
-        assert(try_get_map_string_item_as_string(map, key, &retval) || !"Cannot find key string('my_string') after freeing original key");
+        assert(libreport_try_get_map_string_item_as_string(map, key, &retval) || !"Cannot find key string('my_string') after freeing original key");
         assert(NULL != retval || !"The return value is not assigned to the return variable");
         assert(strcmp(bck, retval) == 0 || !"Garbled string('test') after freeing the original key value");
 
         /* TODO: try to store really big string */
 
-        free_map_string(map);
+        libreport_free_map_string(map);
     }
 
     {
         const char *const key = "my_string_vector";
-        map_string_t *map = new_map_string();
+        map_string_t *map = libreport_new_map_string();
 
         string_vector_ptr_t retval = NULL;
 
-        assert(!try_get_map_string_item_as_string_vector(map, key, &retval) || !"Returns string_vector(NULL) even if option does not exist");
+        assert(!libreport_try_get_map_string_item_as_string_vector(map, key, &retval) || !"Returns string_vector(NULL) even if option does not exist");
         assert(retval == NULL || !"Modifies string_vector(NULL) return value on failure");
 
         const char *const raw_value = "foo, blah, bang";
-        string_vector_ptr_t vector = string_vector_new_from_string(raw_value);
+        string_vector_ptr_t vector = libreport_string_vector_new_from_string(raw_value);
 
-        set_map_string_item_from_string_vector(map, key, vector);
+        libreport_set_map_string_item_from_string_vector(map, key, vector);
 
-        assert(get_map_string_item_or_NULL(map, key) || !"Set string_vector('foo, blah, bang')");
-        assert(strcmp(raw_value, get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for string_vector('foo, blah, bang')");
-        assert(try_get_map_string_item_as_string_vector(map, key, &retval) || !"Failed to return string_vector('foo, blah, bang')");
+        assert(libreport_get_map_string_item_or_NULL(map, key) || !"Set string_vector('foo, blah, bang')");
+        assert(strcmp(raw_value, libreport_get_map_string_item_or_NULL(map, key)) == 0 || !"Invalid string repr for string_vector('foo, blah, bang')");
+        assert(libreport_try_get_map_string_item_as_string_vector(map, key, &retval) || !"Failed to return string_vector('foo, blah, bang')");
         assert(retval || !"Failed to convert 'foo, blah, bang' to string_vector('foo, blah, bang')");
 
-        string_vector_free(vector);
+        libreport_string_vector_free(vector);
 
-        free_map_string(map);
+        libreport_free_map_string(map);
     }
 }
 ]])

--- a/tests/libreport_types.at
+++ b/tests/libreport_types.at
@@ -13,7 +13,7 @@ AT_TESTFUN([string_vector],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     const char *const raw_value = "foo, blah, bang";
     string_vector_ptr_t vector = string_vector_new_from_string(raw_value);
@@ -48,7 +48,7 @@ AT_TESTFUN([map_string_get_set_as_various_types],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     {
         const char *const key = "my_bool";
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
         assert(try_get_map_string_item_as_bool(map, key, &retval) || !"Failed to return bool(0)");
         assert(!retval || !"Failed to convert 'no' to bool(0)");
 
-        replace_map_string_item(map, xstrdup(key), xstrdup("foo"));
+        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("foo"));
         retval = 1;
         assert(try_get_map_string_item_as_bool(map, key, &retval) || !"Can not convert a random string to bool(0)");
         assert(!retval || !"Failed to convert a random string to bool(0)");
@@ -120,20 +120,20 @@ int main(int argc, char **argv)
         assert(retval == INT_MIN || !"Garbled INT_MIN");
 
         retval = 69;
-        replace_map_string_item(map, xstrdup(key), xstrdup(""));
+        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup(""));
         assert(!try_get_map_string_item_as_int(map, key, &retval) || !"Converts '' to number");
         assert(retval == 69 || !"Modifies int(69) on ''");
 
-        replace_map_string_item(map, xstrdup(key), xstrdup("foo"));
+        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("foo"));
         assert(!try_get_map_string_item_as_int(map, key, &retval) || !"Converts 'foo' to number");
         assert(retval == 69 || !"Modifies int(69) on 'foo'");
 
-        replace_map_string_item(map, xstrdup(key), xstrdup("777foo"));
+        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("777foo"));
         assert(!try_get_map_string_item_as_int(map, key, &retval) || !"Converts '777foo' to number");
         assert(retval == 69 || !"Modifies int(69) on '777foo'");
 
                                                  /*0123456789ABCDEF*/
-        replace_map_string_item(map, xstrdup(key), xstrdup("77777777777777777777777777777777"));
+        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("77777777777777777777777777777777"));
         assert(!try_get_map_string_item_as_int(map, key, &retval) || !"Converts '77777777777777777777777777777777' to number");
         assert(retval == 69 || !"Modifies int(69) on '77777777777777777777777777777777'");
 
@@ -174,23 +174,23 @@ int main(int argc, char **argv)
         assert(retval == 0 || !"Garbled 0");
 
         retval = 69;
-        replace_map_string_item(map, xstrdup(key), xstrdup(""));
+        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup(""));
         assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '' to number");
         assert(retval == 69 || !"Modifies int(69) on ''");
 
-        replace_map_string_item(map, xstrdup(key), xstrdup("foo"));
+        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("foo"));
         assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Converts 'foo' to number");
         assert(retval == 69 || !"Modifies int(69) on 'foo'");
 
-        replace_map_string_item(map, xstrdup(key), xstrdup("777foo"));
+        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("777foo"));
         assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '777foo' to number");
         assert(retval == 69 || !"Modifies int(69) on '777foo'");
 
-        replace_map_string_item(map, xstrdup(key), xstrdup("77777777777777777777777777777777"));
+        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("77777777777777777777777777777777"));
         assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '77777777777777777777777777777777' to number");
         assert(retval == 69 || !"Modifies int(69) on '77777777777777777777777777777777'");
 
-        replace_map_string_item(map, xstrdup(key), xstrdup("-1"));
+        replace_map_string_item(map, libreport_xstrdup(key), libreport_xstrdup("-1"));
         assert(!try_get_map_string_item_as_uint(map, key, &retval) || !"Converts '-1' to unsigned number");
         assert(retval == 69 || !"Modifies int(69) on '-1'");
 
@@ -206,13 +206,13 @@ int main(int argc, char **argv)
         assert(!try_get_map_string_item_as_string(map, key, &retval) || !"Returns string(NULL) even if option does not exist");
         assert(retval == NULL || !"Modifies string(NULL) return value on failure");
 
-        char *bck = xstrdup("test");
+        char *bck = libreport_xstrdup("test");
         retval = bck;
 
         assert(!try_get_map_string_item_as_string(map, key, &retval) || !"Returns string('test') even if option does not exist");
         assert(retval == bck || !"Modifies string('test') return value on failure");
 
-        retval = xstrdup(bck);
+        retval = libreport_xstrdup(bck);
         set_map_string_item_from_string(map, key, bck);
 
         free(bck);
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
         free(bck);
         free(retval);
 
-        bck = xstrdup(key);
+        bck = libreport_xstrdup(key);
 
         set_map_string_item_from_string(map, bck, "test");
         free(bck);

--- a/tests/make_description.at
+++ b/tests/make_description.at
@@ -1,6 +1,6 @@
 # -*- Autotest -*-
 
-AT_BANNER([make_description])
+AT_BANNER([libreport_make_description])
 
 ## -------------- ##
 ## flag_show_urls ##
@@ -13,11 +13,11 @@ AT_TESTFUN([flag_show_urls],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     problem_data_t *pd = problem_data_new();
 
-    char *description = make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_URLS);
+    char *description = libreport_make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_URLS);
 
     assert(description != NULL || !"Returns NULL for empty problem data");
     assert(description[0] == '\0' || !"Returns non-empty description for empty problem data");
@@ -26,8 +26,8 @@ int main(int argc, char **argv)
 
     problem_data_add_text_noteditable(pd, FILENAME_REPORTED_TO, "Bugzilla: URL=https://bugzilla.redhat.com/1000000\n");
 
-    description = make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_URLS);
-    char *expected = xasprintf("%s: %*s%s\n",
+    description = libreport_make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_URLS);
+    char *expected = libreport_xasprintf("%s: %*s%s\n",
             "Reported", 14 - strlen("Reported"), "", "https://bugzilla.redhat.com/1000000");
 
     if (strcmp(expected, description) != 0)
@@ -49,8 +49,8 @@ int main(int argc, char **argv)
             "RHTSupport: TIME=12345678 URL=https://access.redhat.com/home MSG=The world's best IT support\n"
             "ABRT Server: URL=https://bug-report.itos.redhat.com\n");
 
-    description = make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_URLS);
-    expected = xasprintf(
+    description = libreport_make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_URLS);
+    expected = libreport_xasprintf(
            /*0123456789ABCDEF*/
             "Reported:       https://bugzilla.redhat.com/1000000\n"
             "                https://access.redhat.com/home\n"
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
 
     problem_data_add_text_noteditable(pd, FILENAME_REPORTED_TO, "ABRT Server: BTHASH=81680083BIGBOOBS\n");
 
-    description = make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_URLS);
+    description = libreport_make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_URLS);
 
     assert(description != NULL || !"Returns NULL for non empty problem data");
     assert(description[0] == '\0' || !"Returns non-empty description for problem data without any URL");
@@ -93,9 +93,9 @@ int main(int argc, char **argv)
             "RHTSupport: TIME=12345678 URL=https://access.redhat.com/home MSG=The world's best IT support\n"
             "ABRT Server: URL=https://bug-report.itos.redhat.com\n");
 
-    description = make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_ONLY_LIST | MAKEDESC_SHOW_URLS);
+    description = libreport_make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE, MAKEDESC_SHOW_ONLY_LIST | MAKEDESC_SHOW_URLS);
 
-    expected = xasprintf(
+    expected = libreport_xasprintf(
             "%s: %*s%s\n"
             "%s: %*s%s\n"
             "%s: %*s%s\n"
@@ -119,9 +119,9 @@ int main(int argc, char **argv)
     const char *const backtrace = "Extremely long backtrace which does not make sense";
     problem_data_add(pd, FILENAME_BACKTRACE, backtrace,  CD_FLAG_TXT | CD_FLAG_ISNOTEDITABLE);
 
-    description = make_description(pd, /*skipped names*/NULL, strlen(backtrace) - 1, MAKEDESC_SHOW_FILES | MAKEDESC_SHOW_URLS);
+    description = libreport_make_description(pd, /*skipped names*/NULL, strlen(backtrace) - 1, MAKEDESC_SHOW_FILES | MAKEDESC_SHOW_URLS);
 
-    expected = xasprintf(
+    expected = libreport_xasprintf(
             "%s: %*s%s\n"
             "%s: %*s%s\n"
             "%s: %*s%s\n"
@@ -159,9 +159,9 @@ int main(int argc, char **argv)
     problem_data_add(pd, FILENAME_COUNT, "0", list_flags);
     problem_data_add(pd, FILENAME_BACKTRACE, backtrace,  CD_FLAG_TXT | CD_FLAG_ISNOTEDITABLE);
 
-    description = make_description(pd, /*skipped names*/NULL, strlen(backtrace) - 1, MAKEDESC_SHOW_FILES);
+    description = libreport_make_description(pd, /*skipped names*/NULL, strlen(backtrace) - 1, MAKEDESC_SHOW_FILES);
 
-    expected = xasprintf(
+    expected = libreport_xasprintf(
             "%s: %*s%s\n"
             "%s: %*s%s\n"
             "%s: %*s%s\n"
@@ -200,16 +200,16 @@ AT_TESTFUN([not_reportable],
 #include <assert.h>
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     problem_data_t *pd = problem_data_new();
 
     problem_data_add_text_noteditable(pd, FILENAME_NOT_REPORTABLE, "not-reportable");
 
-    char *description = make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE,
+    char *description = libreport_make_description(pd, /*skipped names*/NULL, CD_MAX_TEXT_SIZE,
                                          MAKEDESC_SHOW_URLS);
 
-    char *expected = xasprintf("%s: %*s%s\n",
+    char *expected = libreport_xasprintf("%s: %*s%s\n",
             "Reported", 14 - strlen("Reported"), "", "cannot be reported");
 
     if (strstr(description, expected) == NULL)

--- a/tests/osinfo.at
+++ b/tests/osinfo.at
@@ -2,29 +2,29 @@
 
 AT_BANNER([osinfo])
 
-## ------------ ##
-## parse_osinfo ##
-## ------------ ##
+## ---------------------- ##
+## libreport_parse_osinfo ##
+## ---------------------- ##
 
-AT_TESTFUN([parse_osinfo],
+AT_TESTFUN([libreport_parse_osinfo],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
     map_string_t *osinfo = new_map_string();
     {
         /* Test for empty input */
-        parse_osinfo("", osinfo);
+        libreport_parse_osinfo("", osinfo);
         free_map_string(osinfo);
         osinfo = NULL;
     }
     osinfo = new_map_string();
     {
         /* Test for standard valid os-release*/
-        parse_osinfo(
+        libreport_parse_osinfo(
 "# Very useful comment\n"
 "NAME=Fedora\n"
 "VERSION=\"19 (Schrödinger\\'s Cat)\"\n"
@@ -46,7 +46,7 @@ int main(void)
     osinfo = new_map_string();
     {
         /* Test for standard valid os-release*/
-        parse_osinfo(
+        libreport_parse_osinfo(
 "NAME=Fedora\n"
 "VERSION=\"20 (Rawhide)\"\n"
 "ID=fedora\n"
@@ -75,7 +75,7 @@ int main(void)
     osinfo = new_map_string();
     {
         /* Test for standard os-release with few errors */
-        parse_osinfo(
+        libreport_parse_osinfo(
 "# Very useful comment\n"
 "# FOO=blah\n"
 "NAME=Fedora\n"
@@ -103,11 +103,11 @@ int main(void)
 ]])
 
 
-## ------------------- ##
-## parse_osinfo_for_bz ##
-## ------------------- ##
+## ----------------------------- ##
+## libreport_parse_osinfo_for_bz ##
+## ----------------------------- ##
 
-AT_TESTFUN([parse_osinfo_for_bz],
+AT_TESTFUN([libreport_parse_osinfo_for_bz],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
@@ -115,11 +115,11 @@ AT_TESTFUN([parse_osinfo_for_bz],
 void test(const char *osinfo_bytes, const char *product, const char *version)
 {
     map_string_t *osinfo = new_map_string();
-    parse_osinfo(osinfo_bytes, osinfo);
+    libreport_parse_osinfo(osinfo_bytes, osinfo);
 
     char *built_product = (char *)0xDEADBEAF;
     char *built_version = (char *)0xDEADBEAF;
-    parse_osinfo_for_bz(osinfo, &built_product, &built_version);
+    libreport_parse_osinfo_for_bz(osinfo, &built_product, &built_version);
 
     if (product != NULL && built_product != NULL)
     {
@@ -149,7 +149,7 @@ void test(const char *osinfo_bytes, const char *product, const char *version)
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     test("NAME=Fedora\n"
          "VERSION=\"19 (Schrödinger\\'s Cat)\"\n"
@@ -225,10 +225,10 @@ AT_TESTFUN([parse_osinfo_for_bugurl], [[
 void test(const char *osinfo_bytes, const char *url)
 {
     map_string_t *osinfo = new_map_string();
-    parse_osinfo(osinfo_bytes, osinfo);
+    libreport_parse_osinfo(osinfo_bytes, osinfo);
 
     char *default_BugzillaURL = (char *)0xDEADBEEF;
-    parse_osinfo_for_bug_url(osinfo, &default_BugzillaURL);
+    libreport_parse_osinfo_for_bug_url(osinfo, &default_BugzillaURL);
 
     TS_ASSERT_STRING_EQ(default_BugzillaURL, url, "Tested URL");
 
@@ -238,7 +238,7 @@ void test(const char *osinfo_bytes, const char *url)
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     test("NAME=Fedora\n"
          "VERSION=\"19 (Schrödinger\\'s Cat)\"\n"
@@ -280,11 +280,11 @@ int main(void)
 ]])
 
 
-## --------------------- ##
-## parse_osinfo_for_rhts ##
-## --------------------- ##
+## ------------------------------- ##
+## libreport_parse_osinfo_for_rhts ##
+## ------------------------------- ##
 
-AT_TESTFUN([parse_osinfo_for_rhts],
+AT_TESTFUN([libreport_parse_osinfo_for_rhts],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
@@ -292,11 +292,11 @@ AT_TESTFUN([parse_osinfo_for_rhts],
 void test(const char *osinfo_bytes, const char *product, const char *version)
 {
     map_string_t *osinfo = new_map_string();
-    parse_osinfo(osinfo_bytes, osinfo);
+    libreport_parse_osinfo(osinfo_bytes, osinfo);
 
     char *built_product = (char *)0xDEADBEAF;
     char *built_version = (char *)0xDEADBEAF;
-    parse_osinfo_for_rhts(osinfo, &built_product, &built_version);
+    libreport_parse_osinfo_for_rhts(osinfo, &built_product, &built_version);
 
     if (product != NULL && built_product != NULL)
     {
@@ -326,7 +326,7 @@ void test(const char *osinfo_bytes, const char *product, const char *version)
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     test("NAME=Fedora\n"
          "VERSION=\"19 (Schrödinger\\'s Cat)\"\n"
@@ -401,7 +401,7 @@ AT_TESTFUN([problem_data_get_osinfo],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     problem_data_t *pd = problem_data_new();
     map_string_t *osinfo = new_map_string();

--- a/tests/osinfo.at
+++ b/tests/osinfo.at
@@ -14,14 +14,14 @@ AT_TESTFUN([libreport_parse_osinfo],
 int main(void)
 {
     libreport_g_verbose=3;
-    map_string_t *osinfo = new_map_string();
+    map_string_t *osinfo = libreport_new_map_string();
     {
         /* Test for empty input */
         libreport_parse_osinfo("", osinfo);
-        free_map_string(osinfo);
+        libreport_free_map_string(osinfo);
         osinfo = NULL;
     }
-    osinfo = new_map_string();
+    osinfo = libreport_new_map_string();
     {
         /* Test for standard valid os-release*/
         libreport_parse_osinfo(
@@ -33,17 +33,17 @@ int main(void)
 "PRETTY_NAME=\"Fedora 19 (Schrödinger\\'s Cat)\"\n"
 "ANSI_COLOR=\"0;34\"\n"
 "CPE_NAME=\"cpe:/o:fedoraproject:fedora:18\"\n", osinfo);
-        assert(0 == strcmp("Fedora", get_map_string_item_or_NULL(osinfo, OSINFO_NAME)));
-        assert(0 == strcmp("19 (Schrödinger's Cat)", get_map_string_item_or_NULL(osinfo, "VERSION")));
-        assert(0 == strcmp("fedora", get_map_string_item_or_NULL(osinfo, OSINFO_ID)));
-        assert(0 == strcmp("19", get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID)));
-        assert(0 == strcmp("Fedora 19 (Schrödinger\'s Cat)", get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME)));
-        assert(0 == strcmp("0;34", get_map_string_item_or_NULL(osinfo, "ANSI_COLOR")));
-        assert(0 == strcmp("cpe:/o:fedoraproject:fedora:18", get_map_string_item_or_NULL(osinfo, "CPE_NAME")));
-        free_map_string(osinfo);
+        assert(0 == strcmp("Fedora", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_NAME)));
+        assert(0 == strcmp("19 (Schrödinger's Cat)", libreport_get_map_string_item_or_NULL(osinfo, "VERSION")));
+        assert(0 == strcmp("fedora", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_ID)));
+        assert(0 == strcmp("19", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID)));
+        assert(0 == strcmp("Fedora 19 (Schrödinger\'s Cat)", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME)));
+        assert(0 == strcmp("0;34", libreport_get_map_string_item_or_NULL(osinfo, "ANSI_COLOR")));
+        assert(0 == strcmp("cpe:/o:fedoraproject:fedora:18", libreport_get_map_string_item_or_NULL(osinfo, "CPE_NAME")));
+        libreport_free_map_string(osinfo);
         osinfo = NULL;
     }
-    osinfo = new_map_string();
+    osinfo = libreport_new_map_string();
     {
         /* Test for standard valid os-release*/
         libreport_parse_osinfo(
@@ -58,21 +58,21 @@ int main(void)
 "REDHAT_BUGZILLA_PRODUCT_VERSION=Rawhide\n"
 "REDHAT_SUPPORT_PRODUCT=\"Fedora\"\n"
 "REDHAT_SUPPORT_PRODUCT_VERSION=Rawhide\n", osinfo);
-        assert(0 == strcmp("Fedora", get_map_string_item_or_NULL(osinfo, OSINFO_NAME)));
-        assert(0 == strcmp("20 (Rawhide)", get_map_string_item_or_NULL(osinfo, "VERSION")));
-        assert(0 == strcmp("fedora", get_map_string_item_or_NULL(osinfo, OSINFO_ID)));
-        assert(0 == strcmp("20", get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID)));
-        assert(0 == strcmp("Fedora 20 (Rawhide)", get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME)));
-        assert(0 == strcmp("0;34", get_map_string_item_or_NULL(osinfo, "ANSI_COLOR")));
-        assert(0 == strcmp("cpe:/o:fedoraproject:fedora:20", get_map_string_item_or_NULL(osinfo, "CPE_NAME")));
-        assert(0 == strcmp("Fedora", get_map_string_item_or_NULL(osinfo, "REDHAT_BUGZILLA_PRODUCT")));
-        assert(0 == strcmp("Rawhide", get_map_string_item_or_NULL(osinfo, "REDHAT_BUGZILLA_PRODUCT_VERSION")));
-        assert(0 == strcmp("Fedora", get_map_string_item_or_NULL(osinfo, "REDHAT_SUPPORT_PRODUCT")));
-        assert(0 == strcmp("Rawhide", get_map_string_item_or_NULL(osinfo, "REDHAT_SUPPORT_PRODUCT_VERSION")));
-        free_map_string(osinfo);
+        assert(0 == strcmp("Fedora", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_NAME)));
+        assert(0 == strcmp("20 (Rawhide)", libreport_get_map_string_item_or_NULL(osinfo, "VERSION")));
+        assert(0 == strcmp("fedora", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_ID)));
+        assert(0 == strcmp("20", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID)));
+        assert(0 == strcmp("Fedora 20 (Rawhide)", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME)));
+        assert(0 == strcmp("0;34", libreport_get_map_string_item_or_NULL(osinfo, "ANSI_COLOR")));
+        assert(0 == strcmp("cpe:/o:fedoraproject:fedora:20", libreport_get_map_string_item_or_NULL(osinfo, "CPE_NAME")));
+        assert(0 == strcmp("Fedora", libreport_get_map_string_item_or_NULL(osinfo, "REDHAT_BUGZILLA_PRODUCT")));
+        assert(0 == strcmp("Rawhide", libreport_get_map_string_item_or_NULL(osinfo, "REDHAT_BUGZILLA_PRODUCT_VERSION")));
+        assert(0 == strcmp("Fedora", libreport_get_map_string_item_or_NULL(osinfo, "REDHAT_SUPPORT_PRODUCT")));
+        assert(0 == strcmp("Rawhide", libreport_get_map_string_item_or_NULL(osinfo, "REDHAT_SUPPORT_PRODUCT_VERSION")));
+        libreport_free_map_string(osinfo);
         osinfo = NULL;
     }
-    osinfo = new_map_string();
+    osinfo = libreport_new_map_string();
     {
         /* Test for standard os-release with few errors */
         libreport_parse_osinfo(
@@ -87,15 +87,15 @@ int main(void)
 "ANSI_COLOR=\"0;34\"\n"
 "# The next line misses new line character\n"
 "CPE_NAME=\"cpe:/o:fedoraproject:fedora:18\"", osinfo);
-        assert(NULL == get_map_string_item_or_NULL(osinfo, "FOO"));
-        assert(0 == strcmp("Fedora", get_map_string_item_or_NULL(osinfo, OSINFO_NAME)));
-        assert(NULL == get_map_string_item_or_NULL(osinfo, "VERSION"));
-        assert(0 == strcmp("fedora", get_map_string_item_or_NULL(osinfo, OSINFO_ID)));
-        assert(0 == strcmp("19", get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID)));
-        assert(NULL == get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME));
-        assert(0 == strcmp("0;34", get_map_string_item_or_NULL(osinfo, "ANSI_COLOR")));
-        assert(0 == strcmp("cpe:/o:fedoraproject:fedora:18", get_map_string_item_or_NULL(osinfo, "CPE_NAME")));
-        free_map_string(osinfo);
+        assert(NULL == libreport_get_map_string_item_or_NULL(osinfo, "FOO"));
+        assert(0 == strcmp("Fedora", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_NAME)));
+        assert(NULL == libreport_get_map_string_item_or_NULL(osinfo, "VERSION"));
+        assert(0 == strcmp("fedora", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_ID)));
+        assert(0 == strcmp("19", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_VERSION_ID)));
+        assert(NULL == libreport_get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME));
+        assert(0 == strcmp("0;34", libreport_get_map_string_item_or_NULL(osinfo, "ANSI_COLOR")));
+        assert(0 == strcmp("cpe:/o:fedoraproject:fedora:18", libreport_get_map_string_item_or_NULL(osinfo, "CPE_NAME")));
+        libreport_free_map_string(osinfo);
         osinfo = NULL;
     }
     return 0;
@@ -114,7 +114,7 @@ AT_TESTFUN([libreport_parse_osinfo_for_bz],
 
 void test(const char *osinfo_bytes, const char *product, const char *version)
 {
-    map_string_t *osinfo = new_map_string();
+    map_string_t *osinfo = libreport_new_map_string();
     libreport_parse_osinfo(osinfo_bytes, osinfo);
 
     char *built_product = (char *)0xDEADBEAF;
@@ -224,7 +224,7 @@ AT_TESTFUN([parse_osinfo_for_bugurl], [[
 
 void test(const char *osinfo_bytes, const char *url)
 {
-    map_string_t *osinfo = new_map_string();
+    map_string_t *osinfo = libreport_new_map_string();
     libreport_parse_osinfo(osinfo_bytes, osinfo);
 
     char *default_BugzillaURL = (char *)0xDEADBEEF;
@@ -233,7 +233,7 @@ void test(const char *osinfo_bytes, const char *url)
     TS_ASSERT_STRING_EQ(default_BugzillaURL, url, "Tested URL");
 
     free(default_BugzillaURL);
-    free_map_string(osinfo);
+    libreport_free_map_string(osinfo);
 }
 
 int main(void)
@@ -291,7 +291,7 @@ AT_TESTFUN([libreport_parse_osinfo_for_rhts],
 
 void test(const char *osinfo_bytes, const char *product, const char *version)
 {
-    map_string_t *osinfo = new_map_string();
+    map_string_t *osinfo = libreport_new_map_string();
     libreport_parse_osinfo(osinfo_bytes, osinfo);
 
     char *built_product = (char *)0xDEADBEAF;
@@ -404,7 +404,7 @@ int main(void)
     libreport_g_verbose=3;
 
     problem_data_t *pd = problem_data_new();
-    map_string_t *osinfo = new_map_string();
+    map_string_t *osinfo = libreport_new_map_string();
     {
         problem_data_add_text_noteditable(pd, FILENAME_OS_INFO,
              "NAME=Fedora\n"
@@ -412,22 +412,22 @@ int main(void)
              "PRETTY_NAME=\"Fedora 19 (Schrödinger\\'s Cat)\"\n");
 
         problem_data_get_osinfo(pd, osinfo);
-        assert(0 == strcmp("Fedora", get_map_string_item_or_NULL(osinfo, OSINFO_NAME)));
-        free_map_string(osinfo);
+        assert(0 == strcmp("Fedora", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_NAME)));
+        libreport_free_map_string(osinfo);
         problem_data_free(pd);
     }
     pd = problem_data_new();
-    osinfo = new_map_string();
+    osinfo = libreport_new_map_string();
     {
         problem_data_add_text_noteditable(pd, FILENAME_OS_RELEASE, "Fedora release 19 (Schrödinger's Cat)");
 
         problem_data_get_osinfo(pd, osinfo);
-        assert(0 == strcmp("Fedora release 19 (Schrödinger's Cat)", get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME)));
-        free_map_string(osinfo);
+        assert(0 == strcmp("Fedora release 19 (Schrödinger's Cat)", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME)));
+        libreport_free_map_string(osinfo);
         problem_data_free(pd);
     }
     pd = problem_data_new();
-    osinfo = new_map_string();
+    osinfo = libreport_new_map_string();
     {
         problem_data_add_text_noteditable(pd, FILENAME_ROOTDIR, "/var/lib/mock");
         problem_data_add_text_noteditable(pd, FILENAME_OS_INFO_IN_ROOTDIR,
@@ -440,20 +440,20 @@ int main(void)
              "PRETTY_NAME=\"Fedora 19 (Schrödinger\\'s Cat)\"\n");
 
         problem_data_get_osinfo(pd, osinfo);
-        assert(0 == strcmp("Red Hat Enterprise Linux Client", get_map_string_item_or_NULL(osinfo, OSINFO_NAME)));
-        free_map_string(osinfo);
+        assert(0 == strcmp("Red Hat Enterprise Linux Client", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_NAME)));
+        libreport_free_map_string(osinfo);
         problem_data_free(pd);
     }
     pd = problem_data_new();
-    osinfo = new_map_string();
+    osinfo = libreport_new_map_string();
     {
         problem_data_add_text_noteditable(pd, FILENAME_ROOTDIR, "/var/lib/mock");
         problem_data_add_text_noteditable(pd, FILENAME_OS_RELEASE_IN_ROOTDIR, "Red Hat Enterprise Linux Client 7.0 Beta (Maipo)");
         problem_data_add_text_noteditable(pd, FILENAME_OS_RELEASE, "Fedora release 19 (Schrödinger's Cat)");
 
         problem_data_get_osinfo(pd, osinfo);
-        assert(0 == strcmp("Red Hat Enterprise Linux Client 7.0 Beta (Maipo)", get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME)));
-        free_map_string(osinfo);
+        assert(0 == strcmp("Red Hat Enterprise Linux Client 7.0 Beta (Maipo)", libreport_get_map_string_item_or_NULL(osinfo, OSINFO_PRETTY_NAME)));
+        libreport_free_map_string(osinfo);
         problem_data_free(pd);
     }
 

--- a/tests/osrelease.at
+++ b/tests/osrelease.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([osrelease - 730887])
 
-## ---------------------- ##
-## parse_release_for_bz ##
-## ---------------------- ##
+## ------------------------------ ##
+## libreport_parse_release_for_bz ##
+## ------------------------------ ##
 
-AT_TESTFUN([parse_release_for_bz],
+AT_TESTFUN([libreport_parse_release_for_bz],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
@@ -19,7 +19,7 @@ int test(char ***input)
     log_warning("release: >>%s<<\n", release_string);
     char *product = NULL;
     char *version = NULL;
-    parse_release_for_bz(release_string, &product, &version);
+    libreport_parse_release_for_bz(release_string, &product, &version);
     log_warning("version: >>%s<<\n", version);
     log_warning("product: >>%s<<\n", product);
 
@@ -69,11 +69,11 @@ int main(void)
 }
 ]])
 
-## --------------------- ##
-## parse_release_for_rhts##
-## --------------------- ##
+## ------------------------------- ##
+## libreport_parse_release_for_rhts##
+## ------------------------------- ##
 
-AT_TESTFUN([parse_release_for_rhts],
+AT_TESTFUN([libreport_parse_release_for_rhts],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
@@ -87,7 +87,7 @@ int test(char ***input)
     log_warning("release: >>%s<<\n", release_string);
     char *product = NULL;
     char *version = NULL;
-    parse_release_for_rhts(release_string, &product, &version);
+    libreport_parse_release_for_rhts(release_string, &product, &version);
     log_warning("version: >>%s<<\n", version);
     log_warning("product: >>%s<<\n", product);
 

--- a/tests/problem_data.at
+++ b/tests/problem_data.at
@@ -18,7 +18,7 @@ AT_TESTFUN([problem_data_add],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     problem_data_t *data = problem_data_new();
     problem_data_add(data, TEST_NAME, TEST_CONTENTS, TEST_FLAGS);
@@ -51,7 +51,7 @@ AT_TESTFUN([problem_data_add_ext],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     problem_data_t *data = problem_data_new();
     struct problem_item *itm = problem_data_add_ext(data, TEST_NAME, TEST_CONTENTS, TEST_FLAGS, strlen(TEST_CONTENTS));
@@ -81,7 +81,7 @@ AT_TESTFUN([problem_item_get_size],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     problem_data_t *data = problem_data_new();
 
@@ -154,7 +154,7 @@ AT_TESTFUN([problem_data_load_from_dump_dir],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX";
 
@@ -245,8 +245,8 @@ int main(int argc, char **argv)
     {
         int fd4k = openat(dd->dd_fd, "attestsuite-over4k", O_WRONLY | O_CREAT | O_TRUNC, 0550);
         assert(fd4k >= 0);
-        full_write(fd4k, buffer, sizeof(buffer));
-        full_write(fd4k, buffer, sizeof(buffer));
+        libreport_full_write(fd4k, buffer, sizeof(buffer));
+        libreport_full_write(fd4k, buffer, sizeof(buffer));
         close(fd4k);
     }
 
@@ -254,7 +254,7 @@ int main(int argc, char **argv)
         int bigfd = openat(dd->dd_fd, "attestsuite-bigtext", O_WRONLY | O_CREAT | O_TRUNC, 0550);
         assert(bigfd >= 0);
         for (int i = 3000; i > 0; --i)
-            full_write(bigfd, buffer, sizeof(buffer));
+            libreport_full_write(bigfd, buffer, sizeof(buffer));
         close(bigfd);
     }
 
@@ -405,7 +405,7 @@ void test(struct dump_dir *dd, const char *path, const char *exp_content, int ex
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     char template[] = "/tmp/XXXXXX";
 

--- a/tests/problem_report.at
+++ b/tests/problem_report.at
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
         },
     };
 
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     problem_data_t *data = problem_data_new();
     problem_data_add_text_noteditable(data, "package", "libreport");
@@ -182,7 +182,7 @@ int main(int argc, char **argv)
         },
     };
 
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     problem_data_t *data = problem_data_new();
     problem_data_add_text_noteditable(data, "package", "libreport");
@@ -546,7 +546,7 @@ void check(problem_data_t *data, backtrace_result_t br)
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     problem_data_t *data = problem_data_new();
     problem_data_add_text_noteditable(data, "package", "libreport");
@@ -689,7 +689,7 @@ AT_TESTFUN([attach],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     const char *fst[] = { "backtrace", "screenshot", "description", NULL };
 
@@ -757,7 +757,7 @@ int main(int argc, char **argv)
             assert(problem_report_get_attachments(pr));
         }
 
-        GList *clone = g_list_copy_deep(problem_report_get_attachments(pr), (GCopyFunc)xstrdup, NULL);
+        GList *clone = g_list_copy_deep(problem_report_get_attachments(pr), (GCopyFunc)libreport_xstrdup, NULL);
 
         while (*iter) {
             GList *item = g_list_find_custom(clone, *iter, (GCompareFunc)strcmp);
@@ -805,7 +805,7 @@ AT_TESTFUN([custom_section],
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     struct test_case;
     struct test_case {
@@ -966,7 +966,7 @@ void assert_equal_strings(const char *res, const char *exp)
 
 int main(int argc, char **argv)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     problem_formatter_t *pf = problem_formatter_new();
 

--- a/tests/proc_helpers.at
+++ b/tests/proc_helpers.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([/proc helpers])
 
-## -------------------- ##
-## get_env_variable_ext ##
-## -------------------- ##
+## ------------------------------ ##
+## libreport_get_env_variable_ext ##
+## ------------------------------ ##
 
-AT_TESTFUN([get_env_variable_ext],
+AT_TESTFUN([libreport_get_env_variable_ext],
 [[
 
 #include "testsuite.h"
@@ -55,7 +55,7 @@ void test_delim(char delim)
         lseek(fd, 0, SEEK_SET);
         char *value = NULL;
         printf("Looking for '%s'\n", test_data[i-1][0]);
-        TS_ASSERT_FUNCTION(get_env_variable_ext(fd, delim, test_data[i-1][0], &value));
+        TS_ASSERT_FUNCTION(libreport_get_env_variable_ext(fd, delim, test_data[i-1][0], &value));
         TS_ASSERT_STRING_EQ(value, test_data[i-1][1], "Environment value at 'i'");
         free(value);
     }
@@ -72,11 +72,11 @@ TS_RETURN_MAIN
 ]])
 
 
-## ---------------- ##
-## get_env_variable ##
-## ---------------- ##
+## -------------------------- ##
+## libreport_get_env_variable ##
+## -------------------------- ##
 
-AT_TESTFUN([get_env_variable],
+AT_TESTFUN([libreport_get_env_variable],
 [[
 
 #include "testsuite.h"
@@ -87,25 +87,25 @@ TS_MAIN
     getcwd(cwd, sizeof(cwd));
 
     char *value = NULL;
-    TS_ASSERT_FUNCTION(get_env_variable(getpid(), "PWD", &value));
+    TS_ASSERT_FUNCTION(libreport_get_env_variable(getpid(), "PWD", &value));
     TS_ASSERT_STRING_EQ(value, cwd, "Test environment variable - PWD");
     free(value);
 }
 TS_RETURN_MAIN
 ]])
 
-## ----------- ##
-## get_cmdline ##
-## ----------- ##
+## --------------------- ##
+## libreport_get_cmdline ##
+## --------------------- ##
 
-AT_TESTFUN([get_cmdline], [[
+AT_TESTFUN([libreport_get_cmdline], [[
 #include "testsuite.h"
 #include <err.h>
 
 void test(const char *program, const char *args[], const char *expected)
 {
     int inout[2];
-    xpipe(inout);
+    libreport_xpipe(inout);
 
     pid_t pid = fork();
     if (pid < 0) {
@@ -114,7 +114,7 @@ void test(const char *program, const char *args[], const char *expected)
 
     if (pid == 0) {
         close(STDOUT_FILENO);
-        xdup2(inout[1], STDOUT_FILENO);
+        libreport_xdup2(inout[1], STDOUT_FILENO);
         close(inout[0]);
 
         execv(program, (char **)args);
@@ -123,7 +123,7 @@ void test(const char *program, const char *args[], const char *expected)
 
     close(inout[1]);
     int status = 0;
-    if (safe_waitpid(pid, &status, 0) < 0) {
+    if (libreport_safe_waitpid(pid, &status, 0) < 0) {
         err(EXIT_FAILURE, "waitpid");
     }
 
@@ -133,11 +133,11 @@ void test(const char *program, const char *args[], const char *expected)
 
     const size_t buffer_size = strlen(expected) * 2;
     char cmdline[buffer_size];
-    const ssize_t total = full_read(inout[0], cmdline, buffer_size);
+    const ssize_t total = libreport_full_read(inout[0], cmdline, buffer_size);
     close(inout[0]);
 
     if (total < 0) {
-        err(EXIT_FAILURE, "full_read");
+        err(EXIT_FAILURE, "libreport_full_read");
     }
 
     cmdline[total] = '\0';
@@ -148,15 +148,15 @@ TS_MAIN
 {
     if (argc > 1) {
         char *cmdline = NULL;
-        if (strcmp(argv[0], "get_cmdline") == 0) {
-            cmdline = get_cmdline(getpid());
+        if (strcmp(argv[0], "libreport_get_cmdline") == 0) {
+            cmdline = libreport_get_cmdline(getpid());
         }
-        else if (strcmp(argv[0], "get_cmdline_at") == 0) {
+        else if (strcmp(argv[0], "libreport_get_cmdline_at") == 0) {
             int pid_proc_fd = open("/proc/self", O_DIRECTORY);
             if (pid_proc_fd < 0) {
                 err(EXIT_FAILURE, "open(/proc/self, O_DIRECTORY)");
             }
-            cmdline = get_cmdline_at(pid_proc_fd);
+            cmdline = libreport_get_cmdline_at(pid_proc_fd);
             close(pid_proc_fd);
         }
         else {
@@ -168,37 +168,37 @@ TS_MAIN
         exit(EXIT_SUCCESS);
     }
 
-    char *binary = malloc_readlink("/proc/self/exe");
+    char *binary = libreport_malloc_readlink("/proc/self/exe");
     const char *args[] = { NULL, "!fo\" \"o", "@blah", "b\na'r", "g\rea\t", "regular", NULL };
 
 #define EXPECTED " '!fo\\\" \\\"o' @blah 'b\\na\\'r' 'g\\rea\\t' regular"
 
-    args[0] = "get_cmdline";
-    test(binary, args, "get_cmdline" EXPECTED);
+    args[0] = "libreport_get_cmdline";
+    test(binary, args, "libreport_get_cmdline" EXPECTED);
 
-    args[0] = "get_cmdline_at";
-    test(binary, args, "get_cmdline_at" EXPECTED);
+    args[0] = "libreport_get_cmdline_at";
+    test(binary, args, "libreport_get_cmdline_at" EXPECTED);
 
     free(binary);
 }
 TS_RETURN_MAIN
 ]])
 
-## -------------- ##
-## get_executable ##
-## -------------- ##
+## ------------------------ ##
+## libreport_get_executable ##
+## ------------------------ ##
 
-AT_TESTFUN([get_executable], [[
+AT_TESTFUN([libreport_get_executable], [[
 #include "testsuite.h"
 #include <sys/sendfile.h>
 #include <err.h>
 
-#define PRELINK_BASENAME "/tmp/libreport.testsuite.get_executable"
+#define PRELINK_BASENAME "/tmp/libreport.testsuite.libreport_get_executable"
 #
 void test(const char *program, const char *expected, const char *function, const char *argv1)
 {
     int inout[2];
-    xpipe(inout);
+    libreport_xpipe(inout);
 
     pid_t pid = fork();
     if (pid < 0) {
@@ -207,7 +207,7 @@ void test(const char *program, const char *expected, const char *function, const
 
     if (pid == 0) {
         close(STDOUT_FILENO);
-        xdup2(inout[1], STDOUT_FILENO);
+        libreport_xdup2(inout[1], STDOUT_FILENO);
         close(inout[0]);
 
         const char *args[3] = { function, argv1, NULL };
@@ -217,7 +217,7 @@ void test(const char *program, const char *expected, const char *function, const
 
     close(inout[1]);
     int status = 0;
-    if (safe_waitpid(pid, &status, 0) < 0) {
+    if (libreport_safe_waitpid(pid, &status, 0) < 0) {
         err(EXIT_FAILURE, "waitpid");
     }
 
@@ -227,11 +227,11 @@ void test(const char *program, const char *expected, const char *function, const
 
     const size_t buffer_size = strlen(expected) * 2;
     char executable[buffer_size];
-    const ssize_t total = full_read(inout[0], executable, buffer_size);
+    const ssize_t total = libreport_full_read(inout[0], executable, buffer_size);
     close(inout[0]);
 
     if (total < 0) {
-        err(EXIT_FAILURE, "full_read");
+        err(EXIT_FAILURE, "libreport_full_read");
     }
 
     executable[total] = '\0';
@@ -269,7 +269,7 @@ TS_MAIN
 {
     if (argc > 1) {
         if (strcmp(argv[1], "delete") == 0) {
-            char *binary = malloc_readlink("/proc/self/exe");
+            char *binary = libreport_malloc_readlink("/proc/self/exe");
             unlink(binary);
             if (access(binary, R_OK) != -1 && errno != !ENOENT) {
                 err(EXIT_FAILURE, "failed to remove %s", binary);
@@ -278,15 +278,15 @@ TS_MAIN
         }
 
         char *executable = NULL;
-        if (strcmp(argv[0], "get_executable") == 0) {
-            executable = get_executable(getpid());
+        if (strcmp(argv[0], "libreport_get_executable") == 0) {
+            executable = libreport_get_executable(getpid());
         }
-        else if (strcmp(argv[0], "get_executable_at") == 0) {
+        else if (strcmp(argv[0], "libreport_get_executable_at") == 0) {
             int pid_proc_fd = open("/proc/self", O_DIRECTORY);
             if (pid_proc_fd < 0) {
                 err(EXIT_FAILURE, "open(/proc/self, O_DIRECTORY)");
             }
-            executable = get_executable_at(pid_proc_fd);
+            executable = libreport_get_executable_at(pid_proc_fd);
             close(pid_proc_fd);
         }
         else {
@@ -299,10 +299,10 @@ TS_MAIN
     }
 
     {
-        char *binary = malloc_readlink("/proc/self/exe");
+        char *binary = libreport_malloc_readlink("/proc/self/exe");
 
-        test(binary, binary, "get_executable", "keep");
-        test(binary, binary, "get_executable_at", "keep");
+        test(binary, binary, "libreport_get_executable", "keep");
+        test(binary, binary, "libreport_get_executable_at", "keep");
 
         free(binary);
     }
@@ -312,7 +312,7 @@ TS_MAIN
         int binary_fd = copy_to_temporary("/proc/self/exe", binary);
         close(binary_fd);
 
-        test(binary, PRELINK_BASENAME, "get_executable", "keep");
+        test(binary, PRELINK_BASENAME, "libreport_get_executable", "keep");
 
         unlink(binary);
     }
@@ -322,7 +322,7 @@ TS_MAIN
         int binary_fd = copy_to_temporary("/proc/self/exe", binary);
         close(binary_fd);
 
-        test(binary, PRELINK_BASENAME, "get_executable_at", "keep");
+        test(binary, PRELINK_BASENAME, "libreport_get_executable_at", "keep");
 
         unlink(binary);
     }
@@ -332,7 +332,7 @@ TS_MAIN
         int binary_fd = copy_to_temporary("/proc/self/exe", binary);
         close(binary_fd);
 
-        test(binary, PRELINK_BASENAME, "get_executable", "delete");
+        test(binary, PRELINK_BASENAME, "libreport_get_executable", "delete");
 
         if (unlink(binary) == 0) {
             errx(EXIT_FAILURE, "should be already removed %s", binary);
@@ -344,7 +344,7 @@ TS_MAIN
         int binary_fd = copy_to_temporary("/proc/self/exe", binary);
         close(binary_fd);
 
-        test(binary, PRELINK_BASENAME, "get_executable_at", "delete");
+        test(binary, PRELINK_BASENAME, "libreport_get_executable_at", "delete");
 
         if (unlink(binary) == 0) {
             errx(EXIT_FAILURE, "should be already removed %s", binary);
@@ -352,11 +352,11 @@ TS_MAIN
     }
 
     {
-        char binary[] = "/tmp/libreport.testsuite.get_executable.XXXXXX";
+        char binary[] = "/tmp/libreport.testsuite.libreport_get_executable.XXXXXX";
         int binary_fd = copy_to_temporary("/proc/self/exe", binary);
         close(binary_fd);
 
-        test(binary, binary, "get_executable", "delete");
+        test(binary, binary, "libreport_get_executable", "delete");
 
         if (unlink(binary) == 0) {
             errx(EXIT_FAILURE, "should be already removed %s", binary);
@@ -364,11 +364,11 @@ TS_MAIN
     }
 
     {
-        char binary[] = "/tmp/libreport.testsuite.get_executable.XXXXXX";
+        char binary[] = "/tmp/libreport.testsuite.libreport_get_executable.XXXXXX";
         int binary_fd = copy_to_temporary("/proc/self/exe", binary);
         close(binary_fd);
 
-        test(binary, binary, "get_executable_at", "delete");
+        test(binary, binary, "libreport_get_executable_at", "delete");
 
         if (unlink(binary) == 0) {
             errx(EXIT_FAILURE, "should be already removed %s", binary);
@@ -378,11 +378,11 @@ TS_MAIN
 TS_RETURN_MAIN
 ]])
 
-## ------- ##
-## get_cwd ##
-## ------- ##
+## ----------------- ##
+## libreport_get_cwd ##
+## ----------------- ##
 
-AT_TESTFUN([get_cwd], [[
+AT_TESTFUN([libreport_get_cwd], [[
 #include "testsuite.h"
 #include <sys/sendfile.h>
 #include <err.h>
@@ -392,8 +392,8 @@ TS_MAIN
     char wd[PATH_MAX];
     getcwd(wd, sizeof(wd));
 
-    char *cwd = get_cwd(getpid());
-    TS_ASSERT_STRING_EQ(cwd, wd, "get_cwd(getpid())");
+    char *cwd = libreport_get_cwd(getpid());
+    TS_ASSERT_STRING_EQ(cwd, wd, "libreport_get_cwd(getpid())");
     free(cwd);
 
 
@@ -402,29 +402,29 @@ TS_MAIN
         err(EXIT_FAILURE, "open(/proc/self, O_DIRECTORY | O_PATH)");
     }
 
-    char *cwd_at = get_cwd_at(pid_proc_fd);
-    TS_ASSERT_STRING_EQ(cwd_at, wd, "get_cwd_at(open(/proc/self))");
+    char *cwd_at = libreport_get_cwd_at(pid_proc_fd);
+    TS_ASSERT_STRING_EQ(cwd_at, wd, "libreport_get_cwd_at(open(/proc/self))");
     close(pid_proc_fd);
     free(cwd_at);
 }
 TS_RETURN_MAIN
 ]])
 
-## ----------- ##
-## get_rootdir ##
-## ----------- ##
+## --------------------- ##
+## libreport_get_rootdir ##
+## --------------------- ##
 
-AT_TESTFUN([get_rootdir], [[
+AT_TESTFUN([libreport_get_rootdir], [[
 #include "testsuite.h"
 #include <sys/sendfile.h>
 #include <err.h>
 
 TS_MAIN
 {
-    char *proc_self_root = malloc_readlink("/proc/self/root");
+    char *proc_self_root = libreport_malloc_readlink("/proc/self/root");
 
-    char *root_dir = get_rootdir(getpid());
-    TS_ASSERT_STRING_EQ(root_dir, proc_self_root, "get_rootdir(getpid())");
+    char *root_dir = libreport_get_rootdir(getpid());
+    TS_ASSERT_STRING_EQ(root_dir, proc_self_root, "libreport_get_rootdir(getpid())");
     free(root_dir);
 
 
@@ -433,19 +433,19 @@ TS_MAIN
         err(EXIT_FAILURE, "open(/proc/self, O_DIRECTORY | O_PATH)");
     }
 
-    char *root_dir_at = get_rootdir_at(pid_proc_fd);
-    TS_ASSERT_STRING_EQ(root_dir_at, proc_self_root, "get_rootdir_at(open(/proc/self))");
+    char *root_dir_at = libreport_get_rootdir_at(pid_proc_fd);
+    TS_ASSERT_STRING_EQ(root_dir_at, proc_self_root, "libreport_get_rootdir_at(open(/proc/self))");
     close(pid_proc_fd);
     free(root_dir_at);
 }
 TS_RETURN_MAIN
 ]])
 
-## ------------ ##
-## dump_fd_info ##
-## ------------ ##
+## ---------------------- ##
+## libreport_dump_fd_info ##
+## ---------------------- ##
 
-AT_TESTFUN([dump_fd_info], [[
+AT_TESTFUN([libreport_dump_fd_info], [[
 #include "testsuite.h"
 #include <sys/sendfile.h>
 #include <err.h>
@@ -455,9 +455,9 @@ AT_TESTFUN([dump_fd_info], [[
 pid_t prepare_process(void)
 {
     int toparent[2];
-    xpipe(toparent);
+    libreport_xpipe(toparent);
 
-    char *binary = malloc_readlink("/proc/self/exe");
+    char *binary = libreport_malloc_readlink("/proc/self/exe");
     pid_t pid = fork();
     if (pid < 0) {
         err(EXIT_FAILURE, "fork");
@@ -465,7 +465,7 @@ pid_t prepare_process(void)
 
     if (pid == 0) {
         close(STDOUT_FILENO);
-        xdup2(toparent[1], STDOUT_FILENO);
+        libreport_xdup2(toparent[1], STDOUT_FILENO);
 
         DIR *fddir = opendir("/proc/self/fd");
         struct dirent *dent;
@@ -486,7 +486,7 @@ pid_t prepare_process(void)
 
     /* Wait for child */
     char buf[8];
-    if (full_read(toparent[0], buf, 8) < 0) {
+    if (libreport_full_read(toparent[0], buf, 8) < 0) {
         fprintf(stderr, "Failed to read from child: %s\n", strerror(errno));
         fflush(stderr);
     }
@@ -501,7 +501,7 @@ void kill_process(pid_t pid)
     /* Notify child */
     kill(pid, SIGTERM);
     int status = 0;
-    if (safe_waitpid(pid, &status, 0) < 0) {
+    if (libreport_safe_waitpid(pid, &status, 0) < 0) {
         fprintf(stderr, "Couldn't wait for child\n");
     }
     else if (!WIFSIGNALED(status) || WTERMSIG(status) != SIGTERM) {
@@ -520,7 +520,7 @@ void check_file_contents(const char *fdinfo_filename)
         { .fd = 3, .file = "/etc/group", },
     };
 
-    char *file = xmalloc_xopen_read_close(fdinfo_filename, NULL);
+    char *file = libreport_xmalloc_xopen_read_close(fdinfo_filename, NULL);
     int fdno = 0;
     char *cursor = file;
     char *line = file;
@@ -614,13 +614,13 @@ TS_MAIN
     }
 
     {
-        TS_PRINTF("%s\n", "dump_fd_info");
-        char fdinfo_filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("dump_fd_info")];
-        if (sizeof(fdinfo_filename) <= snprintf(fdinfo_filename, sizeof(fdinfo_filename), FILENAME_FORMAT, pid, "dump_fd_info")) {
+        TS_PRINTF("%s\n", "libreport_dump_fd_info");
+        char fdinfo_filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("libreport_dump_fd_info")];
+        if (sizeof(fdinfo_filename) <= snprintf(fdinfo_filename, sizeof(fdinfo_filename), FILENAME_FORMAT, pid, "libreport_dump_fd_info")) {
             errx(EXIT_FAILURE, "too small buffer for file name");
         }
 
-        TS_ASSERT_FUNCTION(dump_fd_info(fdinfo_filename, proc_dir_path));
+        TS_ASSERT_FUNCTION(libreport_dump_fd_info(fdinfo_filename, proc_dir_path));
 
         struct stat st;
         TS_ASSERT_FUNCTION(stat(fdinfo_filename, &st));
@@ -634,15 +634,15 @@ TS_MAIN
     }
 
     {
-        TS_PRINTF("%s\n", "dump_fd_info_ext");
-        char fdinfo_filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("dump_fd_info_ext")];
-        if (sizeof(fdinfo_filename) <= snprintf(fdinfo_filename, sizeof(fdinfo_filename), FILENAME_FORMAT, pid, "dump_fd_info_ext")) {
+        TS_PRINTF("%s\n", "libreport_dump_fd_info_ext");
+        char fdinfo_filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("libreport_dump_fd_info_ext")];
+        if (sizeof(fdinfo_filename) <= snprintf(fdinfo_filename, sizeof(fdinfo_filename), FILENAME_FORMAT, pid, "libreport_dump_fd_info_ext")) {
             errx(EXIT_FAILURE, "too small buffer for file name");
         }
 
         const uid_t uid = getuid();
         const gid_t gid = getgid();
-        TS_ASSERT_FUNCTION(dump_fd_info_ext(fdinfo_filename, proc_dir_path, uid, gid));
+        TS_ASSERT_FUNCTION(libreport_dump_fd_info_ext(fdinfo_filename, proc_dir_path, uid, gid));
 
         struct stat st;
         TS_ASSERT_FUNCTION(stat(fdinfo_filename, &st));
@@ -656,16 +656,16 @@ TS_MAIN
     }
 
     {
-        TS_PRINTF("%s\n", "dump_fd_info_at");
-        char fdinfo_filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("dump_fd_info_at")];
-        if (sizeof(fdinfo_filename) <= snprintf(fdinfo_filename, sizeof(fdinfo_filename), FILENAME_FORMAT, pid, "dump_fd_info_at")) {
+        TS_PRINTF("%s\n", "libreport_dump_fd_info_at");
+        char fdinfo_filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("libreport_dump_fd_info_at")];
+        if (sizeof(fdinfo_filename) <= snprintf(fdinfo_filename, sizeof(fdinfo_filename), FILENAME_FORMAT, pid, "libreport_dump_fd_info_at")) {
             errx(EXIT_FAILURE, "too small buffer for file name");
         }
 
         FILE *dest = fopen(fdinfo_filename, "w");
-        const int pid_proc_fd = open_proc_pid_dir(pid);
+        const int pid_proc_fd = libreport_open_proc_pid_dir(pid);
 
-        TS_ASSERT_FUNCTION(dump_fd_info_at(pid_proc_fd, dest));
+        TS_ASSERT_FUNCTION(libreport_dump_fd_info_at(pid_proc_fd, dest));
 
         close(pid_proc_fd);
         fclose(dest);
@@ -692,20 +692,20 @@ AT_TESTFUN([get_fs-u_g-id], [[
 
 TS_MAIN
 {
-    char *proc_pid_status = xmalloc_xopen_read_close("/proc/self/status", NULL);
-    TS_ASSERT_SIGNED_EQ(get_fsuid(proc_pid_status), getuid());
-    TS_ASSERT_SIGNED_EQ(get_fsgid(proc_pid_status), getgid());
+    char *proc_pid_status = libreport_xmalloc_xopen_read_close("/proc/self/status", NULL);
+    TS_ASSERT_SIGNED_EQ(libreport_get_fsuid(proc_pid_status), getuid());
+    TS_ASSERT_SIGNED_EQ(libreport_get_fsgid(proc_pid_status), getgid());
     free(proc_pid_status);
 }
 TS_RETURN_MAIN
 ]])
 
 
-## ---------- ##
-## get_ns_ids ##
-## ---------- ##
+## -------------------- ##
+## libreport_get_ns_ids ##
+## -------------------- ##
 
-AT_TESTFUN([get_ns_ids], [[
+AT_TESTFUN([libreport_get_ns_ids], [[
 #include "testsuite.h"
 #include <sys/sendfile.h>
 #include <err.h>
@@ -730,7 +730,7 @@ void check(struct ns_ids *ids)
 
     struct dirent *dent = NULL;
     while ((dent = readdir(nsdir))) {
-        if (dot_or_dotdot(dent->d_name))
+        if (libreport_dot_or_dotdot(dent->d_name))
             continue;
 
         size_t i = 0;
@@ -753,15 +753,15 @@ void check(struct ns_ids *ids)
 
 TS_MAIN
 {
-    TS_PRINTF("%s\n", "get_ns_ids");
+    TS_PRINTF("%s\n", "libreport_get_ns_ids");
     struct ns_ids pid_ids;
-    TS_ASSERT_FUNCTION(get_ns_ids(getpid(), &pid_ids));
+    TS_ASSERT_FUNCTION(libreport_get_ns_ids(getpid(), &pid_ids));
     check(&pid_ids);
 
-    TS_PRINTF("%s\n", "get_ns_ids_at");
-    const int pid_proc_dir = open_proc_pid_dir(getpid());
+    TS_PRINTF("%s\n", "libreport_get_ns_ids_at");
+    const int pid_proc_dir = libreport_open_proc_pid_dir(getpid());
     struct ns_ids proc_ids;
-    TS_ASSERT_FUNCTION(get_ns_ids_at(pid_proc_dir, &proc_ids));
+    TS_ASSERT_FUNCTION(libreport_get_ns_ids_at(pid_proc_dir, &proc_ids));
     check(&proc_ids);
     close(pid_proc_dir);
 }
@@ -769,12 +769,12 @@ TS_RETURN_MAIN
 ]])
 
 
-## ------------------------------ ##
-##  get_mountinfo_for_mount_point ##
-## ------------------------------ ##
+## ---------------------------------------- ##
+##  libreport_get_mountinfo_for_mount_point ##
+## ---------------------------------------- ##
 
 
-AT_TESTFUN([get_mountinfo_for_mount_point], [[
+AT_TESTFUN([libreport_get_mountinfo_for_mount_point], [[
 #include "testsuite.h"
 #include <err.h>
 
@@ -798,7 +798,7 @@ void test_get_mountinfo_for_mount_point(
     struct mountinfo mntnf;
     int r;
     TS_ASSERT_STREAM_FD_CONTENTS_EQ_BEGIN(STDERR_FILENO);
-    r = get_mountinfo_for_mount_point(mntnf_file, &mntnf, mount_point);
+    r = libreport_get_mountinfo_for_mount_point(mntnf_file, &mntnf, mount_point);
     TS_ASSERT_STREAM_FD_CONTENTS_EQ_END(error, description);
     TS_ASSERT_SIGNED_OP_MESSAGE(r, ==, exp_r, description);
 
@@ -933,11 +933,11 @@ TS_RETURN_MAIN
 ]])
 
 
-## ------------------- ##
-## dump_namespace_diff ##
-## ------------------- ##
+## ----------------------------- ##
+## libreport_dump_namespace_diff ##
+## ----------------------------- ##
 
-AT_TESTFUN([dump_namespace_diff], [[
+AT_TESTFUN([libreport_dump_namespace_diff], [[
 #include "testsuite.h"
 #include <err.h>
 
@@ -965,7 +965,7 @@ void check_file_contents(const char *filename)
     if (stat("/proc/self/ns/time_for_children", &st) < 0 && ENOENT == errno)
         time_for_children = "unknown";
 
-    expected = xasprintf("cgroup : %s\n"
+    expected = libreport_xasprintf("cgroup : %s\n"
                          "ipc : default\n"
                          "mnt : default\n"
                          "net : default\n"
@@ -977,7 +977,7 @@ void check_file_contents(const char *filename)
                          "uts : default\n",
                          cgroup, pid_for_children, time, time_for_children);
 
-    char *file = xmalloc_xopen_read_close(filename, NULL);
+    char *file = libreport_xmalloc_xopen_read_close(filename, NULL);
     TS_ASSERT_STRING_EQ(file, expected, "Namespaces");
     free(file);
     free(expected);
@@ -986,13 +986,13 @@ void check_file_contents(const char *filename)
 TS_MAIN
 {
     {
-        TS_PRINTF("%s\n", "dump_namespace_diff");
-        char filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("dump_namespace_diff")];
-        if (sizeof(filename) <= snprintf(filename, sizeof(filename), FILENAME_FORMAT, getpid(), "dump_namespace_diff")) {
+        TS_PRINTF("%s\n", "libreport_dump_namespace_diff");
+        char filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("libreport_dump_namespace_diff")];
+        if (sizeof(filename) <= snprintf(filename, sizeof(filename), FILENAME_FORMAT, getpid(), "libreport_dump_namespace_diff")) {
             errx(EXIT_FAILURE, "too small buffer for file name");
         }
 
-        TS_ASSERT_FUNCTION(dump_namespace_diff(filename, getpid(), getppid()));
+        TS_ASSERT_FUNCTION(libreport_dump_namespace_diff(filename, getpid(), getppid()));
 
         struct stat st;
         TS_ASSERT_FUNCTION(stat(filename, &st));
@@ -1006,15 +1006,15 @@ TS_MAIN
     }
 
     {
-        TS_PRINTF("%s\n", "dump_namespace_diff_ext");
-        char filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("dump_namespace_diff_ext")];
-        if (sizeof(filename) <= snprintf(filename, sizeof(filename), FILENAME_FORMAT, getpid(), "dump_namespace_diff_ext")) {
+        TS_PRINTF("%s\n", "libreport_dump_namespace_diff_ext");
+        char filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("libreport_dump_namespace_diff_ext")];
+        if (sizeof(filename) <= snprintf(filename, sizeof(filename), FILENAME_FORMAT, getpid(), "libreport_dump_namespace_diff_ext")) {
             errx(EXIT_FAILURE, "too small buffer for file name");
         }
 
         const uid_t uid = getuid();
         const gid_t gid = getgid();
-        TS_ASSERT_FUNCTION(dump_namespace_diff_ext(filename, getpid(), getppid(), uid, gid));
+        TS_ASSERT_FUNCTION(libreport_dump_namespace_diff_ext(filename, getpid(), getppid(), uid, gid));
 
         struct stat st;
         TS_ASSERT_FUNCTION(stat(filename, &st));
@@ -1028,18 +1028,18 @@ TS_MAIN
     }
 
     {
-        TS_PRINTF("%s\n", "dump_namespace_diff_at");
-        char filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("dump_namespace_diff_at")];
-        if (sizeof(filename) <= snprintf(filename, sizeof(filename), FILENAME_FORMAT, getppid(), "dump_namespace_diff_at")) {
+        TS_PRINTF("%s\n", "libreport_dump_namespace_diff_at");
+        char filename[strlen(FILENAME_FORMAT) + sizeof(pid_t) * 3 + strlen("libreport_dump_namespace_diff_at")];
+        if (sizeof(filename) <= snprintf(filename, sizeof(filename), FILENAME_FORMAT, getppid(), "libreport_dump_namespace_diff_at")) {
             errx(EXIT_FAILURE, "too small buffer for file name");
         }
 
         FILE *dest = fopen(filename, "w");
         assert(dest != NULL);
 
-        const int pid_proc_fd = open_proc_pid_dir(getppid());
+        const int pid_proc_fd = libreport_open_proc_pid_dir(getppid());
 
-        TS_ASSERT_FUNCTION(dump_namespace_diff_at(pid_proc_fd, pid_proc_fd, dest));
+        TS_ASSERT_FUNCTION(libreport_dump_namespace_diff_at(pid_proc_fd, pid_proc_fd, dest));
 
         close(pid_proc_fd);
         fclose(dest);
@@ -1053,11 +1053,11 @@ TS_RETURN_MAIN
 ]])
 
 
-## -------------------- ##
-## process_has_own_root ##
-## -------------------- ##
+## ------------------------------ ##
+## libreport_process_has_own_root ##
+## ------------------------------ ##
 
-AT_TESTFUN([process_has_own_root], [[
+AT_TESTFUN([libreport_process_has_own_root], [[
 #include "testsuite.h"
 #include <sys/sendfile.h>
 #include <err.h>
@@ -1069,7 +1069,7 @@ void write_cmd_output_to_fd(int fd, const char *cmd)
         err(EXIT_FAILURE, "popen(%s)", cmd);
     }
 
-    char *output = xmalloc_fgetline(proc);
+    char *output = libreport_xmalloc_fgetline(proc);
     TS_PRINTF("%s : %s\n", cmd, output);
 
     const int retcode = pclose(proc);
@@ -1085,7 +1085,7 @@ void write_cmd_output_to_fd(int fd, const char *cmd)
         errx(EXIT_FAILURE, "no output of '%s'", cmd);
     }
 
-    full_write_str(fd, output);
+    libreport_full_write_str(fd, output);
     free(output);
 }
 
@@ -1104,7 +1104,7 @@ TS_MAIN
 
     {
         /* TODO: add test for open file descriptors */
-        const int r = process_has_own_root_at(mock_pid_proc_fd);
+        const int r = libreport_process_has_own_root_at(mock_pid_proc_fd);
         TS_ASSERT_SIGNED_EQ(r, -ENOENT);
     }
 
@@ -1114,7 +1114,7 @@ TS_MAIN
 
     {
         /* TODO: add test for open file descriptors */
-        const int r = process_has_own_root_at(mock_pid_proc_fd);
+        const int r = libreport_process_has_own_root_at(mock_pid_proc_fd);
         TS_ASSERT_SIGNED_EQ(r, -EACCES);
     }
 
@@ -1123,12 +1123,12 @@ TS_MAIN
 
     {
         /* TODO: add test for open file descriptors */
-        const int r = process_has_own_root_at(mock_pid_proc_fd);
+        const int r = libreport_process_has_own_root_at(mock_pid_proc_fd);
         TS_ASSERT_SIGNED_EQ(r, -ENOKEY);
     }
 
-    full_write_str(mntnf_fd, "36 35 98:0 /madeuproot /foo rw,noatime master:1 - ext3 /dev/myroot rw,errors=continue\n");
-    full_write_str(mntnf_fd, "37 38 99:0 /mnt3 /mnt4 rw,noatime master:2 - ext3 /dev/boot rw,errors=continue\n");
+    libreport_full_write_str(mntnf_fd, "36 35 98:0 /madeuproot /foo rw,noatime master:1 - ext3 /dev/myroot rw,errors=continue\n");
+    libreport_full_write_str(mntnf_fd, "37 38 99:0 /mnt3 /mnt4 rw,noatime master:2 - ext3 /dev/boot rw,errors=continue\n");
 
     fsync(mntnf_fd);
     lseek(mntnf_fd, 0, SEEK_SET);
@@ -1137,7 +1137,7 @@ TS_MAIN
 
     {
         /* TODO: add test for open file descriptors */
-        const int r = process_has_own_root_at(mock_pid_proc_fd);
+        const int r = libreport_process_has_own_root_at(mock_pid_proc_fd);
         TS_ASSERT_SIGNED_EQ(r, -ENOKEY);
     }
 
@@ -1170,7 +1170,7 @@ TS_MAIN
 
     {
         /* TODO: add test for open file descriptors */
-        const int r = process_has_own_root_at(mock_pid_proc_fd);
+        const int r = libreport_process_has_own_root_at(mock_pid_proc_fd);
         TS_ASSERT_SIGNED_EQ(r, 0);
     }
 
@@ -1178,9 +1178,9 @@ TS_MAIN
     fsync(mntnf_fd);
     lseek(mntnf_fd, 0, SEEK_SET);
 
-    full_write_str(mntnf_fd, "12 34 567:89 /madeuproot / ");
+    libreport_full_write_str(mntnf_fd, "12 34 567:89 /madeuproot / ");
     write_cmd_output_to_fd(mntnf_fd, "findmnt -F /proc/1/mountinfo -r -n -o VFS-OPTIONS,OPT-FIELDS -T /");
-    full_write_str(mntnf_fd, " - ");
+    libreport_full_write_str(mntnf_fd, " - ");
     write_cmd_output_to_fd(mntnf_fd, "findmnt -F /proc/1/mountinfo -r -n -o FSTYPE,SOURCE,FS-OPTIONS -T /");
 
     fsync(mntnf_fd);
@@ -1188,7 +1188,7 @@ TS_MAIN
 
     {
         /* TODO: add test for open file descriptors */
-        const int r = process_has_own_root_at(mock_pid_proc_fd);
+        const int r = libreport_process_has_own_root_at(mock_pid_proc_fd);
         TS_ASSERT_SIGNED_EQ(r, 1);
     }
 

--- a/tests/report_result.at
+++ b/tests/report_result.at
@@ -39,7 +39,7 @@ int main(void)
     report_result_t *result;
     struct strbuf *strbuf;
 
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     setenv("TZ", "", 1);
     setenv("LC_ALL", "C", 1);
@@ -59,7 +59,7 @@ int main(void)
     assert(NULL != strbuf);
     assert(string_cmp("Foo = Bar:", strbuf->buf));
 
-    strbuf_free(strbuf);
+    libreport_strbuf_free(strbuf);
     report_result_free(result);
 
     result = report_result_new_with_label("OnlyURL");
@@ -68,7 +68,7 @@ int main(void)
     assert(NULL != strbuf || !"Only URL");
     assert(string_cmp("OnlyURL: URL=http://test1.com", strbuf->buf));
 
-    strbuf_free(strbuf);
+    libreport_strbuf_free(strbuf);
     report_result_free(result);
 
     result = report_result_new_with_label("OnlyBTHASH");
@@ -77,7 +77,7 @@ int main(void)
     assert(NULL != strbuf || !"Only BTHASH");
     assert(string_cmp("OnlyBTHASH: BTHASH=0123456789ABCDEF", strbuf->buf));
 
-    strbuf_free(strbuf);
+    libreport_strbuf_free(strbuf);
     report_result_free(result);
 
     result = report_result_new_with_label("OnlyMSG");
@@ -86,7 +86,7 @@ int main(void)
     assert(NULL != strbuf || !"Only MSG");
     assert(string_cmp("OnlyMSG: MSG=Message = foo: bar!", strbuf->buf));
 
-    strbuf_free(strbuf);
+    libreport_strbuf_free(strbuf);
     report_result_free(result);
 
     result = report_result_new_with_label("OnlyTIME");
@@ -95,7 +95,7 @@ int main(void)
     assert(NULL != strbuf || !"Only TIME");
     assert(string_cmp("OnlyTIME: TIME=2000-01-01-00:00:00", strbuf->buf));
 
-    strbuf_free(strbuf);
+    libreport_strbuf_free(strbuf);
     report_result_free(result);
 
     result = report_result_new_with_label("OnlyWORKFLOW");
@@ -104,7 +104,7 @@ int main(void)
     assert(NULL != strbuf || !"Only WORKFLOW");
     assert(string_cmp("OnlyWORKFLOW: WORKFLOW=workflow_FedoraCCpp", strbuf->buf));
 
-    strbuf_free(strbuf);
+    libreport_strbuf_free(strbuf);
     report_result_free(result);
 
     result = report_result_new_with_label("Everything");
@@ -117,7 +117,7 @@ int main(void)
     assert(NULL != strbuf || !"Everything");
     assert(string_cmp("Everything: TIME=2000-01-01-00:00:00 URL=http://epic.win BTHASH=0123456789ABCDEF WORKFLOW=workflow_FedoraCCpp MSG=Exhaustive libreport test!", strbuf->buf));
 
-    strbuf_free(strbuf);
+    libreport_strbuf_free(strbuf);
     report_result_free(result);
 
     return EXIT_SUCCESS;

--- a/tests/reported_to.at
+++ b/tests/reported_to.at
@@ -22,7 +22,7 @@ bool string_cmp(const char *orig, const char *other)
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
 #define FIRST_LINE "Bugzilla: URL=https://goodluck.org"
 #define SECOND_LINE "ABRT Server: BTHASH=81680083BIGBOOBS"
@@ -104,7 +104,7 @@ int main(void)
     g_autoptr(report_result_t) second_result = NULL;
     g_autoptr(report_result_t) third_result = NULL;
 
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     setenv("TZ", "", 1);
     setenv("LC_ALL", "C", 1);
@@ -182,7 +182,7 @@ int main(void)
     g_autoptr(report_result_t) fifth_result = NULL;
     g_autoptr(report_result_t) sixth_result = NULL;
 
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     first_result = report_result_new_with_label("Bugzilla");
     second_result = report_result_new_with_label("ABRT Server");

--- a/tests/reported_to.at
+++ b/tests/reported_to.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([reported_to])
 
-## -------------------- ##
-## add_reported_to_data ##
-## -------------------- ##
+## ------------------------------ ##
+## libreport_add_reported_to_data ##
+## ------------------------------ ##
 
-AT_TESTFUN([add_reported_to_data],
+AT_TESTFUN([libreport_add_reported_to_data],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
@@ -29,22 +29,22 @@ int main(void)
 #define THIRD_LINE "RHTSupport: TIME=12345678 URL=https://access.redhat.com/home MSG=The world's best IT support"
 
     char *reported_to = NULL;
-    assert(add_reported_to_data(&reported_to, FIRST_LINE) || !"Refused to add the first line");
+    assert(libreport_add_reported_to_data(&reported_to, FIRST_LINE) || !"Refused to add the first line");
     assert(string_cmp(FIRST_LINE"\n", reported_to) || !"Failed to create reported_to from the line");
 
-    assert(add_reported_to_data(&reported_to, SECOND_LINE) || !"Refused to add the second line" );
+    assert(libreport_add_reported_to_data(&reported_to, SECOND_LINE) || !"Refused to add the second line" );
     assert(string_cmp(FIRST_LINE"\n"SECOND_LINE"\n", reported_to) || !"Failed to add the second line");
 
-    assert(add_reported_to_data(&reported_to, THIRD_LINE) || !"Refused to add the third line");
+    assert(libreport_add_reported_to_data(&reported_to, THIRD_LINE) || !"Refused to add the third line");
     assert(string_cmp(FIRST_LINE"\n"SECOND_LINE"\n"THIRD_LINE"\n", reported_to) || !"Failed to add the third line");
 
-    assert(!add_reported_to_data(&reported_to, FIRST_LINE) || !"Added the first line again");
+    assert(!libreport_add_reported_to_data(&reported_to, FIRST_LINE) || !"Added the first line again");
     assert(string_cmp(FIRST_LINE"\n"SECOND_LINE"\n"THIRD_LINE"\n", reported_to) || !"Modified the reported_to text not adding the first again");
 
-    assert(!add_reported_to_data(&reported_to, SECOND_LINE) || !"Added the second line again");
+    assert(!libreport_add_reported_to_data(&reported_to, SECOND_LINE) || !"Added the second line again");
     assert(string_cmp(FIRST_LINE"\n"SECOND_LINE"\n"THIRD_LINE"\n", reported_to) || !"Modified the reported_to text not adding the second again");
 
-    assert(!add_reported_to_data(&reported_to, THIRD_LINE) || !"Added the third line again");
+    assert(!libreport_add_reported_to_data(&reported_to, THIRD_LINE) || !"Added the third line again");
     assert(string_cmp(FIRST_LINE"\n"SECOND_LINE"\n"THIRD_LINE"\n", reported_to) || !"Modified the reported_to text not adding the second again");
 
     free(reported_to);
@@ -68,7 +68,7 @@ AT_TESTFUN([parse_reported_to_data],
 
 bool parse_and_check(const char *reported_to, GList *expected)
 {
-    GList *reports = read_entire_reported_to_data(reported_to);
+    GList *reports = libreport_read_entire_reported_to_data(reported_to);
 
     const unsigned expected_len = g_list_length(expected);
     const unsigned current_len = g_list_length(expected);
@@ -160,11 +160,11 @@ int main(void)
 }
 ]])
 
-## ------------------- ##
-## find_in_reported_to ##
-## ------------------- ##
+## ----------------------------- ##
+## libreport_find_in_reported_to ##
+## ----------------------------- ##
 
-AT_TESTFUN([find_in_reported_to],
+AT_TESTFUN([libreport_find_in_reported_to],
 [[
 #include "internal_libreport.h"
 
@@ -213,63 +213,63 @@ int main(void)
 #define SIXTH_LINE "RHTSupport: TIME=87654321 URL=https://bugzilla.redhat.com/ MSG=The world's biggest Bugzilla instance"
 
     {
-        report_result_t *found = find_in_reported_to_data(FIRST_LINE, "Bugzilla");
+        report_result_t *found = libreport_find_in_reported_to_data(FIRST_LINE, "Bugzilla");
         assert(found != NULL || !"Failed to find Bugzilla");
         assert(report_result_equals(found, first_result) || !"Failed to parse Bugzilla");
         report_result_free(found);
     }
 
     {
-        report_result_t *found = find_in_reported_to_data(SECOND_LINE, "ABRT Server");
+        report_result_t *found = libreport_find_in_reported_to_data(SECOND_LINE, "ABRT Server");
         assert(found != NULL || !"Failed to find ABRT Server");
         assert(report_result_equals(found, second_result) || !"Failed to parse ABRT Server");
         report_result_free(found);
     }
 
     {
-        report_result_t *found = find_in_reported_to_data(THIRD_LINE, "RHTSupport");
+        report_result_t *found = libreport_find_in_reported_to_data(THIRD_LINE, "RHTSupport");
         assert(found != NULL || !"Failed to find RHTSupport");
         assert(report_result_equals(found, third_result) || !"Failed to parse RHTSupport");
         report_result_free(found);
     }
 
     {
-        report_result_t *found = find_in_reported_to_data(FIRST_LINE"\n"FOURTH_LINE, "Bugzilla");
+        report_result_t *found = libreport_find_in_reported_to_data(FIRST_LINE"\n"FOURTH_LINE, "Bugzilla");
         assert(found != NULL || !"Failed to find the latest Bugzilla");
         assert(report_result_equals(found, fourth_result) || !"Failed to parse the latest Bugzilla");
         report_result_free(found);
     }
 
     {
-        report_result_t *found = find_in_reported_to_data(SECOND_LINE"\n"FIFTH_LINE, "ABRT Server");
+        report_result_t *found = libreport_find_in_reported_to_data(SECOND_LINE"\n"FIFTH_LINE, "ABRT Server");
         assert(found != NULL || !"Failed to find the latest ABRT Server");
         assert(report_result_equals(found, fifth_result) || !"Failed to parse the latest ABRT Server");
         report_result_free(found);
     }
 
     {
-        report_result_t *found = find_in_reported_to_data(THIRD_LINE"\n"SIXTH_LINE, "RHTSupport");
+        report_result_t *found = libreport_find_in_reported_to_data(THIRD_LINE"\n"SIXTH_LINE, "RHTSupport");
         assert(found != NULL || !"Failed to find the RHTSupport");
         assert(report_result_equals(found, sixth_result) || !"Failed to parse the latest RHTSupport");
         report_result_free(found);
     }
 
     {
-        report_result_t *found = find_in_reported_to_data(FIRST_LINE"\n"SECOND_LINE"\n"THIRD_LINE"\n"FOURTH_LINE"\n"FIFTH_LINE"\n"SIXTH_LINE, "Bugzilla");
+        report_result_t *found = libreport_find_in_reported_to_data(FIRST_LINE"\n"SECOND_LINE"\n"THIRD_LINE"\n"FOURTH_LINE"\n"FIFTH_LINE"\n"SIXTH_LINE, "Bugzilla");
         assert(found != NULL || !"Failed to find the latest Bugzilla from huge file");
         assert(report_result_equals(found, fourth_result) || !"Failed to parse the latest Bugzilla from huge file");
         report_result_free(found);
     }
 
     {
-        report_result_t *found = find_in_reported_to_data(FIRST_LINE"\n"SECOND_LINE"\n"THIRD_LINE"\n"FOURTH_LINE"\n"FIFTH_LINE"\n"SIXTH_LINE, "ABRT Server");
+        report_result_t *found = libreport_find_in_reported_to_data(FIRST_LINE"\n"SECOND_LINE"\n"THIRD_LINE"\n"FOURTH_LINE"\n"FIFTH_LINE"\n"SIXTH_LINE, "ABRT Server");
         assert(found != NULL || !"Failed to find the latest ABRT Server from huge file");
         assert(report_result_equals(found, fifth_result) || !"Failed to parse the latest ABRT Server from huge file");
         report_result_free(found);
     }
 
     {
-        report_result_t *found = find_in_reported_to_data(FIRST_LINE"\n"SECOND_LINE"\n"THIRD_LINE"\n"FOURTH_LINE"\n"FIFTH_LINE"\n"SIXTH_LINE, "RHTSupport");
+        report_result_t *found = libreport_find_in_reported_to_data(FIRST_LINE"\n"SECOND_LINE"\n"THIRD_LINE"\n"FOURTH_LINE"\n"FIFTH_LINE"\n"SIXTH_LINE, "RHTSupport");
         assert(found != NULL || !"Failed to find the RHTSupport from huge file");
         assert(report_result_equals(found, sixth_result) || !"Failed to parse the latest RHTSupport from huge file");
         report_result_free(found);

--- a/tests/sitem.at
+++ b/tests/sitem.at
@@ -44,7 +44,7 @@ int test()
 
 int main(void)
 {
-    glib_init();
+    libreport_glib_init();
 
     assert(test() == 0);
 
@@ -99,9 +99,9 @@ int test()
     const char *blacklist = "few,tex";
     const char *whitelist = "few,text";
     const char *whitelist_2 = "words";
-    GList *blacklist_in = parse_delimited_list(blacklist, ",");
-    GList *whitelist_in = parse_delimited_list(whitelist, ",");
-    GList *whitelist_not_in = parse_delimited_list(whitelist_2, ",");
+    GList *blacklist_in = libreport_parse_delimited_list(blacklist, ",");
+    GList *whitelist_in = libreport_parse_delimited_list(whitelist, ",");
+    GList *whitelist_not_in = libreport_parse_delimited_list(whitelist_2, ",");
 
     GList *blacklist_sitems = find_words_in_text_buffer(buffer, blacklist_in);
     GList *whitelist_sitems = find_words_in_text_buffer(buffer, whitelist_in);
@@ -142,7 +142,7 @@ int test()
 
 int main(void)
 {
-    glib_init();
+    libreport_glib_init();
 
     assert(test() == 0);
 

--- a/tests/strbuf.at
+++ b/tests/strbuf.at
@@ -2,39 +2,39 @@
 
 AT_BANNER([strbuf])
 
-## ---------------------- ##
-## strbuf_append_char ##
-## ---------------------- ##
+## ---------------------------- ##
+## libreport_strbuf_append_char ##
+## ---------------------------- ##
 
-AT_TESTFUN([strbuf_append_char],
+AT_TESTFUN([libreport_strbuf_append_char],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
 int main(void)
 {
   int i;
-  struct strbuf *strbuf = strbuf_new();
+  struct strbuf *strbuf = libreport_strbuf_new();
   for (i = 0; i < 100; ++i)
   {
     assert(strbuf->len == i);
     assert(strbuf->alloc > strbuf->len);
     assert(strbuf->buf[i] == '\0');
-    strbuf_append_char(strbuf, 'a');
+    libreport_strbuf_append_char(strbuf, 'a');
     assert(strbuf->buf[i] == 'a');
     assert(strbuf->buf[i+1] == '\0');
     assert(strbuf->len == i + 1);
     assert(strbuf->alloc > strbuf->len);
   }
-  strbuf_free(strbuf);
+  libreport_strbuf_free(strbuf);
   return 0;
 }
 ]])
 
-## --------------------- ##
-## strbuf_append_str ##
-## --------------------- ##
+## --------------------------- ##
+## libreport_strbuf_append_str ##
+## --------------------------- ##
 
-AT_TESTFUN([strbuf_append_str],
+AT_TESTFUN([libreport_strbuf_append_str],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
@@ -48,19 +48,19 @@ void test(int len)
     str[i] = 'a';
   str[i] = '\0';
 
-  struct strbuf *strbuf = strbuf_new();
+  struct strbuf *strbuf = libreport_strbuf_new();
   for (i = 0; i < 100; ++i)
   {
     assert(strbuf->len == i*len);
     assert(strbuf->alloc > strbuf->len);
     assert(strbuf->buf[i*len] == '\0');
-    strbuf_append_str(strbuf, str);
+    libreport_strbuf_append_str(strbuf, str);
     assert(strbuf->buf[i*len] == str[0]);
     assert(strbuf->buf[i*len+len] == '\0');
     assert(strbuf->len == i*len + len);
     assert(strbuf->alloc > strbuf->len);
   }
-  strbuf_free(strbuf);
+  libreport_strbuf_free(strbuf);
 }
 
 int main(void)
@@ -73,11 +73,11 @@ int main(void)
 ]])
 
 
-## ----------- ##
-## strremovech ##
-## ----------- ##
+## --------------------- ##
+## libreport_strremovech ##
+## --------------------- ##
 
-AT_TESTFUN([strremovech],
+AT_TESTFUN([libreport_strremovech],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
@@ -85,7 +85,7 @@ int main(void)
 {
     char test[] = "Hello , world!";
 
-    if (strcmp(strremovech(test, ' '), "Hello,world!") != 0)
+    if (strcmp(libreport_strremovech(test, ' '), "Hello,world!") != 0)
     {
         fprintf(stderr, "Expected: 'Hello,world!'\nResult  : '%s'", test);
         assert(!"Failed to remove space");

--- a/tests/string_list.at
+++ b/tests/string_list.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([string_list])
 
-## ----------------------- ##
-## index_of_string_in_list ##
-## ----------------------- ##
+## --------------------------------- ##
+## libreport_index_of_string_in_list ##
+## --------------------------------- ##
 
-AT_TESTFUN([index_of_string_in_list],
+AT_TESTFUN([libreport_index_of_string_in_list],
 [[
 #include "internal_libreport.h"
 #include <assert.h>
@@ -22,13 +22,13 @@ int main(void)
             NULL
     };
 
-    int index = index_of_string_in_list(FILENAME_REASON, (char**) list_order);
+    int index = libreport_index_of_string_in_list(FILENAME_REASON, (char**) list_order);
     assert(index == 0);
 
-    index = index_of_string_in_list(FILENAME_COUNT, (char**) list_order);
+    index = libreport_index_of_string_in_list(FILENAME_COUNT, (char**) list_order);
     assert(index == 5);
 
-    index = index_of_string_in_list("other", (char**) list_order);
+    index = libreport_index_of_string_in_list("other", (char**) list_order);
     assert(index < 0);
 
     return 0;

--- a/tests/taghyperlinks.at
+++ b/tests/taghyperlinks.at
@@ -2,9 +2,9 @@
 
 AT_BANNER([tag hyperlinks])
 
-## ---------------------- ##
-## parse_release_for_bz ##
-## ---------------------- ##
+## ------------------------------ ##
+## libreport_parse_release_for_bz ##
+## ------------------------------ ##
 
 AT_TESTFUN([gtk_labels],
 [[

--- a/tests/ureport.at
+++ b/tests/ureport.at
@@ -122,7 +122,7 @@ int main(void)
     setenv("uReport_IncludeAuthData", "no", 1);
     setenv("uReport_AuthDataItems", "hostname", 1);
 
-    map_string_t *settings = new_map_string();
+    map_string_t *settings = libreport_new_map_string();
 
     ureport_server_config_load(&config, settings);
 
@@ -199,13 +199,13 @@ int main(void)
     assert(l == NULL);
 
     ureport_server_config_destroy(&config);
-    free_map_string(settings);
+    libreport_free_map_string(settings);
 
     /* value from settings */
     /* IncludeAuthData set to 'yes' but AuthDataItems is empty. */
     ureport_server_config_init(&config);
 
-    settings = new_map_string();
+    settings = libreport_new_map_string();
     insert_map_string(settings, libreport_xstrdup("URL"), libreport_xstrdup("settings_url"));
     insert_map_string(settings, libreport_xstrdup("SSLVerify"), libreport_xstrdup("yes"));
     insert_map_string(settings, libreport_xstrdup("SSLClientAuth"), libreport_xstrdup(""));
@@ -221,13 +221,13 @@ int main(void)
     assert(l == NULL);
 
     ureport_server_config_destroy(&config);
-    free_map_string(settings);
+    libreport_free_map_string(settings);
 
     /* value from settings */
     /* IncludeAuthData set to 'yes' */
     ureport_server_config_init(&config);
 
-    settings = new_map_string();
+    settings = libreport_new_map_string();
     insert_map_string(settings, libreport_xstrdup("URL"), libreport_xstrdup("settings_url"));
     insert_map_string(settings, libreport_xstrdup("SSLVerify"), libreport_xstrdup("no"));
     insert_map_string(settings, libreport_xstrdup("SSLClientAuth"), libreport_xstrdup(""));
@@ -244,14 +244,14 @@ int main(void)
     assert(strcmp(l->next->data, "type") == 0);
 
     ureport_server_config_destroy(&config);
-    free_map_string(settings);
+    libreport_free_map_string(settings);
 
     /* value from env */
     /* HTTPAuth set to 'username:password' */
     /* SSLClientAuth set to 'rhsm' */
     ureport_server_config_init(&config);
 
-    settings = new_map_string();
+    settings = libreport_new_map_string();
 
     setenv("uReport_SSLClientAuth", "rhsm", 1);
     setenv("uReport_HTTPAuth", "username:password", 1);
@@ -277,7 +277,7 @@ int main(void)
     unsetenv("uReport_HTTPAuth");
     unsetenv("uReport_AuthDataItems");
 
-    free_map_string(settings);
+    libreport_free_map_string(settings);
 
     ureport_server_config_destroy(&config);
 
@@ -286,7 +286,7 @@ int main(void)
     /* SSLClientAuth set to 'rhsm' */
     ureport_server_config_init(&config);
 
-    settings = new_map_string();
+    settings = libreport_new_map_string();
     insert_map_string(settings, libreport_xstrdup("SSLClientAuth"), libreport_xstrdup("rhsm"));
     insert_map_string(settings, libreport_xstrdup("HTTPAuth"), libreport_xstrdup("rhn-username:rhn-password"));
     insert_map_string(settings, libreport_xstrdup("AuthDataItems"), libreport_xstrdup("hostname, type"));
@@ -307,7 +307,7 @@ int main(void)
 
     unsetenv("LIBREPORT_DEBUG_RHSMCON_PEM_DIR_PATH");
 
-    free_map_string(settings);
+    libreport_free_map_string(settings);
 
     ureport_server_config_destroy(&config);
 
@@ -1124,7 +1124,7 @@ int main(void)
     struct ureport_server_config config;
     ureport_server_config_init(&config);
 
-    map_string_t *settings = new_map_string();
+    map_string_t *settings = libreport_new_map_string();
 
     setenv("uReport_IncludeAuthData", "yes", 1);
     setenv("uReport_AuthDataItems", "hostname", 1);
@@ -1137,12 +1137,12 @@ int main(void)
     free(ureport);
 
     ureport_server_config_destroy(&config);
-    free_map_string(settings);
+    libreport_free_map_string(settings);
 
     /* auth with unknown uReport_AuthDataItems */
     ureport_server_config_init(&config);
 
-    settings = new_map_string();
+    settings = libreport_new_map_string();
 
     setenv("uReport_AuthDataItems", "hostname, unknown", 1);
 
@@ -1155,7 +1155,7 @@ int main(void)
     free(ureport);
 
     ureport_server_config_destroy(&config);
-    free_map_string(settings);
+    libreport_free_map_string(settings);
     delete_dump_dir("./test");
 
     return 0;

--- a/tests/ureport.at
+++ b/tests/ureport.at
@@ -16,7 +16,7 @@ AT_TESTFUN([ureport_server_config_init],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     struct ureport_server_config config;
     ureport_server_config_init(&config);
@@ -65,7 +65,7 @@ AT_TESTFUN([ureport_server_config_destroy],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     struct ureport_server_config config;
     ureport_server_config_init(&config);
@@ -109,7 +109,7 @@ AT_TESTFUN([ureport_server_config_load],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     /* value from env */
     /* IncludeAuthData set to 'no' */
@@ -184,11 +184,11 @@ int main(void)
     unsetenv("uReport_IncludeAuthData");
     unsetenv("uReport_AuthDataItems");
 
-    insert_map_string(settings, xstrdup("URL"), xstrdup("settings_url"));
-    insert_map_string(settings, xstrdup("SSLVerify"), xstrdup("yes"));
-    insert_map_string(settings, xstrdup("SSLClientAuth"), xstrdup(""));
-    insert_map_string(settings, xstrdup("IncludeAuthData"), xstrdup("no"));
-    insert_map_string(settings, xstrdup("AuthDataItems"), xstrdup("hostname"));
+    insert_map_string(settings, libreport_xstrdup("URL"), libreport_xstrdup("settings_url"));
+    insert_map_string(settings, libreport_xstrdup("SSLVerify"), libreport_xstrdup("yes"));
+    insert_map_string(settings, libreport_xstrdup("SSLClientAuth"), libreport_xstrdup(""));
+    insert_map_string(settings, libreport_xstrdup("IncludeAuthData"), libreport_xstrdup("no"));
+    insert_map_string(settings, libreport_xstrdup("AuthDataItems"), libreport_xstrdup("hostname"));
 
     ureport_server_config_load(&config, settings);
 
@@ -206,11 +206,11 @@ int main(void)
     ureport_server_config_init(&config);
 
     settings = new_map_string();
-    insert_map_string(settings, xstrdup("URL"), xstrdup("settings_url"));
-    insert_map_string(settings, xstrdup("SSLVerify"), xstrdup("yes"));
-    insert_map_string(settings, xstrdup("SSLClientAuth"), xstrdup(""));
-    insert_map_string(settings, xstrdup("IncludeAuthData"), xstrdup("yes"));
-    insert_map_string(settings, xstrdup("AuthDataItems"), xstrdup(""));
+    insert_map_string(settings, libreport_xstrdup("URL"), libreport_xstrdup("settings_url"));
+    insert_map_string(settings, libreport_xstrdup("SSLVerify"), libreport_xstrdup("yes"));
+    insert_map_string(settings, libreport_xstrdup("SSLClientAuth"), libreport_xstrdup(""));
+    insert_map_string(settings, libreport_xstrdup("IncludeAuthData"), libreport_xstrdup("yes"));
+    insert_map_string(settings, libreport_xstrdup("AuthDataItems"), libreport_xstrdup(""));
 
     ureport_server_config_load(&config, settings);
 
@@ -228,11 +228,11 @@ int main(void)
     ureport_server_config_init(&config);
 
     settings = new_map_string();
-    insert_map_string(settings, xstrdup("URL"), xstrdup("settings_url"));
-    insert_map_string(settings, xstrdup("SSLVerify"), xstrdup("no"));
-    insert_map_string(settings, xstrdup("SSLClientAuth"), xstrdup(""));
-    insert_map_string(settings, xstrdup("IncludeAuthData"), xstrdup("yes"));
-    insert_map_string(settings, xstrdup("AuthDataItems"), xstrdup("hostname, type"));
+    insert_map_string(settings, libreport_xstrdup("URL"), libreport_xstrdup("settings_url"));
+    insert_map_string(settings, libreport_xstrdup("SSLVerify"), libreport_xstrdup("no"));
+    insert_map_string(settings, libreport_xstrdup("SSLClientAuth"), libreport_xstrdup(""));
+    insert_map_string(settings, libreport_xstrdup("IncludeAuthData"), libreport_xstrdup("yes"));
+    insert_map_string(settings, libreport_xstrdup("AuthDataItems"), libreport_xstrdup("hostname, type"));
 
     ureport_server_config_load(&config, settings);
 
@@ -287,9 +287,9 @@ int main(void)
     ureport_server_config_init(&config);
 
     settings = new_map_string();
-    insert_map_string(settings, xstrdup("SSLClientAuth"), xstrdup("rhsm"));
-    insert_map_string(settings, xstrdup("HTTPAuth"), xstrdup("rhn-username:rhn-password"));
-    insert_map_string(settings, xstrdup("AuthDataItems"), xstrdup("hostname, type"));
+    insert_map_string(settings, libreport_xstrdup("SSLClientAuth"), libreport_xstrdup("rhsm"));
+    insert_map_string(settings, libreport_xstrdup("HTTPAuth"), libreport_xstrdup("rhn-username:rhn-password"));
+    insert_map_string(settings, libreport_xstrdup("AuthDataItems"), libreport_xstrdup("hostname, type"));
 
     setenv("LIBREPORT_DEBUG_RHSMCON_PEM_DIR_PATH", TESTING_CERTS_CORRECT_DIR_PATH, 1);
 
@@ -330,7 +330,7 @@ AT_TESTFUN([ureport_server_config_set_url],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     struct ureport_server_config config;
     ureport_server_config_init(&config);
@@ -475,7 +475,7 @@ int test_ureport_server_config_set_client_auth_exit_code(struct ureport_server_c
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     struct ureport_server_config config;
     ureport_server_config_init(&config);
@@ -660,7 +660,7 @@ void assert_ureport_server_config(struct ureport_server_config *config,
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     struct ureport_server_config config;
     ureport_server_config_init(&config);
@@ -776,7 +776,7 @@ AT_TESTFUN([ureport_server_response_save_in_dump_dir],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     /* reported to*/
     struct post_state ps;
@@ -888,7 +888,7 @@ AT_TESTFUN([ureport_server_response_get_report_url],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     /* reported to*/
     struct post_state ps;
@@ -909,8 +909,8 @@ int main(void)
 
     char *report_url = ureport_server_response_get_report_url(response, &config);
 
-    char *expect_bthash_url = concat_path_file(config.ur_url, BTHASH_URL_SFX);
-    char *expect_report_url = concat_path_file(expect_bthash_url, response->urr_bthash);
+    char *expect_bthash_url = libreport_concat_path_file(config.ur_url, BTHASH_URL_SFX);
+    char *expect_report_url = libreport_concat_path_file(expect_bthash_url, response->urr_bthash);
     free(expect_bthash_url);
 
     assert(strcmp(report_url, expect_report_url) == 0);
@@ -938,7 +938,7 @@ AT_TESTFUN([ureport_do_post],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     struct dump_dir *dd = dd_create("./test", (uid_t)-1L, DEFAULT_DUMP_DIR_MODE);
     assert(dd != NULL);
@@ -986,7 +986,7 @@ AT_TESTFUN([ureport_submit],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     struct dump_dir *dd = dd_create("./test", (uid_t)-1L, DEFAULT_DUMP_DIR_MODE);
     assert(dd != NULL);
@@ -1035,7 +1035,7 @@ AT_TESTFUN([ureport_json_attachment_new],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     char *json = ureport_json_attachment_new("data_bthash", "data_type", "data_data");
     assert(strcmp(json, "{ \"bthash\": \"data_bthash\", \"type\": \"data_type\", \"data\": \"data_data\" }") == 0);
@@ -1063,7 +1063,7 @@ AT_TESTFUN([ureport_attach_string],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     struct ureport_server_config config;
     ureport_server_config_init(&config);
@@ -1094,7 +1094,7 @@ AT_TESTFUN([ureport_from_dump_dir_ext],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     struct dump_dir *dd = dd_create("./test", (uid_t)-1L, DEFAULT_DUMP_DIR_MODE);
     assert(dd != NULL);
@@ -1179,7 +1179,7 @@ AT_TESTFUN([ureport_server_config_load_basic_auth],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     {
         struct ureport_server_config config;

--- a/tests/ureport.at
+++ b/tests/ureport.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([ureport])
 
-## ---------------------------- ##
-##  ureport_server_config_init  ##
-## ---------------------------- ##
+## -------------------------------------- ##
+##  libreport_ureport_server_config_init  ##
+## -------------------------------------- ##
 
-AT_TESTFUN([ureport_server_config_init],
+AT_TESTFUN([libreport_ureport_server_config_init],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -19,7 +19,7 @@ int main(void)
     libreport_g_verbose=3;
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     assert(config.ur_url == NULL);
     assert(config.ur_ssl_verify == true);
@@ -37,7 +37,7 @@ int main(void)
     config.ur_password = (char *)"password";
     config.ur_prefs.urp_auth_items = DESTROYED_POINTER;
 
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     assert(config.ur_url == NULL);
     assert(config.ur_ssl_verify == true);
@@ -51,11 +51,11 @@ int main(void)
 }
 ]])
 
-## ------------------------------- ##
-##  ureport_server_config_destroy  ##
-## ------------------------------- ##
+## ----------------------------------------- ##
+##  libreport_ureport_server_config_destroy  ##
+## ----------------------------------------- ##
 
-AT_TESTFUN([ureport_server_config_destroy],
+AT_TESTFUN([libreport_ureport_server_config_destroy],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -68,7 +68,7 @@ int main(void)
     libreport_g_verbose=3;
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     config.ur_url = strdup("url");
     config.ur_client_cert = strdup("cert");
@@ -82,7 +82,7 @@ int main(void)
     assert(strcmp(config.ur_username, "username") == 0);
     assert(strcmp(config.ur_password , "password") == 0);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     assert(config.ur_url == DESTROYED_POINTER);
     assert(config.ur_client_cert == DESTROYED_POINTER);
@@ -95,11 +95,11 @@ int main(void)
 }
 ]])
 
-## ---------------------------- ##
-##  ureport_server_config_load  ##
-## ---------------------------- ##
+## -------------------------------------- ##
+##  libreport_ureport_server_config_load  ##
+## -------------------------------------- ##
 
-AT_TESTFUN([ureport_server_config_load],
+AT_TESTFUN([libreport_ureport_server_config_load],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -114,7 +114,7 @@ int main(void)
     /* value from env */
     /* IncludeAuthData set to 'no' */
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     setenv("uReport_URL", "env_url", 1);
     setenv("uReport_SSLVerify", "yes", 1);
@@ -124,7 +124,7 @@ int main(void)
 
     map_string_t *settings = libreport_new_map_string();
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
     assert(strcmp(config.ur_url, "env_url") == 0);
     assert(config.ur_ssl_verify == true);
@@ -132,11 +132,11 @@ int main(void)
     GList *l = config.ur_prefs.urp_auth_items;
     assert(l == NULL);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     /* value from env */
     /* IncludeAuthData set to 'yes' but AuthDataItems is empty. */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     setenv("uReport_URL", "env_url", 1);
     setenv("uReport_SSLVerify", "yes", 1);
@@ -144,7 +144,7 @@ int main(void)
     setenv("uReport_IncludeAuthData", "yes", 1);
     setenv("uReport_AuthDataItems", "", 1);
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
     assert(strcmp(config.ur_url, "env_url") == 0);
     assert(config.ur_ssl_verify == true);
@@ -152,11 +152,11 @@ int main(void)
     l = config.ur_prefs.urp_auth_items;
     assert(l == NULL);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     /* value from env */
     /* IncludeAuthData set to 'yes' */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     setenv("uReport_URL", "env_url", 1);
     setenv("uReport_SSLVerify", "no", 1);
@@ -164,7 +164,7 @@ int main(void)
     setenv("uReport_IncludeAuthData", "yes", 1);
     setenv("uReport_AuthDataItems", "hostname, time", 1);
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
     assert(strcmp(config.ur_url, "env_url") == 0);
     assert(config.ur_ssl_verify == false);
@@ -173,11 +173,11 @@ int main(void)
     assert(strcmp(l->data, "hostname") == 0);
     assert(strcmp(l->next->data, "time") == 0);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     /* value from settings */
     /* IncludeAuthData set to 'no' */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     unsetenv("uReport_URL");
     unsetenv("uReport_SSLVerify");
@@ -190,7 +190,7 @@ int main(void)
     insert_map_string(settings, libreport_xstrdup("IncludeAuthData"), libreport_xstrdup("no"));
     insert_map_string(settings, libreport_xstrdup("AuthDataItems"), libreport_xstrdup("hostname"));
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
     assert(strcmp(config.ur_url, "settings_url") == 0);
     assert(config.ur_ssl_verify == true);
@@ -198,12 +198,12 @@ int main(void)
     l = config.ur_prefs.urp_auth_items;
     assert(l == NULL);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
     libreport_free_map_string(settings);
 
     /* value from settings */
     /* IncludeAuthData set to 'yes' but AuthDataItems is empty. */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     settings = libreport_new_map_string();
     insert_map_string(settings, libreport_xstrdup("URL"), libreport_xstrdup("settings_url"));
@@ -212,7 +212,7 @@ int main(void)
     insert_map_string(settings, libreport_xstrdup("IncludeAuthData"), libreport_xstrdup("yes"));
     insert_map_string(settings, libreport_xstrdup("AuthDataItems"), libreport_xstrdup(""));
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
     assert(strcmp(config.ur_url, "settings_url") == 0);
     assert(config.ur_ssl_verify == true);
@@ -220,12 +220,12 @@ int main(void)
     l = config.ur_prefs.urp_auth_items;
     assert(l == NULL);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
     libreport_free_map_string(settings);
 
     /* value from settings */
     /* IncludeAuthData set to 'yes' */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     settings = libreport_new_map_string();
     insert_map_string(settings, libreport_xstrdup("URL"), libreport_xstrdup("settings_url"));
@@ -234,7 +234,7 @@ int main(void)
     insert_map_string(settings, libreport_xstrdup("IncludeAuthData"), libreport_xstrdup("yes"));
     insert_map_string(settings, libreport_xstrdup("AuthDataItems"), libreport_xstrdup("hostname, type"));
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
     assert(strcmp(config.ur_url, "settings_url") == 0);
     assert(config.ur_ssl_verify == false);
@@ -243,13 +243,13 @@ int main(void)
     assert(strcmp(l->data, "hostname") == 0);
     assert(strcmp(l->next->data, "type") == 0);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
     libreport_free_map_string(settings);
 
     /* value from env */
     /* HTTPAuth set to 'username:password' */
     /* SSLClientAuth set to 'rhsm' */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     settings = libreport_new_map_string();
 
@@ -259,7 +259,7 @@ int main(void)
 
     setenv("LIBREPORT_DEBUG_RHSMCON_PEM_DIR_PATH", TESTING_CERTS_CORRECT_DIR_PATH, 1);
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
     assert(strcmp(config.ur_username, "username") == 0);
     assert(strcmp(config.ur_password, "password") == 0);
@@ -279,12 +279,12 @@ int main(void)
 
     libreport_free_map_string(settings);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     /* value from settings */
     /* HTTPAuth set to 'username:password' */
     /* SSLClientAuth set to 'rhsm' */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     settings = libreport_new_map_string();
     insert_map_string(settings, libreport_xstrdup("SSLClientAuth"), libreport_xstrdup("rhsm"));
@@ -293,7 +293,7 @@ int main(void)
 
     setenv("LIBREPORT_DEBUG_RHSMCON_PEM_DIR_PATH", TESTING_CERTS_CORRECT_DIR_PATH, 1);
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
     assert(strcmp(config.ur_username, "rhn-username") == 0);
     assert(strcmp(config.ur_password, "rhn-password") == 0);
@@ -309,18 +309,18 @@ int main(void)
 
     libreport_free_map_string(settings);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     return 0;
 }
 ]])
 
 
-## ------------------------------- ##
-##  ureport_server_config_set_url  ##
-## ------------------------------- ##
+## ----------------------------------------- ##
+##  libreport_ureport_server_config_set_url  ##
+## ----------------------------------------- ##
 
-AT_TESTFUN([ureport_server_config_set_url],
+AT_TESTFUN([libreport_ureport_server_config_set_url],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -333,27 +333,27 @@ int main(void)
     libreport_g_verbose=3;
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
-    ureport_server_config_set_url(&config, strdup("url"));
+    libreport_ureport_server_config_set_url(&config, strdup("url"));
 
     assert(strcmp(config.ur_url, "url") == 0);
 
-    ureport_server_config_set_url(&config, strdup("next.url"));
+    libreport_ureport_server_config_set_url(&config, strdup("next.url"));
 
     assert(strcmp(config.ur_url, "next.url") == 0);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     return 0;
 }
 ]])
 
-## --------------------------------------- ##
-##  ureport_server_config_set_client_auth  ##
-## --------------------------------------- ##
+## ------------------------------------------------- ##
+##  libreport_ureport_server_config_set_client_auth  ##
+## ------------------------------------------------- ##
 
-AT_TESTFUN([ureport_server_config_set_client_auth],
+AT_TESTFUN([libreport_ureport_server_config_set_client_auth],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -443,7 +443,7 @@ int test_ureport_server_config_set_client_auth_exit_code_ext(struct ureport_serv
                                                              const char *cert_file,
                                                              const char *key_file)
 {
-    ureport_server_config_init(config);
+    libreport_ureport_server_config_init(config);
 
     pid_t pid = fork();
     if (pid < 0)
@@ -454,7 +454,7 @@ int test_ureport_server_config_set_client_auth_exit_code_ext(struct ureport_serv
 
     if (pid == 0)
     {
-        ureport_server_config_set_client_auth(config, client_auth);
+        libreport_ureport_server_config_set_client_auth(config, client_auth);
         assert((cert_file == (void *)-1) || (cert_file == NULL && config->ur_client_cert == NULL) || (strcmp(cert_file, config->ur_client_cert) == 0));
         assert((key_file == (void *)-1) || (key_file == NULL && config->ur_client_cert == NULL) || (strcmp(key_file, config->ur_client_key) == 0));
         exit(0);
@@ -462,7 +462,7 @@ int test_ureport_server_config_set_client_auth_exit_code_ext(struct ureport_serv
     int status;
     wait(&status);
 
-    ureport_server_config_destroy(config);
+    libreport_ureport_server_config_destroy(config);
 
     return status;
 }
@@ -478,21 +478,21 @@ int main(void)
     libreport_g_verbose=3;
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
-    ureport_server_config_set_client_auth(&config, NULL);
+    libreport_ureport_server_config_set_client_auth(&config, NULL);
 
     set_ureport_server_config(&config, "url", true, "cert", "key", "username", "passwd");
 
     /* client_auth == NULL */
-    ureport_server_config_set_client_auth(&config, NULL);
+    libreport_ureport_server_config_set_client_auth(&config, NULL);
     assert_ureport_server_config(&config, "url", true, "cert", "key", "username", "passwd");
 
     /* client_auth == "" */
-    ureport_server_config_set_client_auth(&config, "");
+    libreport_ureport_server_config_set_client_auth(&config, "");
     assert_ureport_server_config(&config, "url", true, NULL, NULL, "username", "passwd");
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     /* client_auth == rhsm */
     /* ur_url == NULL */
@@ -527,36 +527,36 @@ int main(void)
     /* client_auth == rhsm */
     /* ur_url == NULL */
     /* certs exists (correct) */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     setenv("LIBREPORT_DEBUG_RHSMCON_PEM_DIR_PATH", TESTING_CERTS_CORRECT_DIR_PATH, 1);
 
-    ureport_server_config_set_client_auth(&config, "rhsm");
+    libreport_ureport_server_config_set_client_auth(&config, "rhsm");
 
     assert_ureport_server_config(&config, RHSM_WEB_SERVICE_URL, true,
                                 TESTING_CERTS_CORRECT_DIR_PATH"/cert.pem",
                                 TESTING_CERTS_CORRECT_DIR_PATH"/key.pem",
                                 NULL, NULL);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     /* client_auth == cert:key */
     /* ur_url == NULL */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
     set_ureport_server_config(&config, NULL, true, NULL, NULL, "username", "passwd");
-    ureport_server_config_set_client_auth(&config, "cert:key");
+    libreport_ureport_server_config_set_client_auth(&config, "cert:key");
     assert_ureport_server_config(&config, NULL, true, "cert", "key", NULL, NULL);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     /* client_auth == cert:key */
     /* ur_url != NULL */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
     set_ureport_server_config(&config, "url", true, NULL, NULL, "username", "passwd");
-    ureport_server_config_set_client_auth(&config, "cert:key");
+    libreport_ureport_server_config_set_client_auth(&config, "cert:key");
     assert_ureport_server_config(&config, "url", true, "cert", "key", NULL, NULL);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     /* wrong client_auth */
     int ret_val = test_ureport_server_config_set_client_auth_exit_code(&config, "cert:");
@@ -571,8 +571,8 @@ int main(void)
     unsetenv("LIBREPORT_DEBUG_RHSMCON_PEM_DIR_PATH");
     setenv("PYTHONPATH", TESTING_PYTHONPATH, 1);
 
-    ureport_server_config_init(&config);
-    ureport_server_config_set_client_auth(&config, "rhsm");
+    libreport_ureport_server_config_init(&config);
+    libreport_ureport_server_config_set_client_auth(&config, "rhsm");
 
     char *abs_path_cert = realpath(TESTING_CERTS_CORRECT_DIR_PATH"/cert.pem", NULL);
     char *abs_path_key = realpath(TESTING_CERTS_CORRECT_DIR_PATH"/key.pem", NULL);
@@ -584,12 +584,12 @@ int main(void)
     free(abs_path_cert);
     free(abs_path_key);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     /* python script fails, '/etc/pki/consumer' is returned  */
 
     /* set cert dir path to '/etc/pki/consumer' */
-    /* store return value of ureport_server_config_set_client_auth */
+    /* store return value of libreport_ureport_server_config_set_client_auth */
     setenv("LIBREPORT_DEBUG_RHSMCON_PEM_DIR_PATH", RHSMCON_PEM_DIR_PATH, 1);
 
     int exp_ret_val = test_ureport_server_config_set_client_auth_exit_code(&config, "rhsm");
@@ -608,11 +608,11 @@ int main(void)
 }
 ]])
 
-## -------------------------------------- ##
-##  ureport_server_config_set_basic_auth  ##
-## -------------------------------------- ##
+## ------------------------------------------------ ##
+##  libreport_ureport_server_config_set_basic_auth  ##
+## ------------------------------------------------ ##
 
-AT_TESTFUN([ureport_server_config_set_basic_auth],
+AT_TESTFUN([libreport_ureport_server_config_set_basic_auth],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -663,29 +663,29 @@ int main(void)
     libreport_g_verbose=3;
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
-    ureport_server_config_set_basic_auth(&config, NULL, NULL);
+    libreport_ureport_server_config_set_basic_auth(&config, NULL, NULL);
     assert_ureport_server_config(&config, NULL, true, NULL, NULL, NULL, NULL);
 
-    ureport_server_config_set_basic_auth(&config, "usr", NULL);
+    libreport_ureport_server_config_set_basic_auth(&config, "usr", NULL);
     assert_ureport_server_config(&config, NULL, true, NULL, NULL, "usr", NULL);
 
-    ureport_server_config_set_basic_auth(&config, NULL, "passwd");
+    libreport_ureport_server_config_set_basic_auth(&config, NULL, "passwd");
     assert_ureport_server_config(&config, NULL, true, NULL, NULL, NULL, "passwd");
 
-    ureport_server_config_set_basic_auth(&config, "usr", "passwd");
+    libreport_ureport_server_config_set_basic_auth(&config, "usr", "passwd");
     assert_ureport_server_config(&config, NULL, true, NULL, NULL, "usr", "passwd");
 
     return 0;
 }
 ]])
 
-## ------------------------------------ ##
-##  ureport_server_response_from_reply  ##
-## ------------------------------------ ##
+## ---------------------------------------------- ##
+##  libreport_ureport_server_response_from_reply  ##
+## ---------------------------------------------- ##
 
-AT_TESTFUN([ureport_server_response_from_reply],
+AT_TESTFUN([libreport_ureport_server_response_from_reply],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -705,38 +705,38 @@ int main(void)
     ps.body = (char *)"body";
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
-    ureport_server_config_set_url(&config, strdup("url"));
+    libreport_ureport_server_config_set_url(&config, strdup("url"));
 
-    assert(ureport_server_response_from_reply(&ps, &config) == NULL);
+    assert(libreport_ureport_server_response_from_reply(&ps, &config) == NULL);
 
     /* curl_resul is CURLE_OK */
     /* http_resp_code == 404 */
     ps.curl_result = CURLE_OK;
     ps.http_resp_code = 404;
 
-    assert(ureport_server_response_from_reply(&ps, &config) == NULL);
+    assert(libreport_ureport_server_response_from_reply(&ps, &config) == NULL);
 
     ps.http_resp_code = 500;
-    assert(ureport_server_response_from_reply(&ps, &config) == NULL);
+    assert(libreport_ureport_server_response_from_reply(&ps, &config) == NULL);
 
     ps.http_resp_code = 503;
-    assert(ureport_server_response_from_reply(&ps, &config) == NULL);
+    assert(libreport_ureport_server_response_from_reply(&ps, &config) == NULL);
 
     ps.http_resp_code = 404;
-    assert(ureport_server_response_from_reply(&ps, &config) == NULL);
+    assert(libreport_ureport_server_response_from_reply(&ps, &config) == NULL);
 
     ps.http_resp_code = 201;
-    assert(ureport_server_response_from_reply(&ps, &config) == NULL);
+    assert(libreport_ureport_server_response_from_reply(&ps, &config) == NULL);
 
     /* unable parse json */
     ps.http_resp_code = 202;
-    assert(ureport_server_response_from_reply(&ps, &config) == NULL);
+    assert(libreport_ureport_server_response_from_reply(&ps, &config) == NULL);
 
     /* correct json && invalid format */
     ps.body = (char *)"{ \"resultxxxxxxxx\" : true }";
-    assert(ureport_server_response_from_reply(&ps, &config) == NULL);
+    assert(libreport_ureport_server_response_from_reply(&ps, &config) == NULL);
 
     /* correct json && valid format */
     ps.body = (char *)"{ 'result' : true, \
@@ -746,7 +746,7 @@ int main(void)
                          'value': 'value', \
                          'reporter': 'ABRT Server' } ] }";
 
-    struct ureport_server_response *response = ureport_server_response_from_reply(&ps, &config);
+    struct ureport_server_response *response = libreport_ureport_server_response_from_reply(&ps, &config);
     assert(strcmp(response->urr_value, "true") == 0);
     assert(strcmp(response->urr_message, "message") == 0);
     assert(strcmp(response->urr_bthash, "691cf824e3e07457156125636e86c50279e29496") == 0);
@@ -754,18 +754,18 @@ int main(void)
     GList *urr_reported_to_list = response->urr_reported_to_list;
     assert(strcmp(urr_reported_to_list->data, "ABRT Server: URL=value") == 0);
 
-    ureport_server_response_free(response);
+    libreport_ureport_server_response_free(response);
 
     return 0;
 
 }
 ]])
 
-## ----------------------------------------- ##
-##  ureport_server_response_save_in_dump_dir ##
-## ----------------------------------------- ##
+## --------------------------------------------------- ##
+##  libreport_ureport_server_response_save_in_dump_dir ##
+## --------------------------------------------------- ##
 
-AT_TESTFUN([ureport_server_response_save_in_dump_dir],
+AT_TESTFUN([libreport_ureport_server_response_save_in_dump_dir],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -790,8 +790,8 @@ int main(void)
                          'reporter': 'ABRT Server' } ] }";
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
-    ureport_server_config_set_url(&config, strdup("url"));
+    libreport_ureport_server_config_init(&config);
+    libreport_ureport_server_config_set_url(&config, strdup("url"));
 
     struct dump_dir *dd = dd_create("./test", (uid_t)-1L, DEFAULT_DUMP_DIR_MODE);
     assert(dd != NULL);
@@ -800,11 +800,11 @@ int main(void)
     dd_save_text(dd, FILENAME_COUNT, "1");
     dd_close(dd);
 
-    struct ureport_server_response *response = ureport_server_response_from_reply(&ps, &config);
-    assert(ureport_server_response_save_in_dump_dir(response, "./test", &config));
+    struct ureport_server_response *response = libreport_ureport_server_response_from_reply(&ps, &config);
+    assert(libreport_ureport_server_response_save_in_dump_dir(response, "./test", &config));
 
     /* dump dir do not exist */
-    assert(false == ureport_server_response_save_in_dump_dir(response, "not_existing_dir", &config));
+    assert(false == libreport_ureport_server_response_save_in_dump_dir(response, "not_existing_dir", &config));
 
     dd = dd_opendir("./test", 0);
     char *reported_to = dd_load_text_ext(dd, FILENAME_REPORTED_TO, DD_LOAD_TEXT_RETURN_NULL_ON_FAILURE);
@@ -816,7 +816,7 @@ int main(void)
     assert(!dd_exist(dd, FILENAME_NOT_REPORTABLE));
 
     free(config.ur_url);
-    ureport_server_response_free(response);
+    libreport_ureport_server_response_free(response);
     free(reported_to);
     dd_close(dd);
     delete_dump_dir("./test");
@@ -834,8 +834,8 @@ int main(void)
                          'value': 'value', \
                          'reporter': 'ABRT Server' } ] }";
 
-    ureport_server_config_init(&config);
-    ureport_server_config_set_url(&config, strdup("url"));
+    libreport_ureport_server_config_init(&config);
+    libreport_ureport_server_config_set_url(&config, strdup("url"));
 
     dd = dd_create("./test", (uid_t)-1L, DEFAULT_DUMP_DIR_MODE);
     assert(dd != NULL);
@@ -844,8 +844,8 @@ int main(void)
     dd_save_text(dd, FILENAME_COUNT, "1");
     dd_close(dd);
 
-    response = ureport_server_response_from_reply(&ps, &config);
-    assert(ureport_server_response_save_in_dump_dir(response, "./test", &config));
+    response = libreport_ureport_server_response_from_reply(&ps, &config);
+    assert(libreport_ureport_server_response_save_in_dump_dir(response, "./test", &config));
 
     dd = dd_opendir("./test", 0);
     reported_to = dd_load_text_ext(dd, FILENAME_REPORTED_TO, DD_LOAD_TEXT_RETURN_NULL_ON_FAILURE);
@@ -860,7 +860,7 @@ int main(void)
 
 
     free(config.ur_url);
-    ureport_server_response_free(response);
+    libreport_ureport_server_response_free(response);
     free(reported_to);
     free(not_reportable);
     dd_close(dd);
@@ -872,11 +872,11 @@ int main(void)
 ]])
 
 
-## --------------------------------------- ##
-##  ureport_server_response_get_report_url ##
-## --------------------------------------- ##
+## ------------------------------------------------- ##
+##  libreport_ureport_server_response_get_report_url ##
+## ------------------------------------------------- ##
 
-AT_TESTFUN([ureport_server_response_get_report_url],
+AT_TESTFUN([libreport_ureport_server_response_get_report_url],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -902,12 +902,12 @@ int main(void)
                          'reporter': 'ABRT Server' } ] }";
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
-    ureport_server_config_set_url(&config, strdup("url"));
+    libreport_ureport_server_config_init(&config);
+    libreport_ureport_server_config_set_url(&config, strdup("url"));
 
-    struct ureport_server_response *response = ureport_server_response_from_reply(&ps, &config);
+    struct ureport_server_response *response = libreport_ureport_server_response_from_reply(&ps, &config);
 
-    char *report_url = ureport_server_response_get_report_url(response, &config);
+    char *report_url = libreport_ureport_server_response_get_report_url(response, &config);
 
     char *expect_bthash_url = libreport_concat_path_file(config.ur_url, BTHASH_URL_SFX);
     char *expect_report_url = libreport_concat_path_file(expect_bthash_url, response->urr_bthash);
@@ -918,17 +918,17 @@ int main(void)
     free(config.ur_url);
     free(expect_report_url);
     free(report_url);
-    ureport_server_response_free(response);
+    libreport_ureport_server_response_free(response);
 
     return 0;
 }
 ]])
 
-## ---------------- ##
-##  ureport_do_post ##
-## ---------------- ##
+## -------------------------- ##
+##  libreport_ureport_do_post ##
+## -------------------------- ##
 
-AT_TESTFUN([ureport_do_post],
+AT_TESTFUN([libreport_ureport_do_post],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -955,28 +955,28 @@ int main(void)
     dd_save_text(dd, FILENAME_COUNT, "1");
     dd_close(dd);
 
-    char *json = ureport_from_dump_dir_ext("./test", NULL);
+    char *json = libreport_ureport_from_dump_dir_ext("./test", NULL);
 
     /* wrong url */
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
-    struct post_state *post_state = ureport_do_post(json, &config, "not_exist");
+    libreport_ureport_server_config_init(&config);
+    struct post_state *post_state = libreport_ureport_do_post(json, &config, "not_exist");
     assert(post_state->curl_result == CURLE_COULDNT_RESOLVE_HOST);
 
     free(post_state);
     free(json);
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
     delete_dump_dir("./test");
 
     return 0;
 }
 ]])
 
-## --------------- ##
-##  ureport_submit ##
-## --------------- ##
+## ------------------------- ##
+##  libreport_ureport_submit ##
+## ------------------------- ##
 
-AT_TESTFUN([ureport_submit],
+AT_TESTFUN([libreport_ureport_submit],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -1003,18 +1003,18 @@ int main(void)
     dd_save_text(dd, FILENAME_COUNT, "1");
     dd_close(dd);
 
-    char *json = ureport_from_dump_dir_ext("./test", NULL);
+    char *json = libreport_ureport_from_dump_dir_ext("./test", NULL);
 
     /* wrong url */
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
-    struct ureport_server_response *response = ureport_submit(json, &config);
+    libreport_ureport_server_config_init(&config);
+    struct ureport_server_response *response = libreport_ureport_submit(json, &config);
 
     assert(response == NULL);
 
-    ureport_server_response_free(response);
+    libreport_ureport_server_response_free(response);
     free(json);
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
     delete_dump_dir("./test");
 
     return 0;
@@ -1066,7 +1066,7 @@ int main(void)
     libreport_g_verbose=3;
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     bool res = ureport_attach(&config, "691cf824e3e07457156125636e86c50279e29496", "email", "abrt@email.com");
     assert(res == true);
@@ -1074,17 +1074,17 @@ int main(void)
     res = ureport_attach(&config, "691cf824e3e07457156125636e86c50279e29496", "count", "%d", 5);
     assert(res);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
 
     return 0;
 }
 ]])
 
-## ------------------------- ##
-## ureport_from_dump_dir_ext ##
-## ------------------------- ##
+## ----------------------------------- ##
+## libreport_ureport_from_dump_dir_ext ##
+## ----------------------------------- ##
 
-AT_TESTFUN([ureport_from_dump_dir_ext],
+AT_TESTFUN([libreport_ureport_from_dump_dir_ext],
 [[
 #include "internal_libreport.h"
 #include "ureport.h"
@@ -1112,7 +1112,7 @@ int main(void)
     dd_close(dd);
 
     /* no auth */
-    char *ureport = ureport_from_dump_dir_ext("./test", NULL);
+    char *ureport = libreport_ureport_from_dump_dir_ext("./test", NULL);
     assert(strstr(ureport, "auth") == NULL);
     free(ureport);
 
@@ -1122,39 +1122,39 @@ int main(void)
     dd_close(dd);
 
     struct ureport_server_config config;
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     map_string_t *settings = libreport_new_map_string();
 
     setenv("uReport_IncludeAuthData", "yes", 1);
     setenv("uReport_AuthDataItems", "hostname", 1);
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
-    ureport = ureport_from_dump_dir_ext("./test", &config.ur_prefs);
+    ureport = libreport_ureport_from_dump_dir_ext("./test", &config.ur_prefs);
     assert(strstr(ureport, "auth") != NULL);
     assert(strstr(ureport, "\"hostname\": \"env_hostname\"") != NULL);
     free(ureport);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
     libreport_free_map_string(settings);
 
     /* auth with unknown uReport_AuthDataItems */
-    ureport_server_config_init(&config);
+    libreport_ureport_server_config_init(&config);
 
     settings = libreport_new_map_string();
 
     setenv("uReport_AuthDataItems", "hostname, unknown", 1);
 
-    ureport_server_config_load(&config, settings);
+    libreport_ureport_server_config_load(&config, settings);
 
-    ureport = ureport_from_dump_dir_ext("./test", &config.ur_prefs);
+    ureport = libreport_ureport_from_dump_dir_ext("./test", &config.ur_prefs);
     assert(strstr(ureport, "auth") != NULL);
     assert(strstr(ureport, "\"hostname\": \"env_hostname\"") != NULL);
     assert(strstr(ureport, "unknown") == NULL);
     free(ureport);
 
-    ureport_server_config_destroy(&config);
+    libreport_ureport_server_config_destroy(&config);
     libreport_free_map_string(settings);
     delete_dump_dir("./test");
 
@@ -1183,19 +1183,19 @@ int main(void)
 
     {
         struct ureport_server_config config;
-        ureport_server_config_init(&config);
+        libreport_ureport_server_config_init(&config);
 
         ureport_server_config_load_basic_auth(&config, "username:password");
 
         assert(strcmp(config.ur_username, "username") == 0);
         assert(strcmp(config.ur_password, "password") == 0);
 
-        ureport_server_config_destroy(&config);
+        libreport_ureport_server_config_destroy(&config);
     }
 
     {
         struct ureport_server_config config;
-        ureport_server_config_init(&config);
+        libreport_ureport_server_config_init(&config);
 
         setenv("LIBREPORT_DEBUG_PLUGINS_CONF_DIR", "../../ureport-rhts-credentials/", 1);
 
@@ -1206,7 +1206,7 @@ int main(void)
         assert(strcmp(config.ur_url, RHSM_WEB_SERVICE_URL) == 0);
 
         unsetenv("LIBREPORT_DEBUG_PLUGINS_CONF_DIR");
-        ureport_server_config_destroy(&config);
+        libreport_ureport_server_config_destroy(&config);
     }
 
     {
@@ -1220,12 +1220,12 @@ int main(void)
         if (pid == 0)
         {
             struct ureport_server_config config;
-            ureport_server_config_init(&config);
+            libreport_ureport_server_config_init(&config);
 
             setenv("REPORT_CLIENT_NONINTERACTIVE", "1", 1);
             ureport_server_config_load_basic_auth(&config, "username");
 
-            ureport_server_config_destroy(&config);
+            libreport_ureport_server_config_destroy(&config);
 
             exit(0);
         }

--- a/tests/uriparser.at
+++ b/tests/uriparser.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([uriparser])
 
-## ------------------- ##
-## uri_userinfo_remove ##
-## ------------------- ##
+## ----------------------------- ##
+## libreport_uri_userinfo_remove ##
+## ----------------------------- ##
 
-AT_TESTFUN([uri_userinfo_remove],
+AT_TESTFUN([libreport_uri_userinfo_remove],
 [[#include "internal_libreport.h"
 #include <assert.h>
 #include <string.h>
@@ -56,7 +56,7 @@ int test(int retval, const char *uri, const char *result, const char *scheme, co
     fprintf(stderr, "==== Testing: '%s'\n", uri);
     fprintf(stdout, "==== Testing: '%s'\n", uri);
 
-    int r = uri_userinfo_remove(uri, &outputs[0], &outputs[1], &outputs[2], &outputs[3], &outputs[4], &outputs[5]);
+    int r = libreport_uri_userinfo_remove(uri, &outputs[0], &outputs[1], &outputs[2], &outputs[3], &outputs[4], &outputs[5]);
     if (r != retval)
     {
         printf("Invalid retval %d != %d\n", retval, r);
@@ -96,7 +96,7 @@ int test(int retval, const char *uri, const char *result, const char *scheme, co
     fprintf(stdout, "== Test without arguments\n");
 
 
-    r = uri_userinfo_remove(uri, &outputs[0], NULL, NULL, NULL, NULL, NULL);
+    r = libreport_uri_userinfo_remove(uri, &outputs[0], NULL, NULL, NULL, NULL, NULL);
     if (r != retval)
     {
         printf("Invalid retval without arguments: %d != %d\n", retval, r);
@@ -111,7 +111,7 @@ int test(int retval, const char *uri, const char *result, const char *scheme, co
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     int e = 0;
     e += test(      0, "ftp://root:password@", "ftp://", "ftp:", "", "root", "password", "");

--- a/tests/xfuncs.at
+++ b/tests/xfuncs.at
@@ -2,11 +2,11 @@
 
 AT_BANNER([xfuncs])
 
-## --------------- ##
-## xstrdup_between ##
-## --------------- ##
+## ------------------------- ##
+## libreport_xstrdup_between ##
+## ------------------------- ##
 
-AT_TESTFUN([xstrdup_between],
+AT_TESTFUN([libreport_xstrdup_between],
 [[#include "internal_libreport.h"
 #include <assert.h>
 #include <string.h>
@@ -17,7 +17,7 @@ AT_TESTFUN([xstrdup_between],
 
 void test(const char *src, const char *open, const char *close, const char *exp)
 {
-    char *res = xstrdup_between(src, open, close);
+    char *res = libreport_xstrdup_between(src, open, close);
 
     if (exp == NULL && res != NULL)
     {
@@ -43,7 +43,7 @@ void test(const char *src, const char *open, const char *close, const char *exp)
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     test("<a>foo blah</a>", "<?>", "</a>", NULL);
     test("<a>foo blah</a>", "<a>", "</?>", NULL);
@@ -67,7 +67,7 @@ AT_TESTFUN([parse_numbers],
 
 int main(void)
 {
-    g_verbose=3;
+    libreport_g_verbose=3;
 
     /* 1. not a number - ERROR
      * 2. a number with an alpha suffix - ERROR
@@ -80,85 +80,85 @@ int main(void)
 
     {
         unsigned uint_value = 12345;
-        assert(try_atou("foo", &uint_value) != 0);
+        assert(libreport_try_atou("foo", &uint_value) != 0);
         assert(uint_value == 12345);
 
-        assert(try_atou("foo54321", &uint_value) != 0);
+        assert(libreport_try_atou("foo54321", &uint_value) != 0);
         assert(uint_value == 12345);
 
         char buf[sizeof(unsigned long long) * 3 + 1];
 
         snprintf(buf, sizeof(buf), "%llu", 1LLU + UINT_MAX);
-        assert(try_atou(buf, &uint_value) != 0 || !"Above UINT_MAX");
+        assert(libreport_try_atou(buf, &uint_value) != 0 || !"Above UINT_MAX");
         assert(uint_value == 12345);
 
-        assert(try_atou("-1", &uint_value) != 0);
+        assert(libreport_try_atou("-1", &uint_value) != 0);
         assert(uint_value == 12345);
 
         snprintf(buf, sizeof(buf), "%llu", (unsigned long long)UINT_MAX);
-        assert(try_atou(buf, &uint_value) == 0);
+        assert(libreport_try_atou(buf, &uint_value) == 0);
         assert(uint_value == UINT_MAX);
-        assert(xatou(buf) == UINT_MAX);
+        assert(libreport_xatou(buf) == UINT_MAX);
 
-        assert(try_atou("0", &uint_value) == 0);
+        assert(libreport_try_atou("0", &uint_value) == 0);
         assert(uint_value == 0);
-        assert(xatou("0") == 0);
+        assert(libreport_xatou("0") == 0);
     }
 
     {
         int int_value = 12345;
-        assert(try_atoi("foo", &int_value) != 0);
+        assert(libreport_try_atoi("foo", &int_value) != 0);
         assert(int_value == 12345);
 
-        assert(try_atoi("foo54321", &int_value) != 0);
+        assert(libreport_try_atoi("foo54321", &int_value) != 0);
         assert(int_value == 12345);
 
         char buf[sizeof(long long) * 3 + 1];
 
         snprintf(buf, sizeof(buf), "%lld", 1LL + INT_MAX);
-        assert(try_atoi(buf, &int_value) != 0 || !"Parse INT_MAX+1");
+        assert(libreport_try_atoi(buf, &int_value) != 0 || !"Parse INT_MAX+1");
         assert(int_value == 12345 || !"Above INT_MAX");
 
         snprintf(buf, sizeof(buf), "%lld", -1LL + INT_MIN);
-        assert(try_atoi(buf, &int_value) != 0 || !"Parse INT_MIN-1");
+        assert(libreport_try_atoi(buf, &int_value) != 0 || !"Parse INT_MIN-1");
         assert(int_value == 12345 || !"Belove INT_MIN");
 
         snprintf(buf, sizeof(buf), "%lld", (unsigned long long)INT_MAX);
-        assert(try_atoi(buf, &int_value) == 0 || !"Parse INT_MAX");
+        assert(libreport_try_atoi(buf, &int_value) == 0 || !"Parse INT_MAX");
         assert(int_value == INT_MAX);
-        assert(xatoi(buf) == INT_MAX);
+        assert(libreport_xatoi(buf) == INT_MAX);
 
         snprintf(buf, sizeof(buf), "%lld", (unsigned long long)INT_MIN);
-        assert(try_atoi(buf, &int_value) == 0 || !"Parse INT_MIN");
+        assert(libreport_try_atoi(buf, &int_value) == 0 || !"Parse INT_MIN");
         assert(int_value == INT_MIN);
-        assert(xatoi(buf) == INT_MIN);
+        assert(libreport_xatoi(buf) == INT_MIN);
     }
 
     {
         int positive_value = 12345;
-        assert(try_atoi_positive("foo", &positive_value) != 0);
+        assert(libreport_try_atoi_positive("foo", &positive_value) != 0);
         assert(positive_value == 12345);
 
-        assert(try_atoi_positive("foo54321", &positive_value) != 0);
+        assert(libreport_try_atoi_positive("foo54321", &positive_value) != 0);
         assert(positive_value == 12345);
 
         char buf[sizeof(long long) * 3 + 1];
 
         snprintf(buf, sizeof(buf), "%lld", 1LL + INT_MAX);
-        assert(try_atoi_positive(buf, &positive_value) != 0);
+        assert(libreport_try_atoi_positive(buf, &positive_value) != 0);
         assert(positive_value == 12345 || !"Above INT_MAX");
 
-        assert(try_atoi_positive("-1", &positive_value) != 0);
+        assert(libreport_try_atoi_positive("-1", &positive_value) != 0);
         assert(positive_value == 12345 || !"After -1");
 
         snprintf(buf, sizeof(buf), "%lld", (unsigned long long)INT_MAX);
-        assert(try_atoi_positive(buf, &positive_value) == 0 || !"Parse INT_MAX");
+        assert(libreport_try_atoi_positive(buf, &positive_value) == 0 || !"Parse INT_MAX");
         assert(positive_value == INT_MAX);
-        assert(xatoi_positive(buf) == INT_MAX);
+        assert(libreport_xatoi_positive(buf) == INT_MAX);
 
-        assert(try_atoi_positive("0", &positive_value) == 0);
+        assert(libreport_try_atoi_positive("0", &positive_value) == 0);
         assert(positive_value == 0);
-        assert(xatoi_positive("0") == 0);
+        assert(libreport_xatoi_positive("0") == 0);
     }
 
     return 0;

--- a/tests/xml_definition.at
+++ b/tests/xml_definition.at
@@ -16,7 +16,7 @@ AT_TESTFUN([region_specific_language],
 
 int main(void)
 {
-    g_verbose = 3;
+    libreport_g_verbose = 3;
 
     assert(setlocale(LC_ALL, "zh_CN") != NULL || !"setlocale() failed");
 


### PR DESCRIPTION
This PR is analogous to https://github.com/abrt/abrt/pull/1466. Mass-rename functions and globals to `libreport_\1` where `#define`s have been used.