### PR TITLE
Untranslatable strings

### DIFF
--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -251,7 +251,7 @@ int main(int argc, char **argv)
 #endif
 
     /* Can't keep these strings/structs static: _() doesn't support that */
-    const char *program_usage_string = _(
+    g_autofree char *program_usage_string = g_strdup_printf(_(
         "\n& [-vbf] [-g GROUP-NAME]... [-c CONFFILE]... [-F FMTFILE] [-A FMTFILE2] -d DIR"
         "\nor:"
         "\n& [-v] [-c CONFFILE]... [-d DIR] -t[ID] FILE..."
@@ -289,16 +289,18 @@ int main(int argc, char **argv)
         "\nTRACKER_NAME to URL field. This option is applied only when a new bug is to be"
         "\nfiled. The default value is 'ABRT Server'"
         "\n"
-        "\nIf not specified, CONFFILE defaults to "CONF_DIR"/plugins/bugzilla.conf"
-        "\nand user's local ~"USER_HOME_CONFIG_PATH"/bugzilla.conf."
+        "\nIf not specified, CONFFILE defaults to %1$s/plugins/bugzilla.conf"
+        "\nand user's local ~%2$s/bugzilla.conf."
         "\nIts lines should have 'PARAM = VALUE' format."
         "\nRecognized string parameters: BugzillaURL, Login, Password, OSRelease."
         "\nRecognized boolean parameter (VALUE should be 1/0, yes/no): SSLVerify."
         "\nUser's local configuration overrides the system wide configuration."
         "\nParameters can be overridden via $Bugzilla_PARAM environment variables."
         "\n"
-        "\nFMTFILE and FMTFILE2 default to "CONF_DIR"/plugins/bugzilla_format.conf"
-    );
+        "\nFMTFILE and FMTFILE2 default to %1$s/plugins/bugzilla_format.conf"),
+        CONF_DIR,
+        USER_HOME_CONFIG_PATH);
+
     enum {
         OPT_v = 1 << 0,
         OPT_d = 1 << 1,

--- a/src/plugins/reporter-mailx.c
+++ b/src/plugins/reporter-mailx.c
@@ -228,17 +228,17 @@ int main(int argc, char **argv)
     const char *fmt_file = NULL;
 
     /* Can't keep these strings/structs static: _() doesn't support that */
-    const char *program_usage_string = _(
+    g_autofree char *program_usage_string = g_strdup_printf(_(
         "& [-v] -d DIR [-c CONFFILE] [-F FMTFILE]"
         "\n"
         "\n""Sends contents of a problem directory DIR via email"
         "\n"
-        "\n""If not specified, CONFFILE defaults to "CONF_DIR"/plugins/mailx.conf"
+        "\n""If not specified, CONFFILE defaults to %s/plugins/mailx.conf"
         "\n""Its lines should have 'PARAM = VALUE' format."
         "\n""Recognized string parameters: Subject, EmailFrom, EmailTo."
         "\n""Recognized boolean parameter (VALUE should be 1/0, yes/no): SendBinaryData."
-        "\n""Parameters can be overridden via $Mailx_PARAM environment variables."
-    );
+        "\n""Parameters can be overridden via $Mailx_PARAM environment variables."),
+        CONF_DIR);
 
     enum {
         OPT_v = 1 << 0,

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
     textdomain(PACKAGE);
 #endif
 
-    const char *program_usage_string = _(
+    g_autofree char *program_usage_string = g_strdup_printf(_(
         "\n& [-vf] [-c CONFFILE]... [-F FMTFILE] [-A FMTFILE2] -d DIR"
         "\nor:"
         "\n& [-v] [-c CONFFILE]... [-d DIR] -t[ID] FILE..."
@@ -251,17 +251,18 @@ int main(int argc, char **argv)
         "\nTRACKER_NAME to URL field. This option is applied only when a new issue is to be"
         "\nfiled. The default value is 'ABRT Server'"
         "\n"
-        "\nIf not specified, CONFFILE defaults to "CONF_DIR"/plugins/mantisbt.conf"
-        "\nand user's local ~"USER_HOME_CONFIG_PATH"/mantisbt.conf."
+        "\nIf not specified, CONFFILE defaults to %1$s/plugins/mantisbt.conf"
+        "\nand user's local ~%2$s/mantisbt.conf."
         "\nIts lines should have 'PARAM = VALUE' format."
         "\nRecognized string parameters: MantisbtURL, Login, Password, Project, ProjectVersion."
         "\nRecognized boolean parameter (VALUE should be 1/0, yes/no): SSLVerify, CreatePrivate."
         "\nUser's local configuration overrides the system wide configuration."
         "\nParameters can be overridden via $Mantisbt_PARAM environment variables."
         "\n"
-        "\nFMTFILE default to "CONF_DIR"/plugins/mantisbt_format.conf."
-        "\nFMTFILE2 default to "CONF_DIR"/plugins/mantisbt_formatdup.conf."
-    );
+        "\nFMTFILE default to %1$s/plugins/mantisbt_format.conf."
+        "\nFMTFILE2 default to %1$s/plugins/mantisbt_formatdup.conf."),
+        CONF_DIR,
+        USER_HOME_CONFIG_PATH);
 
     enum {
         OPT_v = 1 << 0,

--- a/src/plugins/reporter-upload.c
+++ b/src/plugins/reporter-upload.c
@@ -149,11 +149,11 @@ int main(int argc, char **argv)
     const char *ssh_private_key = NULL;
 
     /* Can't keep these strings/structs static: _() doesn't support that */
-    const char *program_usage_string = _(
+    g_autofree char *program_usage_string = g_strdup_printf(_(
         "& [-v] -d DIR [-c CONFFILE] [-u URL] [-b FILE] [-r FILE]\n"
         "\n"
         "Uploads compressed tarball of problem directory DIR to URL.\n"
-        "If URL is not specified, creates tarball in "LARGE_DATA_TMP_DIR" and exits.\n"
+        "If URL is not specified, creates tarball in %1$s and exits.\n"
         "\n"
         "URL should have form 'protocol://[user[:pass]@]host/dir/[file.tar.gz]'\n"
         "where protocol can be http(s), ftp, scp, or file.\n"
@@ -164,11 +164,13 @@ int main(int argc, char **argv)
         "Files with names listed in $EXCLUDE_FROM_REPORT are not included\n"
         "into the tarball.\n"
         "\n"
-        "\n""If not specified, CONFFILE defaults to "CONF_DIR"/plugins/upload.conf"
+        "\n""If not specified, CONFFILE defaults to %2$s/plugins/upload.conf"
         "\n""Its lines should have 'PARAM = VALUE' format."
         "Recognized string parameter: URL.\n"
-        "Parameter can be overridden via $Upload_URL."
-    );
+        "Parameter can be overridden via $Upload_URL."),
+        LARGE_DATA_TMP_DIR,
+        CONF_DIR);
+
     enum {
         OPT_v = 1 << 0,
         OPT_d = 1 << 1,

--- a/src/plugins/reporter-ureport.c
+++ b/src/plugins/reporter-ureport.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
         OPT_END(),
     };
 
-    const char *program_usage_string = _(
+    g_autofree char *program_usage_string = g_strdup_printf(_(
         "& [-v] [-c FILE] [-u URL] [-k] [-t SOURCE] [-h CREDENTIALS]\n"
         "  [-A -a bthash -B -b bug-id -E -e email -O -o comment] [-d DIR]\n"
         "  [-A -a bthash -T ATTACHMENT_TYPE -r REPORT_RESULT_TYPE -L RESULT_FIELD] [-d DIR]\n"
@@ -118,8 +118,8 @@ int main(int argc, char **argv)
         "\n"
         "Upload micro report or add an attachment to a micro report\n"
         "\n"
-        "Reads the default configuration from "UREPORT_CONF_FILE_PATH
-    );
+        "Reads the default configuration from %s"),
+        UREPORT_CONF_FILE_PATH);
 
     unsigned opts = libreport_parse_opts(argc, argv, program_options, program_usage_string);
 


### PR DESCRIPTION
Strings that are marked for translations should not include macros or any other compile time resolved values.