### PR TITLE
spec: Drop subscription-manager-rhsm dependency

### DIFF
--- a/libreport.spec
+++ b/libreport.spec
@@ -222,9 +222,6 @@ Summary: %{name}'s micro report plugin
 BuildRequires: %{libjson_devel}
 Requires: %{name} = %{version}-%{release}
 Requires: libreport-web = %{version}-%{release}
-%if 0%{?rhel} && ! 0%{?eln}
-Requires: python3-subscription-manager-rhsm
-%endif
 
 %description plugin-ureport
 Uploads micro-report to abrt server

--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -217,9 +217,6 @@ Summary: %{name}'s micro report plugin
 BuildRequires: %{libjson_devel}
 Requires: %{name} = %{version}-%{release}
 Requires: libreport-web = %{version}-%{release}
-%if 0%{?rhel} && ! 0%{?eln}
-Requires: python3-subscription-manager-rhsm
-%endif
 
 %description plugin-ureport
 Uploads micro-report to abrt server


### PR DESCRIPTION
python3-subscription-manager-rhsm isn't required since aeb7980e

Resolves:
https://github.com/abrt/libreport/issues/688
Signed-off-by: Michal Fabik <mfabik@redhat.com>