### PR TITLE
.tito: Change commit message and tag format

### DIFF
--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -3,3 +3,5 @@ builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
+tag_commit_message_format = Release version %(version)s
+tag_format = {version}


### PR DESCRIPTION
Set tito tag and release title format to simple x.y.z and
Release x.y.z respectively instead of the unwieldy defaults to
continue the release practice used so far.