### PR TITLE
dirsize: No need to check for NULL

### DIFF
--- a/src/lib/dirsize.c
+++ b/src/lib/dirsize.c
@@ -90,8 +90,8 @@ double libreport_get_dirsize_find_largest_dir(
         if (libreport_dot_or_dotdot(ep->d_name))
             continue;
         g_autofree char *dname = g_build_filename(pPath ? pPath : "", ep->d_name, NULL);
-        g_autofree char *sosreport_path = g_build_filename(dname ? dname : "", "sosreport.log", NULL);
-        g_autofree char *lock_path = g_build_filename(dname ? dname : "", ".lock", NULL);
+        g_autofree char *sosreport_path = g_build_filename(dname, "sosreport.log", NULL);
+        g_autofree char *lock_path = g_build_filename(dname, ".lock", NULL);
         if (lstat(sosreport_path, &statbuf) == 0)
         {
             log_debug("Skipping %s': sosreport is being generated.", dname);


### PR DESCRIPTION
Reported by covscan. If we check for NULL the static
analyzers assume the value can be NULL, but it can not
as it is allocated using the g_* family of functions
and the application would terminate if the memory allocation
failed.