### PR TITLE
[spec] Drop AnacondaRHEL workflow reference

### DIFF
--- a/libreport.spec
+++ b/libreport.spec
@@ -648,9 +648,6 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %if 0%{?fedora} || 0%{?eln}
 %{_datadir}/%{name}/workflows/workflow_AnacondaFedora.xml
 %endif
-%if 0%{?rhel} && ! 0%{?eln}
-%{_datadir}/%{name}/workflows/workflow_AnacondaRHEL.xml
-%endif
 %{_datadir}/%{name}/workflows/workflow_AnacondaUpload.xml
 %config(noreplace) %{_sysconfdir}/libreport/workflows.d/anaconda_event.conf
 %config(noreplace) %{_sysconfdir}/libreport/events.d/bugzilla_anaconda_event.conf

--- a/libreport.spec.in
+++ b/libreport.spec.in
@@ -640,9 +640,6 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %if 0%{?fedora} || 0%{?eln}
 %{_datadir}/%{name}/workflows/workflow_AnacondaFedora.xml
 %endif
-%if 0%{?rhel} && ! 0%{?eln}
-%{_datadir}/%{name}/workflows/workflow_AnacondaRHEL.xml
-%endif
 %{_datadir}/%{name}/workflows/workflow_AnacondaUpload.xml
 %config(noreplace) %{_sysconfdir}/libreport/workflows.d/anaconda_event.conf
 %config(noreplace) %{_sysconfdir}/libreport/events.d/bugzilla_anaconda_event.conf


### PR DESCRIPTION
The support for Red Hat Customer Portal was removed in 1972853. This
forgotten reference in spec file is making the package FTBFS in RHEL now.