### PR TITLE
spec: Make plugin-mailx depend on /usr/bin/mailx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,7 +260,8 @@ files.
 functions reporting errors through errno.
 
 
-[Unreleased]: https://github.com/abrt/libreport/compare/2.14.0...HEAD
+[Unreleased]: https://github.com/abrt/libreport/compare/2.15.0...HEAD
+[2.15.0]: https://github.com/abrt/libreport/compare/2.14.0...2.15.0
 [2.14.0]: https://github.com/abrt/libreport/compare/2.13.1...2.14.0
 [2.13.1]: https://github.com/abrt/libreport/compare/2.13.0...2.13.1
 [2.13.0]: https://github.com/abrt/libreport/compare/2.12.0...2.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - ignored_words: add more "key" variations
 - Add support for excluding whole elements from search for sensitive words
 
+### Changed
+- libreport-plugin-mailx now depends on /usr/bin/mailx (also provided by s-nail) instead of the mailx package
+
 ## [2.15.0] - 2020-03-03
 ### Added
 - Add support for sub-components in RH Bugzilla

--- a/libreport.spec
+++ b/libreport.spec
@@ -179,7 +179,7 @@ The simple reporter plugin which writes a report to the systemd journal.
 %package plugin-mailx
 Summary: %{name}'s mailx reporter plugin
 Requires: %{name} = %{version}-%{release}
-Requires: mailx
+Requires: /usr/bin/mailx
 
 %description plugin-mailx
 The simple reporter plugin which sends a report via mailx to a specified


### PR DESCRIPTION
Resolves [rhbz#1947018](https://bugzilla.redhat.com/show_bug.cgi?id=1947018)