### PR TITLE
Fix a few segfaults + minor things

### DIFF
--- a/src/cli/cli-report.c
+++ b/src/cli/cli-report.c
@@ -742,8 +742,9 @@ static char *select_event_name(GList *list_options)
 
 int select_and_run_one_event(const char *dump_dir_name, const char *pfx, int interactive)
 {
-    g_autolist (GList) list_events = list_possible_events_glist(dump_dir_name, pfx);
+    GList *list_events = list_possible_events_glist(dump_dir_name, pfx);
     g_autofree char *event_name = select_event_name(list_events);
+    g_list_free_full(list_events, free);
 
     struct run_event_state *run_state = new_run_event_state();
     run_state->logging_callback = do_log;

--- a/src/gtk-helpers/problem_details_widget.c
+++ b/src/gtk-helpers/problem_details_widget.c
@@ -147,16 +147,6 @@ problem_details_widget_add_multi_line(ProblemDetailsWidget *self, const char *na
     if (g_provider == NULL)
         load_css_style();
 
-#if 0
-    GtkWidget *value = gtk_text_view_new();
-    gtk_text_view_set_editable(GTK_TEXT_VIEW(value), FALSE);
-
-    if (strcmp(name, FILENAME_COMMENT) == 0
-            || strcmp(name, FILENAME_REASON) == 0)
-        gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(value), GTK_WRAP_WORD);
-
-    libreport_reload_text_to_text_view(GTK_TEXT_VIEW(value), content);
-#else
     GtkWidget *value = gtk_label_new(content);
     gtk_widget_set_halign(value, GTK_ALIGN_START);
 
@@ -169,7 +159,6 @@ problem_details_widget_add_multi_line(ProblemDetailsWidget *self, const char *na
     }
 
     gtk_label_set_selectable(GTK_LABEL(value), TRUE);
-#endif
 
     gtk_widget_set_name(GTK_WIDGET(value), "value");
 

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -2316,10 +2316,13 @@ static gboolean highligh_words_in_tabs(GList *forbidden_words,  GList *allowed_w
 
 static gboolean highlight_forbidden(void)
 {
-    g_autolist (GList) forbidden_words = libreport_load_words_from_file(FORBIDDEN_WORDS_BLACKLLIST);
-    g_autolist (GList) allowed_words = libreport_load_words_from_file(FORBIDDEN_WORDS_WHITELIST);
+    GList *forbidden_words = libreport_load_words_from_file(FORBIDDEN_WORDS_BLACKLLIST);
+    GList *allowed_words = libreport_load_words_from_file(FORBIDDEN_WORDS_WHITELIST);
 
     const gboolean result = highligh_words_in_tabs(forbidden_words, allowed_words, /*case sensitive*/false);
+
+    g_list_free_full(allowed_words, free);
+    g_list_free_full(forbidden_words, free);
 
     return result;
 }
@@ -2721,9 +2724,13 @@ static gint select_next_page_no(gint current_page_no)
 
 static void rehighlight_forbidden_words(int page, GtkTextView *tev)
 {
-    g_autolist (GList) forbidden_words = libreport_load_words_from_file(FORBIDDEN_WORDS_BLACKLLIST);
-    g_autolist (GList) allowed_words = libreport_load_words_from_file(FORBIDDEN_WORDS_WHITELIST);
+    GList *forbidden_words = libreport_load_words_from_file(FORBIDDEN_WORDS_BLACKLLIST);
+    GList *allowed_words = libreport_load_words_from_file(FORBIDDEN_WORDS_WHITELIST);
+
     highlight_words_in_textview(page, tev, forbidden_words, allowed_words, /*case sensitive*/false);
+
+    g_list_free_full(allowed_words, free);
+    g_list_free_full(forbidden_words, free);
 }
 
 static void on_sensitive_word_selection_changed(GtkTreeSelection *sel, gpointer user_data)

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -2151,7 +2151,7 @@ static void search_item_to_list_store_item(GtkListStore *store, GtkTreeIter *new
             -1);
 }
 
-static bool highligh_words_in_textview(int page, GtkTextView *tev, GList *words, GList *ignored_words, bool case_insensitive)
+static bool highlight_words_in_textview(int page, GtkTextView *tev, GList *words, GList *ignored_words, bool case_insensitive)
 {
     GtkTextBuffer *buffer = gtk_text_view_get_buffer(tev);
     gtk_text_buffer_set_modified(buffer, FALSE);
@@ -2304,7 +2304,7 @@ static gboolean highligh_words_in_tabs(GList *forbidden_words,  GList *allowed_w
             continue;
 
         GtkTextView *tev = GTK_TEXT_VIEW(gtk_bin_get_child(GTK_BIN(notebook_child)));
-        found |= highligh_words_in_textview(page, tev, forbidden_words, allowed_words, case_insensitive);
+        found |= highlight_words_in_textview(page, tev, forbidden_words, allowed_words, case_insensitive);
     }
 
     GtkTreeIter iter;
@@ -2723,7 +2723,7 @@ static void rehighlight_forbidden_words(int page, GtkTextView *tev)
 {
     g_autolist (GList) forbidden_words = libreport_load_words_from_file(FORBIDDEN_WORDS_BLACKLLIST);
     g_autolist (GList) allowed_words = libreport_load_words_from_file(FORBIDDEN_WORDS_WHITELIST);
-    highligh_words_in_textview(page, tev, forbidden_words, allowed_words, /*case sensitive*/false);
+    highlight_words_in_textview(page, tev, forbidden_words, allowed_words, /*case sensitive*/false);
 }
 
 static void on_sensitive_word_selection_changed(GtkTreeSelection *sel, gpointer user_data)
@@ -2752,7 +2752,7 @@ static void on_sensitive_word_selection_changed(GtkTreeSelection *sel, gpointer 
         {
             log_notice("searching again: '%s'", g_search_text);
             GList *searched_words = g_list_append(NULL, (gpointer)g_search_text);
-            highligh_words_in_textview(new_word->page, new_word->tev, searched_words, NULL, /*case insensitive*/true);
+            highlight_words_in_textview(new_word->page, new_word->tev, searched_words, NULL, /*case insensitive*/true);
             g_list_free(searched_words);
         }
 

--- a/src/include/internal_libreport.h
+++ b/src/include/internal_libreport.h
@@ -268,11 +268,6 @@ bool libreport_is_in_comma_separated_list_of_glob_patterns(const char *value, co
  */
 void libreport_glib_init(void);
 
-/* Frees every element'd data using free(),
- * then frees list itself using g_list_free(list):
- */
-void libreport_list_free_with_free(GList *list);
-
 double libreport_get_dirsize(const char *pPath);
 double libreport_get_dirsize_find_largest_dir(
                 const char *pPath,

--- a/src/lib/abrt_xmlrpc.c
+++ b/src/lib/abrt_xmlrpc.c
@@ -38,7 +38,7 @@ void abrt_xmlrpc_error(xmlrpc_env *env)
 
 struct abrt_xmlrpc *abrt_xmlrpc_new_client(const char *url, int ssl_verify)
 {
-    g_autolist (GList) proxies = NULL;
+    GList *proxies = NULL;
     xmlrpc_env env;
     xmlrpc_env_init(&env);
 
@@ -85,6 +85,8 @@ struct abrt_xmlrpc *abrt_xmlrpc_new_client(const char *url, int ssl_verify)
                          PACKAGE_NAME, VERSION,
                          &client_parms, XMLRPC_CPSIZE(transportparm_size),
                          &ax->ax_client);
+
+    g_list_free_full(proxies, free);
 
     if (env.fault_occurred)
         abrt_xmlrpc_die(&env);

--- a/src/lib/curl.c
+++ b/src/lib/curl.c
@@ -409,15 +409,7 @@ post(post_state_t *state,
         const char *basename = strrchr(data, '/');
         if (basename) basename++;
         else basename = data;
-#if 0
-        // Simple way, without custom reader function
-        CURLFORMcode curlform_err = curl_formadd(&post, &last,
-                        CURLFORM_PTRNAME, "file", // element name
-                        CURLFORM_FILE, data, // filename to read from
-                        CURLFORM_CONTENTTYPE, content_type,
-                        CURLFORM_FILENAME, basename, // filename to put in the form
-                        CURLFORM_END);
-#else
+
         data_file = fopen(data, "r");
         if (!data_file)
         {
@@ -440,7 +432,7 @@ post(post_state_t *state,
                         CURLFORM_CONTENTTYPE, content_type,
                         CURLFORM_FILENAME, basename, // filename to put in the form
                         CURLFORM_END);
-#endif
+
         if (curlform_err != 0)
 //FIXME:
             error_msg_and_die("out of memory or read error (curl_formadd error code: %d)", (int)curlform_err);
@@ -507,21 +499,6 @@ post(post_state_t *state,
 // apparently with POST->GET remapping - which server didn't like at all.
 // Attempted to suppress remapping on 305 using CURLOPT_POSTREDIR of -1,
 // but it still did not work.
-#if 0
-    // Please handle 301/302 redirects for me
-    xcurl_easy_setopt_long(handle, CURLOPT_FOLLOWLOCATION, 1);
-    xcurl_easy_setopt_long(handle, CURLOPT_MAXREDIRS, 10);
-    // Bitmask to control how libcurl acts on redirects after POSTs.
-    // Bit 0 set (value CURL_REDIR_POST_301) makes libcurl
-    // not convert POST requests into GET requests when following
-    // a 301 redirection. Bit 1 (value CURL_REDIR_POST_302) makes libcurl
-    // maintain the request method after a 302 redirect.
-    // CURL_REDIR_POST_ALL is a convenience define that sets both bits.
-    // The non-RFC behaviour is ubiquitous in web browsers, so the library
-    // does the conversion by default to maintain consistency.
-    // However, a server may require a POST to remain a POST.
-    xcurl_easy_setopt_long(handle, CURLOPT_POSTREDIR, -1L /*CURL_REDIR_POST_ALL*/ );
-#endif
 
     // Prepare for saving information
     if (state->flags & POST_WANT_HEADERS)

--- a/src/lib/curl.c
+++ b/src/lib/curl.c
@@ -79,8 +79,8 @@ xcurl_easy_setopt_off_t(CURL *handle, CURLoption option, curl_off_t parameter)
 
 CURLcode curl_easy_perform_with_proxy(CURL *handle, const char *url)
 {
-    g_autolist (GList) proxy_list = NULL;
-    GList *li;
+    GList *proxy_list = NULL;
+    GList *li = NULL;
     CURLcode curl_err;
 
     proxy_list = get_proxy_list(url);
@@ -101,6 +101,8 @@ CURLcode curl_easy_perform_with_proxy(CURL *handle, const char *url)
         log_notice("Connecting to %s", url);
         curl_err = curl_easy_perform(handle);
     }
+
+    g_list_free_full(proxy_list, free);
 
     return curl_err;
 }

--- a/src/lib/glib_support.c
+++ b/src/lib/glib_support.c
@@ -77,11 +77,3 @@ GList *libreport_parse_delimited_list(const char *string, const char *delimiter)
 
     return g_list_reverse(list);
 }
-
-void libreport_list_free_with_free(GList *list)
-{
-    GList *li;
-    for (li = list; li; li = g_list_next(li))
-        free(li->data);
-    g_list_free(list);
-}

--- a/src/lib/libreport-web.sym
+++ b/src/lib/libreport-web.sym
@@ -100,7 +100,6 @@ global:
     libreport_is_in_comma_separated_list;
     libreport_is_in_comma_separated_list_of_glob_patterns;
     libreport_glib_init;
-    libreport_list_free_with_free;
     libreport_get_dirsize;
     libreport_get_dirsize_find_largest_dir;
     libreport_ndelay_on;

--- a/src/lib/libreport.sym
+++ b/src/lib/libreport.sym
@@ -322,7 +322,6 @@ global:
     libreport_is_in_comma_separated_list;
     libreport_is_in_comma_separated_list_of_glob_patterns;
     libreport_glib_init;
-    libreport_list_free_with_free;
     libreport_get_dirsize;
     libreport_get_dirsize_find_largest_dir;
     libreport_ndelay_on;

--- a/src/lib/run_event.c
+++ b/src/lib/run_event.c
@@ -125,7 +125,7 @@ void free_rule_list(GList *rule_list)
     while (rule_list)
     {
         struct rule *cur_rule = rule_list->data;
-        libreport_list_free_with_free(cur_rule->conditions);
+        g_list_free_full(cur_rule->conditions, free);
         free(cur_rule->command);
         free(cur_rule);
 
@@ -442,7 +442,7 @@ static char* pop_next_command(GList **pp_rule_list,
         /* We are here if all conditions are satisfied */
         /* IOW, we found rule to run, delete it and return its command */
         *pp_rule_list = g_list_remove(*pp_rule_list, cur_rule);
-        libreport_list_free_with_free(cur_rule->conditions);
+        g_list_free_full(cur_rule->conditions, free);
         command = cur_rule->command;
         /*free(cur_rule->command); - WRONG! we are returning it! */
         free(cur_rule);

--- a/src/lib/user_settings.c
+++ b/src/lib/user_settings.c
@@ -140,7 +140,7 @@ GList *libreport_load_words_from_file(const char* filename)
         file_list_cur = g_list_next(file_list_cur);
     }
 
-    libreport_list_free_with_free(file_list);
+    g_list_free_full(file_list, free);
 
     return words_list;
 }

--- a/src/lib/xfuncs.c
+++ b/src/lib/xfuncs.c
@@ -225,24 +225,6 @@ void libreport_xunlinkat(int dir_fd, const char *pathname, int flags)
         perror_msg_and_die("Can't remove file '%s'", pathname);
 }
 
-#if 0 //UNUSED
-// Warn if we can't open a file and return a fd.
-int open3_or_warn(const char *pathname, int flags, int mode)
-{
-    int ret;
-    ret = open(pathname, flags, mode);
-    if (ret < 0)
-        perror_msg("Can't open '%s'", pathname);
-    return ret;
-}
-
-// Warn if we can't open a file and return a fd.
-int open_or_warn(const char *pathname, int flags)
-{
-    return open3_or_warn(pathname, flags, 0666);
-}
-#endif
-
 /* Just testing dent->d_type == DT_REG is wrong: some filesystems
  * do not report the type, they report DT_UNKNOWN for every dirent
  * (and this is not a bug in filesystem, this is allowed by standards).

--- a/src/plugins/mantisbt.c
+++ b/src/plugins/mantisbt.c
@@ -364,28 +364,6 @@ soap_request_to_str(const soap_request_t *req)
     return ret;
 }
 
-#if 0
-void
-soap_request_print(soap_request_t *req)
-{
-    if (req == NULL || req->sr_root == NULL || req->sr_root->doc == NULL)
-        error_msg_and_die(_("SOAP: Failed to print SOAP string."));
-
-    xmlBufferPtr buffer = xmlBufferCreate();
-    int err = xmlNodeDump(buffer, req->sr_root->doc, req->sr_root, 1, /* formatting */ 0);
-    if (err == -1)
-    {
-        xmlBufferFree(buffer);
-        error_msg_and_die(_("Failed to dump xml node."));
-    }
-
-    puts((const char *) xmlBufferContent(buffer));
-
-    xmlBufferFree(buffer);
-    return;
-}
-#endif
-
 static bool
 reader_move_reader_if_node_type_is_element_with_name_and_verify_its_value(xmlTextReaderPtr reader, const char *name)
 {

--- a/src/plugins/mantisbt.c
+++ b/src/plugins/mantisbt.c
@@ -104,8 +104,8 @@ mantisbt_issue_info_free(mantisbt_issue_info_t *info)
     free(info->mii_reporter);
     free(info->mii_project);
 
-    libreport_list_free_with_free(info->mii_notes);
-    libreport_list_free_with_free(info->mii_attachments);
+    g_list_free_full(info->mii_notes, free);
+    g_list_free_full(info->mii_attachments, free);
 
     free(info);
 }

--- a/src/plugins/mantisbt.h
+++ b/src/plugins/mantisbt.h
@@ -103,10 +103,6 @@ void soap_request_add_credentials_parameter(soap_request_t *req, const mantisbt_
 
 char *soap_request_to_str(const soap_request_t *req);
 
-#if 0
-void soap_request_print(soap_request_t *req);
-#endif
-
 GList * response_get_main_ids_list(const char *xml);
 int response_get_main_id(const char *xml);
 void response_values_free(GList *values);

--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -557,9 +557,6 @@ int main(int argc, char **argv)
         log_warning(_("Logging out"));
         rhbz_logout(client);
 
-#if 0  /* enable if you search for leaks (valgrind etc) */
-        abrt_xmlrpc_free_client(client);
-#endif
         return 0;
     }
 
@@ -983,12 +980,5 @@ int main(int argc, char **argv)
         dd_close(dd);
     }
 
-#if 0  /* enable if you search for leaks (valgrind etc) */
-    free(rhbz.b_product);
-    free(rhbz.b_product_version);
-    problem_data_free(problem_data);
-    free_bug_info(bz);
-    abrt_xmlrpc_free_client(client);
-#endif
     return 0;
 }

--- a/src/plugins/rhbz.c
+++ b/src/plugins/rhbz.c
@@ -62,7 +62,7 @@ void free_bug_info(struct bug_info *bi)
     free(bi->bi_reporter);
     free(bi->bi_product);
 
-    libreport_list_free_with_free(bi->bi_cc_list);
+    g_list_free_full(bi->bi_cc_list, free);
 
     free(bi);
 }

