### PR TITLE
spec: Sync upstream with distgit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,6 @@ testsuite.log
 # misc
 \#*
 *~
-# this is obsolete since moving to tito, but leaving here for some time
 libreport-version
 
 #generated api docs

--- a/libreport.spec
+++ b/libreport.spec
@@ -37,6 +37,7 @@ BuildRequires: libproxy-devel
 BuildRequires: satyr-devel >= 0.24
 BuildRequires: glib2-devel >= %{glib_ver}
 BuildRequires: nettle-devel
+BuildRequires: git-core
 
 %if 0%{?fedora} >= 24 || 0%{?rhel} > 7
 # A test case uses zh_CN locale to verify XML event translations
@@ -281,10 +282,7 @@ data over ftp/scp...
 %autosetup
 
 %build
-sed 's|DEF_VER=.*$$|DEF_VER='%{version}'|' -i gen-version
-#./gen-version
 ./autogen.sh
-autoconf
 
 %configure \
 %if %{without bugzilla}


### PR DESCRIPTION
Since the current setup with GitHub Actions automatically opens PRs
against the distgit with each realease tag and since the spec file is
included in the release commit by tito, we want the upstream and distgit
version of the spec file to be as close as possible.