### PR TITLE
Fix more memory management errors

### DIFF
--- a/src/cli/cli-report.c
+++ b/src/cli/cli-report.c
@@ -874,7 +874,7 @@ int select_and_run_workflow(const char *dump_dir_name, GHashTable *workflows, in
     workflow_t *workflow;
     GList *events;
     const char *workflow_name;
-    g_autofree char *environment_variable = NULL;
+    char *environment_variable = NULL;
     struct run_event_state *run_state;
     int retval;
 

--- a/src/lib/curl.c
+++ b/src/lib/curl.c
@@ -685,12 +685,14 @@ char *libreport_upload_file_ext(post_state_t *state, const char *url, const char
                 (state->curl_result == CURLE_LOGIN_DENIED
                  || state->curl_result == CURLE_REMOTE_ACCESS_DENIED))
         {
-            g_autofree char *msg = g_strdup_printf(_("Please enter user name for '%s//%s':"), scheme, hostname);
+            char *msg = g_strdup_printf(_("Please enter user name for '%s//%s':"), scheme, hostname);
             username = libreport_ask(msg);
+            free(msg);
             if (username != NULL && username[0] != '\0')
             {
                 msg = g_strdup_printf(_("Please enter password for '%s//%s@%s':"), scheme, username, hostname);
                 password = libreport_ask_password(msg);
+                free(msg);
                 /* What about empty password? */
                 if (password != NULL && password[0] != '\0')
                 {

--- a/src/lib/steal_directory.c
+++ b/src/lib/steal_directory.c
@@ -47,10 +47,11 @@ struct dump_dir *libreport_steal_directory(const char *base_dir, const char *dum
 
     struct dump_dir *dd_dst;
     unsigned count = 100;
-    g_autofree char *dst_dir_name = g_build_filename(base_dir ? base_dir : "", base_name, NULL);
+    char *dst_dir_name = g_build_filename(base_dir ? base_dir : "", base_name, NULL);
     while (1)
     {
         dd_dst = dd_create(dst_dir_name, (uid_t)-1, DEFAULT_DUMP_DIR_MODE);
+        free(dst_dir_name);
         if (dd_dst)
             break;
         if (--count == 0)

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -695,6 +695,7 @@ int main(int argc, char **argv)
                     if (g_list_find_custom(ii->mii_attachments, name, (GCompareFunc) strcmp) == NULL)
                         break;
 
+                    free(name);
                 }
                 mantisbt_attach_data(&mbt_settings, bug_id_str, name, bt, strlen(bt));
             }

--- a/src/plugins/reporter-systemd-journal.c
+++ b/src/plugins/reporter-systemd-journal.c
@@ -69,7 +69,7 @@ static void msg_content_add_ext(msg_content_t *msg_c, const char *key, const cha
         msg_c->data = g_realloc(msg_c->data, msg_c->allocated * sizeof(*(msg_c->data)));
     }
 
-    g_autofree char *s = g_strdup_printf("%s%s=%s", prefix, key, value);
+    char *s = g_strdup_printf("%s%s=%s", prefix, key, value);
     for (char *c = s; *c != '='; ++c) *c = toupper(*c);
     msg_c->data[msg_c->used].iov_base = s;
     msg_c->data[msg_c->used].iov_len = strlen(s);


### PR DESCRIPTION
The `g_autofree` was incorrectly added in 05e9c9273. This causes a double-free error and crash.

These strings are needed elsewhere and are freed later by `msg_content_free()`.