### PR TITLE
internal: Remove useless #define

### DIFF
--- a/src/include/internal_libreport.h
+++ b/src/include/internal_libreport.h
@@ -418,7 +418,6 @@ extern int libreport_g_verbose;
 #define VERB3 if (libreport_g_verbose >= 3)
 /* there is no level > 3 */
 
-#define  libreport_
 void libreport_xfunc_die(void) NORETURN;
 
 void libreport_die_out_of_memory(void) NORETURN;


### PR DESCRIPTION
This `#define` was introduced in fd2f416b3 for no obvious reason and apparently does nothing.