### PR TITLE
rhbz: Fix a double-free condition

### DIFF
--- a/src/plugins/rhbz.c
+++ b/src/plugins/rhbz.c
@@ -407,18 +407,20 @@ GList *rhbz_bug_cc(xmlrpc_value* result_xml)
         if (!item)
             continue;
 
-        const char* cc = NULL;
-        xmlrpc_read_string(&env, item, &cc);
+        char *cc = NULL;
+        xmlrpc_read_string(&env, item, (const char **)&cc);
         xmlrpc_DECREF(item);
         if (env.fault_occurred)
             abrt_xmlrpc_die(&env);
 
         if (*cc != '\0')
         {
-            cc_list = g_list_append(cc_list, (char*)cc);
+            cc_list = g_list_append(cc_list, cc);
             log_debug("member on cc is %s", cc);
             continue;
         }
+
+        free(cc);
     }
     xmlrpc_DECREF(cc_member);
     return cc_list;


### PR DESCRIPTION
The `cc` string must not be freed after the variable goes out of scope since it's appended to `cc_list`. (`g_list_append()` does not copy its input.) We only need to free the last string in the loop, which is an empty string.

The bug was introduced in 7aba6e53.

Resolves [rhbz#1893595](https://bugzilla.redhat.com/show_bug.cgi?id=1893595)