### PR TITLE
spec: Use autoreconf in %build instead of autoconf

### DIFF
--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -284,7 +284,7 @@ data over ftp/scp...
 %autosetup
 
 %build
-autoconf
+autoreconf
 
 %configure \
 %if %{without bugzilla}


### PR DESCRIPTION
This way, when stuff is fixed in automake, the source tarball does not need to be re-generated in upstream to use the fix.

Resolves [rhbz#1893652](https://bugzilla.redhat.com/show_bug.cgi?id=1893652)

Backport of [downstream MR](https://src.fedoraproject.org/rpms/libreport/pull-request/5).