### PR TITLE
client-python: Add getter for package count to downloader

### DIFF
--- a/src/client-python/reportclient/debuginfo.py
+++ b/src/client-python/reportclient/debuginfo.py
@@ -242,6 +242,9 @@ class DebugInfoDownload(object):
     def get_install_size(self):
         return self.installed_size
 
+    def get_package_count(self):
+        return len(self.package_files_dict)
+
     def mute_stdout(self):
         """
         Links sys.stdout with /dev/null and saves the old stdout


### PR DESCRIPTION
Add a new method `get_package_count()` to the `DebugInfoDownload` class which returns the number of packages that will be downloaded.