### PR TITLE
gtk-helpers: Check for NULL before saving event config data

### DIFF
--- a/src/gtk-helpers/event_config_dialog.c
+++ b/src/gtk-helpers/event_config_dialog.c
@@ -86,6 +86,11 @@ static void save_data_from_event_dialog_name(GList *widgets, const char *name)
 {
     event_config_t *ec = get_event_config(name);
 
+    if (ec == NULL) {
+        log_warning("Cannot save data from event dialog. Event '%s' could not be found", name);
+        return;
+    }
+
     save_data_from_event_config_dialog(widgets, ec);
 }
 


### PR DESCRIPTION
Check that the configuration object for the current event is not null. This has been causing segfaults intermittently. I'm not yet sure how exactly this happens so this is kind of a hotfix.

Related: [rhbz#1909855](https://bugzilla.redhat.com/show_bug.cgi?id=1909855)