### PR TITLE
gui-wizard-gtk: Improve docs and add missing free

### DIFF
--- a/src/gui-wizard-gtk/wizard.c
+++ b/src/gui-wizard-gtk/wizard.c
@@ -1105,6 +1105,9 @@ static void update_ls_details_checkboxes(const char *event_name)
             } while (gtk_tree_model_iter_next(GTK_TREE_MODEL(g_ls_details), &iter));
         }
     }
+
+    /* Free allocated resources before exiting */
+    g_strfreev(global_exclude);
 }
 
 void update_gui_state_from_problem_data(int flags)

--- a/src/include/global_configuration.h
+++ b/src/include/global_configuration.h
@@ -32,6 +32,15 @@ bool libreport_load_global_configuration_from_dirs(const char *dirs[], int dir_f
 
 void libreport_free_global_configuration(void);
 
+/**
+ * Returns list of excluded elements
+ *
+ * This function returns list of elements in problem directory
+ * that are always excluded from the report.
+ *
+ * @return NULL terminated array of strings with names of excluded elements.
+ * Must be freed using g_strfreev by the caller.
+ */
 string_vector_ptr_t libreport_get_global_always_excluded_elements(void);
 
 bool libreport_get_global_create_private_ticket(void);


### PR DESCRIPTION
Add missing g_strfreev. Reported by covscan. Also
add doxygen comment to the function that allocated
the resources to mention that the returned value
should be freed.