### PR TITLE
Null autofree pointers before returning

### DIFF
--- a/src/lib/event_config.c
+++ b/src/lib/event_config.c
@@ -541,10 +541,10 @@ bool check_problem_rating_usability(const event_config_t *cfg,
 
 finish:
     if (description)
-        *description = tmp_desc;
+        *description = g_steal_pointer(&tmp_desc);
 
     if (detail)
-        *detail = tmp_detail;
+        *detail = g_steal_pointer(&tmp_detail);
 
     return result;
 }


### PR DESCRIPTION
The pointers to strings in the function `check_problem_rating_usability()` need to be nullified before the function returns as they are declared for auto-cleanup.

This change fixes a double-free condition in which the returned strings were attempted to be freed again in the caller, `is_backtrace_rating_usable()`.

Bug was introduced in 05e9c9273.

Resolves [rhbz#1883410](https://bugzilla.redhat.com/show_bug.cgi?id=1883410)