### PR TITLE
Fix segfault in wizard

### DIFF
--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -495,7 +495,7 @@ static void open_browse_if_link(GtkWidget *text_view, GtkTextIter *iter)
         GtkTextTag *tag = tagp->data;
         const char *url = g_object_get_data (G_OBJECT (tag), "url");
 
-        if (url != 0)
+        if (url != NULL)
         {
             /* http://techbase.kde.org/KDE_System_Administration/Environment_Variables#KDE_FULL_SESSION */
             if (getenv("KDE_FULL_SESSION") != NULL)
@@ -614,7 +614,7 @@ static void set_cursor_if_appropriate(GtkTextView *text_view,
         GtkTextTag *tag = tagp->data;
         gpointer url = g_object_get_data(G_OBJECT (tag), "url");
 
-        if (url != 0)
+        if (url != NULL)
         {
             hovering = TRUE;
             break;

--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -462,8 +462,8 @@ static void append_to_textview(GtkTextView *tv, const char *str)
         GtkTextTag *tag;
         tag = gtk_text_buffer_create_tag(tb, NULL, "foreground", "blue",
                                          "underline", PANGO_UNDERLINE_SINGLE, NULL);
-        g_autofree char *url = g_strndup(t->start, t->len);
-        g_object_set_data(G_OBJECT(tag), "url", url);
+        char *url = g_strndup(t->start, t->len);
+        g_object_set_data_full(G_OBJECT(tag), "url", url, g_free);
 
         gtk_text_buffer_insert_with_tags(tb, &text_iter, url, -1, tag, NULL);
 


### PR DESCRIPTION
`g_object_set_data()` does not (and cannot) copy the data passed to it, so once `url` is freed, a subsequent access to the `url` tag leads to an invalid read and segfault.

Bug was introduced in df386b097.

Resolves [rhbz#1882328](https://bugzilla.redhat.com/show_bug.cgi?id=1882328)