### PR TITLE
SPEC file updates for ELN

### DIFF
--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -217,7 +217,7 @@ Summary: %{name}'s micro report plugin
 BuildRequires: %{libjson_devel}
 Requires: %{name} = %{version}-%{release}
 Requires: libreport-web = %{version}-%{release}
-%if 0%{?rhel}
+%if 0%{?rhel} && ! 0%{?eln}
 Requires: python3-subscription-manager-rhsm
 %endif
 
@@ -232,7 +232,7 @@ Requires: libreport-web = %{version}-%{release}
 %description plugin-reportuploader
 Plugin to report bugs into anonymous FTP site associated with ticketing system.
 
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?eln}
 %package fedora
 Summary: Default configuration for reporting bugs via Fedora infrastructure
 Requires: %{name} = %{version}-%{release}
@@ -243,7 +243,7 @@ used to easily configure the reporting process for Fedora systems. Just
 install this package and you're done.
 %endif
 
-%if 0%{?rhel}
+%if 0%{?rhel} && ! 0%{?eln}
 %package rhel-bugzilla
 Summary: Default configuration for reporting bugs to Red Hat Bugzilla
 Requires: %{name} = %{version}-%{release}
@@ -271,7 +271,7 @@ package and you're done.
 Summary: Default configuration for reporting anaconda bugs
 Requires: %{name} = %{version}-%{release}
 Requires: libreport-plugin-reportuploader = %{version}-%{release}
-%if ! 0%{?rhel}
+%if ! 0%{?rhel} || 0%{?eln}
 Requires: libreport-plugin-bugzilla = %{version}-%{release}
 %endif
 
@@ -324,7 +324,7 @@ mkdir -p %{buildroot}/%{_datadir}/%{name}/workflows/
 rm -f %{buildroot}/%{_infodir}/dir
 
 # Remove unwanted Fedora specific workflow configuration files
-%if 0%{!?fedora:1}
+%if ! 0%{?fedora} && ! 0%{?eln}
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_FedoraCCpp.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_FedoraKerneloops.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_FedoraPython.xml
@@ -340,7 +340,7 @@ rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_AnacondaFedora.xml
 %endif
 
 # Remove unwanted RHEL specific workflow configuration files
-%if 0%{!?rhel:1}
+%if ! 0%{?rhel} || 0%{?eln}
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_uReport.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_AnacondaRHELBugzilla.xml
 rm -f %{buildroot}/%{_datadir}/libreport/workflows/workflow_RHELBugzillaCCpp.xml
@@ -523,7 +523,7 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{_mandir}/man1/reporter-ureport.1.gz
 %{_mandir}/man5/ureport.conf.5.gz
 %{_datadir}/%{name}/events/report_uReport.xml
-%if 0%{?rhel}
+%if 0%{?rhel} && ! 0%{?eln}
 %config(noreplace) %{_sysconfdir}/libreport/workflows.d/report_uReport.conf
 %{_datadir}/%{name}/workflows/workflow_uReport.xml
 %{_mandir}/man5/report_uReport.conf.5.*
@@ -605,7 +605,7 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %config(noreplace) %{_sysconfdir}/libreport/events/report_Uploader.conf
 %{_mandir}/man5/report_Uploader.conf.5.*
 
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?eln}
 %files fedora
 %{_datadir}/%{name}/workflows/workflow_FedoraCCpp.xml
 %{_datadir}/%{name}/workflows/workflow_FedoraKerneloops.xml
@@ -620,7 +620,7 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{_mandir}/man5/report_fedora.conf.5.*
 %endif
 
-%if 0%{?rhel}
+%if 0%{?rhel} && ! 0%{?eln}
 %files rhel-bugzilla
 %{_datadir}/%{name}/workflows/workflow_RHELBugzillaCCpp.xml
 %{_datadir}/%{name}/workflows/workflow_RHELBugzillaKerneloops.xml
@@ -639,10 +639,10 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 
 %if %{with bugzilla}
 %files anaconda
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?eln}
 %{_datadir}/%{name}/workflows/workflow_AnacondaFedora.xml
 %endif
-%if 0%{?rhel}
+%if 0%{?rhel} && ! 0%{?eln}
 %{_datadir}/%{name}/workflows/workflow_AnacondaRHEL.xml
 %endif
 %{_datadir}/%{name}/workflows/workflow_AnacondaUpload.xml
@@ -657,6 +657,10 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %endif
 
 %changelog
+* Wed Aug 19 2020 Merlin Mathesius <mmathesi@redhat.com> - 2.14.0-1
+- Updates so ELN builds in a Fedora-like reporting configuration, even though
+  the %%{rhel} macro is set.
+
 * Thu Aug 13 2020 Michal Fabik <mfabik@redhat.com> 2.14.0-1
 - Update version-info before new release
 - Purge commented-out code


### PR DESCRIPTION
`libreport` currently fails to build for ELN.

It also needs to build correctly for ELN. This PR adjusts the SPEC file conditionals to package a Fedora-like reporting onfiguration--even though the `%{rhel}` macro is set. This is different than most other packages which shouldn't care or check if the `%{eln}` macro is set.

This PR corresponds to downstream PR https://src.fedoraproject.org/rpms/libreport/pull-request/4