### PR TITLE
dump_dir: Use g_free and re-init to NULL

### DIFF
--- a/src/lib/dump_dir.c
+++ b/src/lib/dump_dir.c
@@ -1668,7 +1668,7 @@ int dd_chown(struct dump_dir *dd, uid_t new_uid)
             }
 
 next:
-            free(short_name);
+            g_clear_pointer(&short_name, g_free);
         }
     }
 
@@ -2539,10 +2539,10 @@ retry:
             close(fd);
         }
 
-        free(short_name);
-        free(full_name);
+        g_clear_pointer(&short_name, g_free);
+        g_clear_pointer(&full_name, g_free);
 
-    }
+    } /*while*/
 
 finito:
 


### PR DESCRIPTION
Covscan reported this as potential double free.
It is definitelly better to re-init to NULL in
case we free memory in the middle of a function
and the pointer is being used after that.