### PR TITLE
Fix segfault in gui-wizard-gtk

### DIFF
--- a/src/gui-wizard-gtk/main.c
+++ b/src/gui-wizard-gtk/main.c
@@ -125,6 +125,7 @@ int main(int argc, char **argv)
     /* List of events specified on the command line. */
     GList *user_event_list = NULL;
     const char *prgname = "abrt";
+    int ret = 0;
     abrt_init(argv);
 
     /* I18n */
@@ -217,13 +218,14 @@ int main(int argc, char **argv)
     g_signal_connect(app, "startup",  G_CALLBACK(startup_wizard),  NULL);
 
     /* Enter main loop */
-    g_application_run(G_APPLICATION(app), argc, argv);
+    ret = g_application_run(G_APPLICATION(app), argc, argv);
     g_object_unref(app);
+    libreport_g_custom_logger = NULL;
 
     if (opts & OPT_d)
         delete_dump_dir_possibly_using_abrtd(g_dump_dir_name);
 
     libreport_save_user_settings();
 
-    return 0;
+    return ret;
 }

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -360,6 +360,8 @@ struct dump_dir *wizard_open_directory_for_writing(const char *dump_dir_name)
 
 void show_error_as_msgbox(const char *msg)
 {
+    g_return_if_fail(g_wnd_assistant != NULL);
+
     GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(g_wnd_assistant),
                 GTK_DIALOG_DESTROY_WITH_PARENT,
                 GTK_MESSAGE_WARNING,


### PR DESCRIPTION
Since `show_error_as_msgbox()` is specified as the custom logging handler in `gui-wizard-gtk/main.c` (via setting `libreport_g_custom_logger`), it will get called if an error occurs in `libreport_save_user_settings()`. However, at that point, `g_wnd_assistant` has already been destroyed, which leads to an invalid read in `show_error_as_msgbox()`.

This change unsets the custom logging handler after the GUI is destroyed and adds an assertion in `show_error_as_msgbox()` checking that `g_wnd_assistant` is not a null pointer.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1883337