### PR TITLE
steal_directory: Silence a warning

### DIFF
--- a/src/lib/steal_directory.c
+++ b/src/lib/steal_directory.c
@@ -51,7 +51,8 @@ struct dump_dir *libreport_steal_directory(const char *base_dir, const char *dum
     while (1)
     {
         dd_dst = dd_create(dst_dir_name, (uid_t)-1, DEFAULT_DUMP_DIR_MODE);
-        free(dst_dir_name);
+        g_clear_pointer(&dst_dir_name, g_free);
+
         if (dd_dst)
             break;
         if (--count == 0)


### PR DESCRIPTION
This is to silence a double-free warning. The
double-free can not really happen with current code
but it is good practice to init the pointer with
NULL after it is freed and planned to be used
again.