### PR TITLE
Fix build_ids_to_paths function name

### DIFF
--- a/src/client-python/reportclient/debuginfo.py
+++ b/src/client-python/reportclient/debuginfo.py
@@ -461,7 +461,7 @@ def filter_installed_debuginfos(build_ids, cache_dirs):
         List of missing debuginfo files.
     """
 
-    files = build_ids_to_path("", build_ids)
+    files = build_ids_to_paths("", build_ids)
     missing = []
 
     # 1st pass -> search in /usr/lib


### PR DESCRIPTION
Likely oversight in [commit 324a5ad96572bf6cd384931b0697663dbd00d1c3](https://github.com/abrt/libreport/commit/324a5ad96572bf6cd384931b0697663dbd00d1c3)
that changed the function definition but not the call below in the code

Signed-off-by: Michal Fabik <mfabik@redhat.com>