### PR TITLE
Memory management and GLib structures

### DIFF
--- a/src/include/problem_data.h
+++ b/src/include/problem_data.h
@@ -19,14 +19,12 @@
 
 /** @file problem_data.h */
 
-#ifndef LIBREPORT_PROBLEM_DATA_H_
-#define LIBREPORT_PROBLEM_DATA_H_
+#pragma once
 
+#include <glib.h>
 #include "libreport_types.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 struct dump_dir;
 
@@ -76,6 +74,8 @@ static inline void problem_data_free(problem_data_t *problem_data)
     if (problem_data)
         g_hash_table_destroy(problem_data);
 }
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(problem_data_t, problem_data_free);
 
 void problem_data_add_basics(problem_data_t *pd);
 
@@ -181,8 +181,4 @@ enum {
 int get_problem_data_reproducible(problem_data_t *problem_data);
 const char *get_problem_data_reproducible_name(int reproducible);
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif
+G_END_DECLS

--- a/src/include/problem_report.h
+++ b/src/include/problem_report.h
@@ -132,16 +132,13 @@
         printf("%s\n",                  problem_data_get_content_or_NULL(data, "comment"));
         printf("Additional info: %s\n", problem_data_get_content_or_NULL(data, "maps"));
 */
-#ifndef LIBREPORT_PROBLEM_REPORT_H
-#define LIBREPORT_PROBLEM_REPORT_H
+#pragma once
 
 #include <glib.h>
 #include <stdio.h>
 #include "problem_data.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 #define PR_SEC_SUMMARY "summary"
 #define PR_SEC_DESCRIPTION "description"
@@ -251,6 +248,8 @@ GList *problem_report_get_attachments(const problem_report_t *self);
  */
 void problem_report_free(problem_report_t *self);
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(problem_report_t, problem_report_free)
+
 
 /*
  * An enum of Extra section flags
@@ -282,6 +281,8 @@ problem_formatter_t *problem_formatter_new(void);
  * @param self Problem formatter
  */
 void problem_formatter_free(problem_formatter_t *self);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(problem_formatter_t, problem_formatter_free)
 
 /*
  * Adds a new recognized section
@@ -361,8 +362,4 @@ problem_report_settings_t problem_formatter_get_settings(const problem_formatter
  */
 void problem_formatter_set_settings(problem_formatter_t *self, problem_report_settings_t settings);
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif // LIBREPORT_PROBLEM_REPORT_H
+G_END_DECLS

--- a/src/plugins/reporter-kerneloops.c
+++ b/src/plugins/reporter-kerneloops.c
@@ -89,7 +89,7 @@ static void report_to_kerneloops(
                 const char *dump_dir_name,
                 GHashTable *settings)
 {
-    problem_data_t *problem_data = create_problem_data_for_reporting(dump_dir_name);
+    g_autoptr(problem_data_t) problem_data = create_problem_data_for_reporting(dump_dir_name);
     if (!problem_data)
         libreport_xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
 
@@ -110,8 +110,6 @@ static void report_to_kerneloops(
     if (ret != CURLE_OK)
         error_msg_and_die("Kernel oops has not been sent due to %s", curl_easy_strerror(ret));
 
-    problem_data_free(problem_data);
-
     /* Server replies with:
      * 200 thank you for submitting the kernel oops information
      * RemoteIP: 34192fd15e34bf60fac6a5f01bba04ddbd3f0558
@@ -120,15 +118,11 @@ static void report_to_kerneloops(
     struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
     if (dd)
     {
-        report_result_t *result;
-
-        result = report_result_new_with_label_from_env("kerneloops");
+        g_autoptr(report_result_t) result = report_result_new_with_label_from_env("kerneloops");
 
         report_result_set_url(result, submitURL);
 
         libreport_add_reported_to_entry(dd, result);
-
-        report_result_free(result);
 
         dd_close(dd);
     }

--- a/src/plugins/reporter-mailx.c
+++ b/src/plugins/reporter-mailx.c
@@ -104,7 +104,7 @@ static void create_and_send_email(
                 const char *fmt_file,
                 int flag)
 {
-    problem_data_t *problem_data = create_problem_data_for_reporting(dump_dir_name);
+    g_autoptr(problem_data_t) problem_data = create_problem_data_for_reporting(dump_dir_name);
     if (!problem_data)
         libreport_xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
 
@@ -118,7 +118,7 @@ static void create_and_send_email(
         env = g_hash_table_lookup(settings, "SendBinaryData");
     bool send_binary_data = libreport_string_to_bool(env ? env : "");
 
-    problem_formatter_t *pf = problem_formatter_new();
+    g_autoptr(problem_formatter_t) pf = problem_formatter_new();
     /* formatting file is not set */
     if (fmt_file == NULL)
     {
@@ -140,7 +140,7 @@ static void create_and_send_email(
             error_msg_and_die("Invalid format file: %s", fmt_file);
     }
 
-    problem_report_t *pr = NULL;
+    g_autoptr(problem_report_t) pr = NULL;
     if (problem_formatter_generate_report(pf, problem_data, &pr))
         error_msg_and_die("Failed to format bug report from problem data");
 
@@ -160,8 +160,6 @@ static void create_and_send_email(
         for (GList *a = problem_report_get_attachments(pr); a != NULL; a = g_list_next(a))
             printf(" %s\n", (const char *)a->data);
 
-        problem_report_free(pr);
-        problem_formatter_free(pf);
         exit(0);
     }
 
@@ -203,11 +201,6 @@ static void create_and_send_email(
         log_warning(_("Sending an email..."));
 
     exec_and_feed_input(dsc, args);
-
-    problem_report_free(pr);
-    problem_formatter_free(pf);
-
-    problem_data_free(problem_data);
 
     if (!(flag & RM_FLAG_NOTIFY))
     {

--- a/src/plugins/reporter-print.c
+++ b/src/plugins/reporter-print.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
         }
     }
 
-    problem_data_t *problem_data = create_problem_data_for_reporting(dump_dir_name);
+    g_autoptr(problem_data_t) problem_data = create_problem_data_for_reporting(dump_dir_name);
     if (!problem_data)
         libreport_xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
 
@@ -124,7 +124,6 @@ int main(int argc, char **argv)
     fputs(dsc, stdout);
     if (open_mode[0] == 'a')
         fputs("\nEND:\n\n", stdout);
-    problem_data_free(problem_data);
 
     if (output_file)
     {

--- a/src/plugins/reporter-systemd-journal.c
+++ b/src/plugins/reporter-systemd-journal.c
@@ -274,11 +274,11 @@ int main(int argc, char **argv)
 
     libreport_export_abrt_envvars(0);
 
-    problem_data_t *problem_data = create_problem_data_for_reporting(dump_dir_name);
+    g_autoptr(problem_data_t) problem_data = create_problem_data_for_reporting(dump_dir_name);
     if (!problem_data)
         libreport_xfunc_die(); /* create_problem_data_for_reporting already emitted error msg */
 
-    problem_formatter_t *pf = problem_formatter_new();
+    g_autoptr(problem_formatter_t) pf = problem_formatter_new();
 
     if (fmt_file)
     {
@@ -325,7 +325,7 @@ int main(int argc, char **argv)
         problem_data_add_text_noteditable(problem_data, MESSAGE_ID, message_id);
 
     /* Generating of problem report */
-    problem_report_t *pr = NULL;
+    g_autoptr(problem_report_t) pr = NULL;
     if (problem_formatter_generate_report(pf, problem_data, &pr))
         error_msg_and_die("Failed to format bug report from problem data");
 
@@ -339,10 +339,6 @@ int main(int argc, char **argv)
                 , problem_report_get_summary(pr)
                 , problem_report_get_description(pr)
         );
-
-        problem_data_free(problem_data);
-        problem_report_free(pr);
-        problem_formatter_free(pf);
         return 0;
     }
 
@@ -352,10 +348,6 @@ int main(int argc, char **argv)
     sd_journal_sendv(msg_content_get_data(msg_c), msg_content_get_size(msg_c));
 
     msg_content_free(msg_c);
-
-    problem_data_free(problem_data);
-    problem_formatter_free(pf);
-    problem_report_free(pr);
 
     return 0;
 }


### PR DESCRIPTION
* Use `GPtrArray` for pointer arrays in `reporter-mailx`.
* Declare GLib auto-cleanup functions for `problem_data_t`, `problem_formatter_t` and `problem_report_t`.

Broken out of #641.