### PR TITLE
ignored_words: Ignore "bypass" and "IBRS_FW"

### DIFF
--- a/src/gui-wizard-gtk/ignored_words.conf
+++ b/src/gui-wizard-gtk/ignored_words.conf
@@ -9,6 +9,9 @@ Accessible
 accountsservice
 account_for_vscrollbar
 AccountsService
+bypass
+Bypass
+BYPASS
 Cannot access memory
 EventKey
 event_key
@@ -17,6 +20,7 @@ gnome-ssh-askpass
 hawkey
 hotkey
 Hotkey
+IBRS_FW
 keyboard
 KEYBOARD
 keymap
@@ -45,7 +49,6 @@ KeyValuePairKeyExtractor
 keyup
 KEYUP
 ksshaskpass
-irqbypass
 libkeyutils.so
 libpciaccess.so
 libsecret
@@ -58,7 +61,6 @@ PassOwnPtr
 PassRefPtr
 passed
 QNetworkAccessManager
-SYSTEMD_NSS_BYPASS_BUS
 This access was not denied.
 .keymap=
 (because of 'access')


### PR DESCRIPTION
"Bypass" is used in multiple contexts. `IBRS_FW` is used in cpuinfo as indicator of Indirect Branch Restricted Speculation (IBRS), a mitigation technique against Spectre attacks.

Resolves #667