### PR TITLE
Add support for excluding whole elements from search for sensitive words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - ignored_words: add more "key" variations
+- Add support for excluding whole elements from search for sensitive words
 
 ## [2.15.0] - 2020-03-03
 ### Added

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -44,6 +44,7 @@ MAN5_TXT = \
 	mantisbt_format_analyzer_libreport.conf.txt \
 	mantisbt_formatdup_analyzer_libreport.conf.txt \
 	ignored_words.conf.txt \
+	ignored_elements.conf.txt \
 	forbidden_words.conf.txt \
 	libreport.conf.txt \
 	mailx.conf.txt \

--- a/doc/forbidden_words.conf.txt
+++ b/doc/forbidden_words.conf.txt
@@ -35,7 +35,7 @@ $XDG_CONFIG_HOME/abrt/settings/forbidden_words.conf
 
 SEE ALSO
 --------
-report-gtk(1), ignored_words.conf(5)
+report-gtk(1), ignored_words.conf(5), ignored_elements.conf(5)
 
 AUTHOR
 ------

--- a/doc/ignored_elements.conf.txt
+++ b/doc/ignored_elements.conf.txt
@@ -1,0 +1,47 @@
+ignored_elements.conf(5)
+========================
+
+NAME
+----
+ignored_elements.conf - configuration file for libreport.
+
+DESCRIPTION
+-----------
+This configuration file specifies which elements should *NOT* be checked
+for sensitive data during the process of reporting a problem. This means
+that, for the elements specified in this file, no words will be highlighted
+in the User Interface (UI). See also report-gtk(1).
+
+Only elements that are known not to contain sensitive data should be on this
+list.
+
+Custom search in the UI ignores this list and works with all elements.
+
+The configuration format is one line per ignored element.
+
+Users can provide own file with the list of ignored elements which will be
+appended to the list of ignored elements loaded from
+/etc/libreport/ignored_elements.conf
+
+EXAMPLES
+--------
+System configuration:
+
+/etc/libreport/ignored_elements.conf
+
+    cpuinfo
+    open_fds
+
+User configuration:
+
+$XDG_CONFIG_HOME/abrt/settings/ignored_elements.conf
+
+    hostname
+
+SEE ALSO
+--------
+report-gtk(1), forbidden_words.conf(5), ignored_words.conf(5)
+
+AUTHOR
+------
+* ABRT team

--- a/doc/ignored_words.conf.txt
+++ b/doc/ignored_words.conf.txt
@@ -35,7 +35,7 @@ $XDG_CONFIG_HOME/abrt/settings/ignored_words.conf
 
 SEE ALSO
 --------
-report-gtk(1), forbidden_words.conf(5)
+report-gtk(1), forbidden_words.conf(5), ignored_elements.conf(5)
 
 AUTHOR
 ------

--- a/doc/report-gtk.txt
+++ b/doc/report-gtk.txt
@@ -55,7 +55,7 @@ If $XDG_CONFIG_HOME is not set, $HOME/.config is used instead.
 Sensitive data search
 ~~~~~~~~~~~~~~~~~~~~~
 
-See forbidden_words.conf(5) and ignored_words.conf(5)
+See forbidden_words.conf(5), ignored_words.conf(5) and ignored_elements.conf(5)
 
 Reporting work flow configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -114,7 +114,7 @@ Simple reporting work flow
 
 SEE ALSO
 --------
-forbidden_words.conf(5), ignored_words.conf(5)
+forbidden_words.conf(5), ignored_words.conf(5), ignored_elements.conf(5)
 
 AUTHORS
 -------

--- a/libreport.spec
+++ b/libreport.spec
@@ -400,12 +400,14 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %config(noreplace) %{_sysconfdir}/%{name}/report_event.conf
 %config(noreplace) %{_sysconfdir}/%{name}/forbidden_words.conf
 %config(noreplace) %{_sysconfdir}/%{name}/ignored_words.conf
+%config(noreplace) %{_sysconfdir}/%{name}/ignored_elements.conf
 %{_datadir}/%{name}/conf.d/libreport.conf
 %{_libdir}/libreport.so.*
 %{_mandir}/man5/libreport.conf.5*
 %{_mandir}/man5/report_event.conf.5*
 %{_mandir}/man5/forbidden_words.conf.5*
 %{_mandir}/man5/ignored_words.conf.5*
+%{_mandir}/man5/ignored_elements.conf.5*
 # filesystem package owns /usr/share/augeas/lenses directory
 %{_datadir}/augeas/lenses/libreport.aug
 

--- a/src/gui-wizard-gtk/Makefile.am
+++ b/src/gui-wizard-gtk/Makefile.am
@@ -45,7 +45,8 @@ EXTRA_DIST = $(GLADE_FILES)
 libreportconfdir = $(CONF_DIR)
 dist_libreportconf_DATA = \
     forbidden_words.conf \
-    ignored_words.conf
+    ignored_words.conf \
+    ignored_elements.conf
 
 # For internal glade file storage in the binary:
 wizard.c: wizard_glade.c

--- a/src/gui-wizard-gtk/ignored_elements.conf
+++ b/src/gui-wizard-gtk/ignored_elements.conf
@@ -1,0 +1,2 @@
+cpuinfo
+open_fds


### PR DESCRIPTION
Sections like "cpuinfo" or "open_fds" should be fairly safe
to ignore. There shouldn't be any URLs, tokens or passwords
in them.

Users can still review those sections and custom user searches will still
highlight words in them. We will just not flag any forbidden words in
them by default.

If needed, more sections can be easily added to the list.

Signed-off-by: Michal Srb <michal@redhat.com>