--- a/src/plugins/rhbz.c
+++ b/src/plugins/rhbz.c
@@ -731,13 +731,6 @@ void rhbz_mail_to_cc(struct abrt_xmlrpc *ax, int bug_id, const char *mail, int f
 
     xmlrpc_value *result;
     int minor_update = !!IS_MINOR_UPDATE(flags);
-#if 0 /* Obsolete API */
-    result = abrt_xmlrpc_call(ax, "Bug.update", "({s:i,s:{s:(s),s:i}})",
-                              "ids", bug_id,
-                              "updates", "add_cc", mail,
-                                         "minor_update", minor_update
-    );
-#endif
     /* Bugzilla 4.0+ uses this API: */
     result = abrt_xmlrpc_call(ax, "Bug.update", "{s:i,s:{s:(s),s:i}}",
                               "ids", bug_id,


### PR DESCRIPTION
* Commit 7aba6e5 converted several pointers to GList into `g_autolist`s of `GList`. This is a mistake: the type parameter denotes the type of the contained data, not of the container.

  When the `g_autolist`'ed variable goes out of scope, the auto-cleanup procedure attempts to free the data using the `GList` cleanup function, which is `g_list_free()`. This leads to a segfault since the data are usually strings allocated via `malloc()`.
* Replace`libreport_list_free_with_free()` with `g_list_free_full()` everywhere.
* Fix typo in a static function name in `gui-wizard-gtk`.
* Purge commented-out code.

Follow-up in abrt: abrt/abrt#1518