### PR TITLE
lib: Remove creates-items tag parsing in event definitions

### DIFF
--- a/src/include/event_config.h
+++ b/src/include/event_config.h
@@ -82,7 +82,6 @@ typedef struct
 {
     config_item_info_t *info;
 
-    char *ec_creates_items;
     char *ec_requires_items;
     char *ec_exclude_items_by_default;
     char *ec_include_items_by_default;

--- a/src/lib/event_config.c
+++ b/src/lib/event_config.c
@@ -154,7 +154,6 @@ void free_event_config(event_config_t *p)
         return;
 
     free_config_info(p->info);
-    free(p->ec_creates_items);
     free(p->ec_requires_items);
     free(p->ec_exclude_items_by_default);
     free(p->ec_include_items_by_default);

--- a/src/lib/event_xml_parser.c
+++ b/src/lib/event_xml_parser.c
@@ -25,7 +25,6 @@
 #define LONG_DESCR_ELEMENT      "long-description"
 #define ALLOW_EMPTY_ELEMENT     "allow-empty"
 #define NOTE_HTML_ELEMENT       "note-html"
-#define CREATES_ELEMENT         "creates-items"
 #define OPTION_ELEMENT          "option"
 //#define ACTION_ELEMENT        "action"
 #define NAME_ELEMENT            "name"
@@ -370,24 +369,7 @@ static void text(GMarkupParseContext *context,
     }
     else
     {
-        /* we're not in option, so the description is for the event */
-        /*
-        if (strcmp(inner_element, ACTION_ELEMENT) == 0)
-        {
-            log_info("action description:'%s'", text_copy);
-            free(ui->action);
-            ui->action = text_copy;
-            text_copy = NULL;
-        }
-        */
-        if (strcmp(inner_element, CREATES_ELEMENT) == 0)
-        {
-            log_info("ec_creates_items:'%s'", text_copy);
-            free(ui->ec_creates_items);
-            ui->ec_creates_items = text_copy;
-            text_copy = NULL;
-        }
-        else if (strcmp(inner_element, NAME_ELEMENT) == 0)
+        if (strcmp(inner_element, NAME_ELEMENT) == 0)
         {
             if (parse_data->attribute_lang != NULL) /* if it isn't for other locale */
             {

--- a/tests/bugzilla_plugin.at.in
+++ b/tests/bugzilla_plugin.at.in
@@ -18,8 +18,6 @@ TS_MAIN
     TS_ASSERT_STRING_EQ(ec_get_screen_name(conf), "Bugzilla", "Screen name");
     TS_ASSERT_STRING_EQ(ec_get_description(conf), "Report to Bugzilla bug tracker", "Description");
 
-    TS_ASSERT_STRING_EQ(conf->ec_creates_items, NULL, "Not-defined create items");
-
     TS_ASSERT_STRING_EQ(conf->ec_requires_items, "component,duphash,os_release", "Correct required items");
 
     TS_ASSERT_STRING_EQ(conf->ec_exclude_items_by_default, "coredump,count,event_log,reported_to,vmcore", "Correct excluded items by default");


### PR DESCRIPTION
c9120cdc51ce7aba5a19500bf24692144ac64983 in abrt introduced these for
the reporting wizard (advanced mode), but, with that gone, this makes no
sense to keep around.