### PR TITLE
Add a commit message template

### DIFF
--- a/.git-commit-template
+++ b/.git-commit-template
@@ -1,0 +1,13 @@
+COMPONENT: Subject
+
+Explanation
+
+Resolves:
+https://github.com/abrt/libreport/issues/XXXX
+https://bugzilla.redhat.com/show_bug.cgi?id=XXXXXX
+
+# Try to keep the subject line within 52 chars ----|
+# Also please try to not exceed 72 characters of length for the body --|
+# Avoid using exact file names as COMPONENT. Use keywords such as spec,
+# client, dump_dir etc. You do not need to follow this template 100%.
+# See git log for examples.


### PR DESCRIPTION
To start using this template:
$ git config commit.template .git-commit-template

If this makes sense, we could add commit templates to other abrt repositories as well.