### PR TITLE
Use g_free for GLib-alloc'd memory

### DIFF
--- a/src/cli/cli-report.c
+++ b/src/cli/cli-report.c
@@ -25,7 +25,7 @@
 
 /*
  * Escapes the field content string to avoid confusion with file comments.
- * Returned field must be free()d by caller.
+ * Returned field must be g_free()d by caller.
  */
 static char *escape(const char *str)
 {
@@ -239,7 +239,7 @@ static int read_crash_report_field(const char *text, problem_data_t *report,
     if (strcmp(newvalue, oldvalue) == 0)
         return 0;
 
-    free(value->content);
+    g_free(value->content);
     value->content = g_strdup(newvalue);
     return 1;
 }

--- a/src/include/internal_libreport.h
+++ b/src/include/internal_libreport.h
@@ -450,7 +450,7 @@ GString *libreport_strbuf_prepend_strfv(GString *strbuf,
                                     const char *format, va_list p);
 
 /* Returns command line of running program.
- * Caller is responsible to free() the returned value.
+ * Caller is responsible to g_free() the returned value.
  * If the pid is not valid or command line can not be obtained,
  * empty string is returned.
  */
@@ -601,8 +601,8 @@ void libreport_parse_osinfo(const char *osinfo_bytes, GHashTable *osinfo);
  * https://bugzilla.redhat.com/show_bug.cgi?id=950373
  *
  * @param osinfo Input data from which the values are built
- * @param produc Non-NULL pointer where pointer to malloced string will be stored. Memory must be released by free()
- * @param version Non-NULL pointer where pointer to malloced string will be stored. Memory must be released by free()
+ * @param product Non-NULL pointer where pointer to g_malloced string will be stored. Memory must be released by g_free()
+ * @param version Non-NULL pointer where pointer to g_malloced string will be stored. Memory must be released by g_free()
  */
 void libreport_parse_osinfo_for_bz(GHashTable *osinfo, char **product, char **version);
 
@@ -615,7 +615,7 @@ void libreport_parse_osinfo_for_bz(GHashTable *osinfo, char **product, char **ve
  * https://github.com/abrt/libreport/issues/459
  *
  * @param osinfo Input data from which the values are built
- * @param url Non-NULL pointer where pointer to malloced string will be stored. Memory must be released by free()
+ * @param url Non-NULL pointer where pointer to g_malloced string will be stored. Memory must be released by g_free()
  */
 void libreport_parse_osinfo_for_bug_url(GHashTable *osinfo, char** url);
 

--- a/src/lib/abrt_xmlrpc.c
+++ b/src/lib/abrt_xmlrpc.c
@@ -122,7 +122,7 @@ void abrt_xmlrpc_free_client(struct abrt_xmlrpc *ax)
 
     g_list_free(ax->ax_session_params);
 
-    free(ax);
+    g_free(ax);
 }
 
 void abrt_xmlrpc_client_add_session_param_string(xmlrpc_env *env, struct abrt_xmlrpc *ax,

--- a/src/lib/config_item_info.c
+++ b/src/lib/config_item_info.c
@@ -41,29 +41,29 @@ void free_config_info(config_item_info_t *info)
     if (info == NULL)
         return;
 
-    free(info->name);
-    free(info->screen_name);
-    free(info->description);
-    free(info->long_desc);
+    g_free(info->name);
+    g_free(info->screen_name);
+    g_free(info->description);
+    g_free(info->long_desc);
 
-    free(info);
+    g_free(info);
 }
 
 void ci_set_screen_name(config_item_info_t *ci, const char *screen_name)
 {
-    free(ci->screen_name);
+    g_free(ci->screen_name);
     ci->screen_name = g_strdup(screen_name);
 }
 
 void ci_set_description(config_item_info_t *ci, const char *description)
 {
-    free(ci->description);
+    g_free(ci->description);
     ci->description = g_strdup(description);
 }
 
 void ci_set_long_desc(config_item_info_t *ci, const char *long_description)
 {
-    free(ci->long_desc);
+    g_free(ci->long_desc);
     ci->long_desc = g_strdup(long_description);
 }
 

--- a/src/lib/curl.c
+++ b/src/lib/curl.c
@@ -127,12 +127,12 @@ void free_post_state(post_state_t *state)
     if (headers)
     {
         while (*headers)
-            free(*headers++);
-        free(state->headers);
+            g_free(*headers++);
+        g_free(state->headers);
     }
-    free(state->curl_error_msg);
+    g_free(state->curl_error_msg);
     free(state->body);
-    free(state);
+    g_free(state);
 }
 
 char *find_header_in_post_state(post_state_t *state, const char *str)
@@ -183,7 +183,7 @@ save_headers(void *buffer_pv, size_t count, size_t nmemb, void *ptr)
         if (headers)
         {
             while (*headers)
-                free(*headers++);
+                g_free(*headers++);
         }
         cnt = 0;
     }
@@ -666,12 +666,12 @@ char *libreport_upload_file_ext(post_state_t *state, const char *url, const char
         {
             char *msg = g_strdup_printf(_("Please enter user name for '%s//%s':"), scheme, hostname);
             username = libreport_ask(msg);
-            free(msg);
+            g_free(msg);
             if (username != NULL && username[0] != '\0')
             {
                 msg = g_strdup_printf(_("Please enter password for '%s//%s@%s':"), scheme, username, hostname);
                 password = libreport_ask_password(msg);
-                free(msg);
+                g_free(msg);
                 /* What about empty password? */
                 if (password != NULL && password[0] != '\0')
                 {

--- a/src/lib/dirsize.c
+++ b/src/lib/dirsize.c
@@ -138,7 +138,7 @@ double libreport_get_dirsize_find_largest_dir(
                         if (!proc_dir || strcmp(proc_dir, ep->d_name) != 0)
                         {
                             maxsz = sz;
-                            free(*worst_dir);
+                            g_free(*worst_dir);
                             *worst_dir = g_strdup(ep->d_name);
                         }
                     }

--- a/src/lib/dump_dir.c
+++ b/src/lib/dump_dir.c
@@ -304,7 +304,7 @@ static int read_number_from_file_at(int dir_fd, const char *filename, const char
 
 finito:
     close(fd);
-    free(value_buf);
+    g_free(value_buf);
     /* If we got here, strtoll() successfully parsed a number */
     return ret;
 }
@@ -538,9 +538,9 @@ void dd_close(struct dump_dir *dd)
 
     dd_clear_next_file(dd);
 
-    free(dd->dd_type);
-    free(dd->dd_dirname);
-    free(dd);
+    g_free(dd->dd_type);
+    g_free(dd->dd_dirname);
+    g_free(dd);
 }
 
 static int dd_create_subdir(int dd_fd, const char *dirname, uid_t dd_uid, gid_t dd_gid, mode_t dd_mode)
@@ -1445,7 +1445,7 @@ void dd_sanitize_mode_and_owner(struct dump_dir *dd)
 
         close(fd);
 next:
-        free(short_name);
+        g_free(short_name);
     }
 
     /* No need to check return value, the functions print good messages.
@@ -2199,7 +2199,7 @@ int dd_rename(struct dump_dir *dd, const char *new_path)
     int res = rename(dd->dd_dirname, new_path);
     if (res == 0)
     {
-        free(dd->dd_dirname);
+        g_free(dd->dd_dirname);
         dd->dd_dirname = rm_trailing_slashes(new_path);
     }
     return res;

--- a/src/lib/event_config.c
+++ b/src/lib/event_config.c
@@ -130,22 +130,20 @@ void free_invalid_options(invalid_option_t *p)
 {
     if (!p)
         return;
-    free(p->invopt_name);
-    free(p->invopt_error);
-    free(p);
+    g_free(p->invopt_name);
+    g_free(p->invopt_error);
+    g_free(p);
 }
 
 void free_event_option(event_option_t *p)
 {
     if (!p)
         return;
-    free(p->eo_name);
-    free(p->eo_value);
-    free(p->eo_label);
-    free(p->eo_note_html);
-    //free(p->eo_description);
-    //free(p->eo_allowed_value);
-    free(p);
+    g_free(p->eo_name);
+    g_free(p->eo_value);
+    g_free(p->eo_label);
+    g_free(p->eo_note_html);
+    g_free(p);
 }
 
 void free_event_config(event_config_t *p)
@@ -154,15 +152,15 @@ void free_event_config(event_config_t *p)
         return;
 
     free_config_info(p->info);
-    free(p->ec_requires_items);
-    free(p->ec_exclude_items_by_default);
-    free(p->ec_include_items_by_default);
-    free(p->ec_exclude_items_always);
-    free(p->ec_restricted_access_option);
-    g_list_free_full(p->ec_imported_event_names, free);
+    g_free(p->ec_requires_items);
+    g_free(p->ec_exclude_items_by_default);
+    g_free(p->ec_include_items_by_default);
+    g_free(p->ec_exclude_items_always);
+    g_free(p->ec_restricted_access_option);
+    g_list_free_full(p->ec_imported_event_names, g_free);
     g_list_free_full(p->options, (GDestroyNotify)free_event_option);
 
-    free(p);
+    g_free(p);
 }
 
 
@@ -211,7 +209,7 @@ static void load_config_files(const char *dir_path)
             if (elem)
             {
                 opt = elem->data;
-                free(opt->eo_value);
+                g_free(opt->eo_value);
             }
             else
             {

--- a/src/lib/event_xml_parser.c
+++ b/src/lib/event_xml_parser.c
@@ -149,7 +149,7 @@ static void consume_cur_option(struct my_parse_data *parse_data)
             /* ...and it already has a value, which
              * overrides xml-defined default one:
              */
-            free(opt->eo_value);
+            g_free(opt->eo_value);
             opt->eo_value = old_opt->eo_value;
             old_opt->eo_value = NULL;
         }
@@ -198,7 +198,7 @@ static void start_element(GMarkupParseContext *context,
             log_info("attr: %s:%s", attribute_names[i], attribute_values[i]);
             if (strcmp(attribute_names[i], "name") == 0)
             {
-                free(opt->eo_name);
+                g_free(opt->eo_name);
                 opt->eo_name = g_strdup(attribute_values[i]);
             }
             else if (strcmp(attribute_names[i], "type") == 0)
@@ -233,7 +233,7 @@ static void start_element(GMarkupParseContext *context,
      || strcmp(element_name, NAME_ELEMENT) == 0
      || strcmp(element_name, NOTE_HTML_ELEMENT) == 0
     ) {
-        free(parse_data->attribute_lang);
+        g_free(parse_data->attribute_lang);
         parse_data->attribute_lang = get_element_lang(parse_data, attribute_names, attribute_values);
     }
     else
@@ -260,7 +260,7 @@ static void end_element(GMarkupParseContext *context,
 {
     struct my_parse_data *parse_data = user_data;
 
-    free(parse_data->attribute_lang);
+    g_free(parse_data->attribute_lang);
     parse_data->attribute_lang = NULL;
 
     if (strcmp(element_name, ADV_OPTIONS_ELEMENT) == 0)
@@ -309,7 +309,7 @@ static void text(GMarkupParseContext *context,
                             (strcmp(parse_data->attribute_lang, parse_data->cur_locale) == 0);
 
                         log_info("new label:'%s'", text_copy);
-                        free(opt->eo_label);
+                        g_free(opt->eo_label);
                         opt->eo_label = text_copy;
                         text_copy = NULL;
                     }
@@ -325,7 +325,7 @@ static void text(GMarkupParseContext *context,
         else if (strcmp(inner_element, DEFAULT_VALUE_ELEMENT) == 0)
         {
             log_info("default value:'%s'", text_copy);
-            free(opt->eo_value);
+            g_free(opt->eo_value);
             opt->eo_value = text_copy;
             text_copy = NULL;
         }
@@ -345,7 +345,7 @@ static void text(GMarkupParseContext *context,
                             (strcmp(parse_data->attribute_lang, parse_data->cur_locale) == 0);
 
                         log_info("html note:'%s'", text_copy);
-                        free(opt->eo_note_html);
+                        g_free(opt->eo_note_html);
                         opt->eo_note_html = text_copy;
                         text_copy = NULL;
                     }
@@ -361,7 +361,7 @@ static void text(GMarkupParseContext *context,
         if (strcmp(inner_element, DESCRIPTION_ELEMENT) == 0)
         {
             log_info("tooltip:'%s'", text_copy);
-            free(opt->eo_description);
+            g_free(opt->eo_description);
             opt->eo_description = text_copy;
             text_copy = NULL;
         }
@@ -440,25 +440,25 @@ static void text(GMarkupParseContext *context,
         }
         else if (strcmp(inner_element, REQUIRES_ELEMENT) == 0)
         {
-            free(ui->ec_requires_items);
+            g_free(ui->ec_requires_items);
             ui->ec_requires_items = text_copy;
             text_copy = NULL;
         }
         else if (strcmp(inner_element, EXCL_BY_DEFAULT_ELEMENT) == 0)
         {
-            free(ui->ec_exclude_items_by_default);
+            g_free(ui->ec_exclude_items_by_default);
             ui->ec_exclude_items_by_default = text_copy;
             text_copy = NULL;
         }
         else if (strcmp(inner_element, INCL_BY_DEFAULT_ELEMENT) == 0)
         {
-            free(ui->ec_include_items_by_default);
+            g_free(ui->ec_include_items_by_default);
             ui->ec_include_items_by_default = text_copy;
             text_copy = NULL;
         }
         else if (strcmp(inner_element, EXCL_ALWAYS_ELEMENT) == 0)
         {
-            free(ui->ec_exclude_items_always);
+            g_free(ui->ec_exclude_items_always);
             ui->ec_exclude_items_always = text_copy;
             text_copy = NULL;
         }
@@ -494,7 +494,7 @@ static void text(GMarkupParseContext *context,
             ui->ec_requires_details = libreport_string_to_bool(text_copy);
         }
     }
-    free(text_copy);
+    g_free(text_copy);
 }
 
   // Called for strings that should be re-saved verbatim in this same
@@ -567,6 +567,6 @@ void load_event_description_from_file(event_config_t *event_config, const char* 
     g_markup_parse_context_free(context);
 
     consume_cur_option(&parse_data); /* just in case */
-    free(parse_data.attribute_lang); /* just in case */
-    free(parse_data.cur_locale);
+    g_free(parse_data.attribute_lang); /* just in case */
+    g_free(parse_data.cur_locale);
 }

--- a/src/lib/file_obj.c
+++ b/src/lib/file_obj.c
@@ -32,9 +32,9 @@ void libreport_free_file_obj(file_obj_t *f)
     if (f == NULL)
         return;
 
-    free(f->fullpath);
-    free(f->filename);
-    free(f);
+    g_free(f->fullpath);
+    g_free(f->filename);
+    g_free(f);
 }
 
 const char *fo_get_fullpath(file_obj_t *fo)

--- a/src/lib/get_cmdline.c
+++ b/src/lib/get_cmdline.c
@@ -608,7 +608,7 @@ int libreport_dump_namespace_diff(const char *dest_filename, pid_t base_pid, pid
 void libreport_mountinfo_destroy(struct mountinfo *mntnf)
 {
     for (size_t i = 0; i < ARRAY_SIZE(mntnf->mntnf_items); ++i)
-        free(mntnf->mntnf_items[i]);
+        g_free(mntnf->mntnf_items[i]);
 }
 
 static int _read_mountinfo_word(FILE *fin)

--- a/src/lib/parse_options.c
+++ b/src/lib/parse_options.c
@@ -217,7 +217,7 @@ unsigned libreport_parse_opts(int argc, char **argv, const struct options *opt,
 
         if (c == '?' || help)
         {
-            free(longopts);
+            g_free(longopts);
             g_string_free(shortopts, TRUE);
             libreport_xfunc_error_retval = 0; /* this isn't error, exit code = 0 */
             libreport_show_usage_and_die(usage, opt);
@@ -260,7 +260,7 @@ unsigned libreport_parse_opts(int argc, char **argv, const struct options *opt,
         }
     }
 
-    free(longopts);
+    g_free(longopts);
     g_string_free(shortopts, TRUE);
 
     return retval;

--- a/src/lib/problem_data.c
+++ b/src/lib/problem_data.c
@@ -23,8 +23,8 @@ static void free_problem_item(void *ptr)
     if (ptr)
     {
         struct problem_item *item = (struct problem_item *)ptr;
-        free(item->content);
-        free(item);
+        g_free(item->content);
+        g_free(item);
     }
 }
 
@@ -340,7 +340,7 @@ static int is_text_file_at(int dir_fd, const char *name, char **content, ssize_t
     if (r < 0)
     {
         close(fd);
-        free(buf);
+        g_free(buf);
         return -EIO; /* it's not text (because we can't read it) */
     }
 
@@ -386,7 +386,7 @@ static int is_text_file_at(int dir_fd, const char *name, char **content, ssize_t
             /* We don't like NULs and other control chars very much.
              * Not text for sure!
              */
-            free(buf);
+            g_free(buf);
             return CD_FLAG_BIN;
         }
         if (buf[i] == 0x7f)
@@ -408,13 +408,13 @@ static int is_text_file_at(int dir_fd, const char *name, char **content, ssize_t
     if ((total_chars / bad_chars) >= RATIO)
         goto text; /* looks like text to me */
 
-    free(buf);
+    g_free(buf);
     return CD_FLAG_BIN; /* it's binary */
 
  text:
     if (size > CD_MAX_TEXT_SIZE)
     {
-        free(buf);
+        g_free(buf);
         return CD_FLAG_BIN | CD_FLAG_BIGTXT;
     }
 
@@ -451,7 +451,7 @@ static int _problem_data_load_dump_dir_element(struct dump_dir *dd, const char *
     if (sz >= IS_TEXT_FILE_AT_PROBE_SIZE) /* did is_text_file() read entire file? */
     {
         /* no, it didn't, we need to read it all */
-        free(text);
+        g_free(text);
         lseek(*file_fd_ptr, 0, SEEK_SET);
         text = libreport_xmalloc_read(*file_fd_ptr, NULL);
     }
@@ -472,7 +472,7 @@ static int _problem_data_load_dump_dir_element(struct dump_dir *dd, const char *
 
     if (sanitized != NULL)
     {
-        free(text);
+        g_free(text);
         text = sanitized;
     }
 
@@ -555,10 +555,10 @@ void problem_data_load_from_dump_dir(problem_data_t *problem_data, struct dump_d
                 content,
                 flags
         );
-        free(content);
+        g_free(content);
  next:
-        free(short_name);
-        free(full_name);
+        g_free(short_name);
+        g_free(full_name);
     }
 }
 

--- a/src/lib/problem_report.c
+++ b/src/lib/problem_report.c
@@ -123,11 +123,11 @@ section_free(section_t *self)
     if (self == NULL)
         return;
 
-    free(self->name);
+    g_free(self->name);
     g_list_free_full(self->items, free);
     g_list_free_full(self->children, (GDestroyNotify)section_free);
 
-    free(self);
+    g_free(self);
 }
 
 static int
@@ -285,7 +285,7 @@ load_stream(FILE *fp)
             master->children = g_list_prepend(master->children, sec);
 
  free_line:
-        free(line);
+        g_free(line);
     }
 
     /* If master equals sec, then master's children list was not yet reversed.
@@ -812,7 +812,7 @@ memstream_buffer_free(struct memstream_buffer *self)
     free(self->msb_buffer);
     self->msb_buffer = DESTROYED_POINTER;
 
-    free(self);
+    g_free(self);
 }
 
 static FILE *
@@ -1015,7 +1015,7 @@ problem_report_free(problem_report_t *self)
         self->pr_sec_custom = DESTROYED_POINTER;
     }
 
-    free(self);
+    g_free(self);
 }
 
 /*
@@ -1044,10 +1044,10 @@ extra_section_free(struct extra_section *self)
     if (self == NULL)
         return;
 
-    free(self->pfes_name);
+    g_free(self->pfes_name);
     self->pfes_name = DESTROYED_POINTER;
 
-    free(self);
+    g_free(self);
 }
 
 static int
@@ -1114,13 +1114,13 @@ problem_formatter_free(problem_formatter_t *self)
     g_list_free_full(self->pf_extra_sections, (GDestroyNotify)extra_section_free);
     self->pf_extra_sections = DESTROYED_POINTER;
 
-    free(self->pf_default_summary);
+    g_free(self->pf_default_summary);
     self->pf_default_summary = DESTROYED_POINTER;
 
-    free(self->fmt_file);
+    g_free(self->fmt_file);
     self->fmt_file = DESTROYED_POINTER;
 
-    free(self);
+    g_free(self);
 }
 
 static int

--- a/src/lib/proxies.c
+++ b/src/lib/proxies.c
@@ -48,7 +48,7 @@ GList *get_proxy_list(const char *url)
     /* Don't set proxy if the list contains just "direct://" */
     if (l && !g_list_next(l) && !strcmp(l->data, "direct://"))
     {
-        free(l->data);
+        g_free(l->data);
         g_list_free(l);
         l = NULL;
     }

--- a/src/lib/read_write.c
+++ b/src/lib/read_write.c
@@ -148,7 +148,7 @@ void* libreport_xmalloc_read(int fd, size_t *maxsz_p)
         buf = g_realloc(buf, total + size + 1);
         rd_size = libreport_full_read(fd, buf + total, size);
         if ((ssize_t)rd_size == (ssize_t)(-1)) { /* error */
-            free(buf);
+            g_free(buf);
             return NULL;
         }
         total += rd_size;

--- a/src/lib/reporters.c
+++ b/src/lib/reporters.c
@@ -31,10 +31,10 @@ libreport_is_comment_dup(GList *comments, const char *comment)
         const char * const comment_body = (const char *) l->data;
         char * const trim_comment_body = libreport_trim_all_whitespace(comment_body);
         same_comments = (strcmp(trim_comment_body, trim_comment) == 0);
-        free(trim_comment_body);
+        g_free(trim_comment_body);
     }
 
-    free(trim_comment);
+    g_free(trim_comment);
     return same_comments;
 }
 

--- a/src/lib/run_event.c
+++ b/src/lib/run_event.c
@@ -126,8 +126,8 @@ void free_rule_list(GList *rule_list)
     {
         struct rule *cur_rule = rule_list->data;
         g_list_free_full(cur_rule->conditions, free);
-        free(cur_rule->command);
-        free(cur_rule);
+        g_free(cur_rule->command);
+        g_free(cur_rule);
 
         GList *next = rule_list->next;
         g_list_free_1(rule_list);
@@ -165,7 +165,7 @@ GList *load_rule_list(GList *rule_list,
         if (*next_line == '\0' || *next_line == '#')
         {
             log_parser("empty or comment, skipping");
-            free(next_line);
+            g_free(next_line);
             continue;
         }
 
@@ -207,14 +207,14 @@ GList *load_rule_list(GList *rule_list,
                     if (fseek(conffile, prev, SEEK_SET) < 0)
                         perror_msg_and_die("fseek");
 
-                    free(next_line);
+                    g_free(next_line);
                     break;
                 }
 
                 ++line_counter;
                 char *tmp = g_strdup_printf("%s\n%s", line, next_line);
-                free(line);
-                free(next_line);
+                g_free(line);
+                g_free(next_line);
                 line = tmp;
             }
 
@@ -303,7 +303,7 @@ GList *load_rule_list(GList *rule_list,
         else
             log_parser("Unknown line found, ignoring: '%s'", line);
 
-        free(line);
+        g_free(line);
     } /* end of line loop */
 
     fclose(conffile);
@@ -389,7 +389,7 @@ static char* pop_next_command(GList **pp_rule_list,
                     goto next_rule; /* prefix doesn't match */
                 if (pp_event_name)
                 {
-                    free(*pp_event_name);
+                    g_free(*pp_event_name);
                     *pp_event_name = g_strdup(eq_sign + 1);
                 }
             }
@@ -444,8 +444,7 @@ static char* pop_next_command(GList **pp_rule_list,
         *pp_rule_list = g_list_remove(*pp_rule_list, cur_rule);
         g_list_free_full(cur_rule->conditions, free);
         command = cur_rule->command;
-        /*free(cur_rule->command); - WRONG! we are returning it! */
-        free(cur_rule);
+        g_free(cur_rule);
         break;
 
  next_rule:

--- a/src/lib/ureport.c
+++ b/src/lib/ureport.c
@@ -47,7 +47,7 @@ puppet_config_print(const char *key)
     *newline = '\0';
     return result;
 error:
-    free(result);
+    g_free(result);
     error_msg_and_die("Unable to determine puppet %s path (puppet not installed?)", key);
 }
 
@@ -55,7 +55,7 @@ void
 libreport_ureport_server_config_set_url(struct ureport_server_config *config,
                               char *server_url)
 {
-    free(config->ur_url);
+    g_free(config->ur_url);
     config->ur_url = server_url;
 }
 
@@ -68,10 +68,10 @@ libreport_ureport_server_config_set_client_auth(struct ureport_server_config *co
 
     if (strcmp(client_auth, "") == 0)
     {
-        free(config->ur_client_cert);
+        g_free(config->ur_client_cert);
         config->ur_client_cert = NULL;
 
-        free(config->ur_client_key);
+        g_free(config->ur_client_key);
         config->ur_client_key = NULL;
 
         log_notice("Not using client authentication");
@@ -96,10 +96,10 @@ libreport_ureport_server_config_set_client_auth(struct ureport_server_config *co
         log_notice("Using client certificate: %s", config->ur_client_cert);
         log_notice("Using client private key: %s", config->ur_client_key);
 
-        free(config->ur_username);
+        g_free(config->ur_username);
         config->ur_username = NULL;
 
-        free(config->ur_password);
+        g_free(config->ur_password);
         config->ur_password = NULL;
     }
 }
@@ -110,10 +110,10 @@ libreport_ureport_server_config_set_basic_auth(struct ureport_server_config *con
 {
     libreport_ureport_server_config_set_client_auth(config, "");
 
-    free(config->ur_username);
+    g_free(config->ur_username);
     config->ur_username = g_strdup(login);
 
-    free(config->ur_password);
+    g_free(config->ur_password);
     config->ur_password = g_strdup(password);
 }
 
@@ -203,22 +203,22 @@ libreport_ureport_server_config_init(struct ureport_server_config *config)
 void
 libreport_ureport_server_config_destroy(struct ureport_server_config *config)
 {
-    free(config->ur_url);
+    g_free(config->ur_url);
     config->ur_url = DESTROYED_POINTER;
 
-    free(config->ur_client_cert);
+    g_free(config->ur_client_cert);
     config->ur_client_cert = DESTROYED_POINTER;
 
-    free(config->ur_client_key);
+    g_free(config->ur_client_key);
     config->ur_client_key = DESTROYED_POINTER;
 
-    free(config->ur_cert_authority_cert);
+    g_free(config->ur_cert_authority_cert);
     config->ur_cert_authority_cert = DESTROYED_POINTER;
 
-    free(config->ur_username);
+    g_free(config->ur_username);
     config->ur_username = DESTROYED_POINTER;
 
-    free(config->ur_password);
+    g_free(config->ur_password);
     config->ur_password = DESTROYED_POINTER;
 
     g_list_free_full(config->ur_prefs.urp_auth_items, g_free);
@@ -231,22 +231,22 @@ libreport_ureport_server_response_free(struct ureport_server_response *resp)
     if (!resp)
         return;
 
-    free(resp->urr_solution);
+    g_free(resp->urr_solution);
     resp->urr_solution = DESTROYED_POINTER;
 
     g_list_free_full(resp->urr_reported_to_list, g_free);
     resp->urr_reported_to_list = DESTROYED_POINTER;
 
-    free(resp->urr_bthash);
+    g_free(resp->urr_bthash);
     resp->urr_bthash = DESTROYED_POINTER;
 
-    free(resp->urr_message);
+    g_free(resp->urr_message);
     resp->urr_message = DESTROYED_POINTER;
 
-    free(resp->urr_value);
+    g_free(resp->urr_value);
     resp->urr_value = DESTROYED_POINTER;
 
-    free(resp);
+    g_free(resp);
 }
 
 static char *

--- a/src/lib/user_settings.c
+++ b/src/lib/user_settings.c
@@ -79,7 +79,7 @@ bool libreport_save_user_settings()
 bool libreport_load_user_settings(const char *application_name)
 {
     if (conf_path)
-        free(conf_path);
+        g_free(conf_path);
     conf_path = get_conf_path(application_name);
 
     if (user_settings)
@@ -127,7 +127,7 @@ GList *libreport_load_words_from_file(const char* filename)
                 if (line[0] != '#') // if it's not comment
                     words_list = g_list_append(words_list, line);
                 else
-                    free(line);
+                    g_free(line);
             }
             fclose(fp);
         }

--- a/src/lib/workflow.c
+++ b/src/lib/workflow.c
@@ -46,7 +46,7 @@ void free_workflow(workflow_t *w)
 
     free_config_info(w->info);
     g_list_free_full(w->events, (GDestroyNotify)free_event_config);
-    free(w);
+    g_free(w);
 }
 
 void free_workflow_list(GHashTable **wl)

--- a/src/lib/workflow_xml_parser.c
+++ b/src/lib/workflow_xml_parser.c
@@ -46,7 +46,7 @@ static void start_element(GMarkupParseContext *context,
     if (strcmp(element_name, NAME_ELEMENT) == 0
      || strcmp(element_name, DESCRIPTION_ELEMENT) == 0
     ) {
-        free(parse_data->attribute_lang);
+        g_free(parse_data->attribute_lang);
         parse_data->attribute_lang = get_element_lang(parse_data, attribute_names, attribute_values);
     }
 }
@@ -59,7 +59,7 @@ static void end_element(GMarkupParseContext *context,
 {
     struct my_parse_data *parse_data = user_data;
 
-    free(parse_data->attribute_lang);
+    g_free(parse_data->attribute_lang);
     parse_data->attribute_lang = NULL;
 
     if (strcmp(element_name, EVENTS_ELEMENT) == 0)
@@ -223,6 +223,6 @@ void load_workflow_description_from_file(workflow_t *workflow, const char* filen
 
     g_markup_parse_context_free(context);
 
-    free(parse_data.attribute_lang); /* just in case */
-    free(parse_data.cur_locale);
+    g_free(parse_data.attribute_lang); /* just in case */
+    g_free(parse_data.cur_locale);
 }

--- a/src/lib/xfuncs.c
+++ b/src/lib/xfuncs.c
@@ -136,10 +136,6 @@ char* libreport_xvasprintf(const char *format, va_list p)
 
 void libreport_safe_unsetenv(const char *var_val)
 {
-    //char *name = g_strndup(var_val, strchrnul(var_val, '=') - var_val);
-    //unsetenv(name);
-    //free(name);
-
     /* Avoid malloc/free (name is usually very short) */
     unsigned len = strchrnul(var_val, '=') - var_val;
     char name[len + 1];

--- a/src/plugins/mantisbt.c
+++ b/src/plugins/mantisbt.c
@@ -73,11 +73,11 @@ mantisbt_settings_free(mantisbt_settings_t *s)
     if (s == NULL)
         return;
 
-    free(s->m_login);
-    free(s->m_password);
-    free(s->m_project);
-    free(s->m_project_id);
-    free(s->m_project_version);
+    g_free(s->m_login);
+    g_free(s->m_password);
+    g_free(s->m_project);
+    g_free(s->m_project_id);
+    g_free(s->m_project_version);
 }
 
 /*

--- a/src/plugins/reporter-kerneloops.c
+++ b/src/plugins/reporter-kerneloops.c
@@ -23,22 +23,6 @@
 static size_t writefunction(void *ptr, size_t size, size_t nmemb, void *stream)
 {
     size *= nmemb;
-/*
-    char *c, *c1, *c2;
-
-    log_warning("received: '%*.*s'", (int)size, (int)size, (char*)ptr);
-    c = (char*)g_malloc0(size + 1);
-    memcpy(c, ptr, size);
-    c1 = strstr(c, "201 ");
-    if (c1)
-    {
-        c1 += 4;
-        c2 = strchr(c1, '\n');
-        if (c2)
-            *c2 = 0;
-    }
-    free(c);
-*/
 
     return size;
 }

--- a/src/plugins/reporter-mantisbt.c
+++ b/src/plugins/reporter-mantisbt.c
@@ -74,8 +74,8 @@ ask_mantisbt_password(const char *message)
 static void
 ask_mantisbt_credentials(mantisbt_settings_t *settings, const char *pre_message)
 {
-    free(settings->m_login);
-    free(settings->m_password);
+    g_free(settings->m_login);
+    g_free(settings->m_password);
 
     g_autofree char *question = g_strdup_printf("%s %s", pre_message, _("Please enter your MantisBT login:"));
     settings->m_login = ask_mantisbt_login(question);
@@ -168,8 +168,8 @@ set_settings(mantisbt_settings_t *m, GHashTable *settings, struct dump_dir *dd)
 
     if (!m->m_project || !*m->m_project) /* if not overridden or empty... */
     {
-        free(m->m_project);
-        free(m->m_project_version);
+        g_free(m->m_project);
+        g_free(m->m_project_version);
 
         if (dd != NULL)
         {
@@ -691,7 +691,7 @@ int main(int argc, char **argv)
                     if (g_list_find_custom(ii->mii_attachments, name, (GCompareFunc) strcmp) == NULL)
                         break;
 
-                    free(name);
+                    g_free(name);
                 }
                 mantisbt_attach_data(&mbt_settings, bug_id_str, name, bt, strlen(bt));
             }

--- a/src/plugins/reporter-print.c
+++ b/src/plugins/reporter-print.c
@@ -86,11 +86,11 @@ int main(int argc, char **argv)
             /* prompt for another file name if needed */
             if (msg)
             {
-                free(output_file);
+                g_free(output_file);
                 char *response = libreport_ask(msg);
                 if (!response)
                     perror_msg_and_die("libreport_ask");
-                free(msg);
+                g_free(msg);
 
                 if (response[0] == '\0' || response[0] == '\n')
                 {
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
         }
         const char *format = (open_mode[0] == 'a' ? _("The report was appended to %s") : _("The report was stored to %s"));
         log_warning(format, output_file);
-        free(output_file);
+        g_free(output_file);
     }
 
     return 0;

--- a/src/plugins/reporter-systemd-journal.c
+++ b/src/plugins/reporter-systemd-journal.c
@@ -88,10 +88,10 @@ static void msg_content_free(msg_content_t *msg_c)
         return;
 
     for (unsigned i = 0; i < msg_c->used; ++i)
-        free(msg_c->data[i].iov_base);
+        g_free(msg_c->data[i].iov_base);
 
-    free(msg_c->data);
-    free(msg_c);
+    g_free(msg_c->data);
+    g_free(msg_c);
 
     return;
 }

--- a/src/plugins/reporter-upload.c
+++ b/src/plugins/reporter-upload.c
@@ -67,7 +67,7 @@ static int interactive_upload_file(const char *url, const char *file_name,
     if (remote_name)
         *remote_name = tmp;
     else
-        free(tmp);
+        g_free(tmp);
 
     free_post_state(state);
 

--- a/src/plugins/reporter-ureport.c
+++ b/src/plugins/reporter-ureport.c
@@ -313,7 +313,7 @@ int main(int argc, char **argv)
     }
 
     struct ureport_server_response *response = libreport_ureport_submit(json_ureport, &config);
-    free(json_ureport);
+    g_free(json_ureport);
 
     if (!response)
         goto finalize;

--- a/src/plugins/rhbz.c
+++ b/src/plugins/rhbz.c
@@ -65,7 +65,7 @@ void free_bug_info(struct bug_info *bi)
 
     g_list_free_full(bi->bi_cc_list, g_free);
 
-    free(bi);
+    g_free(bi);
 }
 
 static GList *rhbz_comments(struct abrt_xmlrpc *ax, int bug_id)

--- a/src/report-newt/report-newt.c
+++ b/src/report-newt/report-newt.c
@@ -180,12 +180,12 @@ static int configure_reporter(struct reporter *r, bool skip_if_valid)
                     case OPTION_TYPE_TEXT:
                     case OPTION_TYPE_NUMBER:
                     case OPTION_TYPE_PASSWORD:
-                        free(opt->eo_value);
-                        opt->eo_value = strdup(newtEntryGetValue(options[i]));
+                        g_free(opt->eo_value);
+                        opt->eo_value = g_strdup(newtEntryGetValue(options[i]));
                         break;
                     case OPTION_TYPE_BOOL:
-                        free(opt->eo_value);
-                        opt->eo_value = strdup(newtCheckboxGetValue(options[i]) == '*' ? "yes" : "no");
+                        g_free(opt->eo_value);
+                        opt->eo_value = g_strdup(newtCheckboxGetValue(options[i]) == '*' ? "yes" : "no");
                         break;
                     default:
                         break;
@@ -230,9 +230,9 @@ static char *save_log_line(char *log_line, void *param)
         /* Append the log line */
         len = strlen(log->text) + 1 + strlen(log_line) + 1;
         new = g_malloc(len);
-        snprintf(new, len, "%s\n%s", log->text, log_line);
-        free(log->text);
-        free(log_line);
+        g_snprintf(new, len, "%s\n%s", log->text, log_line);
+        g_free(log->text);
+        g_free(log_line);
         log->text = new;
         newtTextboxSetText(log->co, new);
     }
@@ -352,7 +352,7 @@ static int report(const char *dump_dir_name)
         newtWinMessage(NULL, _("Ok"), _("No reporters available"));
 
     g_array_free(reporters, TRUE);
-    free(events_as_lines);
+    g_free(events_as_lines);
 
     return 0;
 }

--- a/tests/dump_dir.at
+++ b/tests/dump_dir.at
@@ -86,8 +86,8 @@ void validate_dump_dir_contents(struct dump_dir *dd)
         TS_ASSERT_STRING_EQ(short_name, (strrchr(full_name, '/') + 1), NULL);
         TS_ASSERT_STRING_BEGINS_WITH(full_name, dd->dd_dirname, NULL);
         TS_ASSERT_CHAR_EQ_MESSAGE(full_name[strlen(dd->dd_dirname)], '/', full_name);
-        free(short_name);
-        free(full_name);
+        g_free(short_name);
+        g_free(full_name);
     }
 
     TS_ASSERT_SIGNED_EQ(items, items_counter);
@@ -101,8 +101,8 @@ void validate_dump_dir_contents(struct dump_dir *dd)
     while (dd_get_next_file(dd, &short_name, &full_name))
     {
         --items_counter;
-        free(short_name);
-        free(full_name);
+        g_free(short_name);
+        g_free(full_name);
     }
 
     TS_ASSERT_SIGNED_OP_MESSAGE(items_counter, ==, 0, "Second run iterator goes through all items");
@@ -749,11 +749,11 @@ TS_MAIN
 
         char *loaded_text = dd_load_text(dd, FILENAME_TYPE);
         TS_ASSERT_STRING_EQ(loaded_text, "birds", "'type' is created from the passed string");
-        free(loaded_text);
+        g_free(loaded_text);
 
         loaded_text = dd_load_text(dd, "egg");
         TS_ASSERT_STRING_EQ(loaded_text, "canary", "Call back saves durable data");
-        free(loaded_text);
+        g_free(loaded_text);
         TS_ASSERT_SIGNED_EQ(dd_delete(dd), 0);
     }
 
@@ -1039,36 +1039,35 @@ int main(void)
     dd_save_text(dd, "empty", "");
     assert(dd_load_int32(dd, "empty", &value) == -EINVAL);
 
-    char *buf = NULL;
-    asprintf(&buf, "%lld", -1LL + INT32_MIN);
+    char *buf = g_strdup_printf("%lld", -1LL + INT32_MIN);
     assert(buf != NULL);
 
     dd_save_text(dd, "below_min", buf);
-    free(buf);
+    g_free(buf);
 
     assert(dd_load_int32(dd, "below_min", &value) == -ERANGE);
 
-    asprintf(&buf, "%"PRId32, INT32_MIN);
+    buf = g_strdup_printf("%"PRId32, INT32_MIN);
     dd_save_text(dd, "min", buf);
-    free(buf);
+    g_free(buf);
 
     assert(dd_load_int32(dd, "min", &value) == 0);
     assert(value == INT32_MIN || !"min");
 
-    asprintf(&buf, "%"PRId32, INT32_MAX);
+    buf = g_strdup_printf("%"PRId32, INT32_MAX);
     assert(buf != NULL);
 
     dd_save_text(dd, "max", buf);
-    free(buf);
+    g_free(buf);
 
     assert(dd_load_int32(dd, "max", &value) == 0);
     assert(value == INT32_MAX);
 
-    asprintf(&buf, "%lld", 1LL + INT32_MAX);
+    buf = g_strdup_printf("%lld", 1LL + INT32_MAX);
     assert(buf != NULL);
 
     dd_save_text(dd, "above_max", buf);
-    free(buf);
+    g_free(buf);
 
     assert(dd_load_int32(dd, "above_max", &value) == -ERANGE);
 
@@ -1124,20 +1123,19 @@ int main(void)
     assert(dd_load_uint32(dd, "min", &value) == 0);
     assert(value == 0 || !"min");
 
-    char *buf = NULL;
-    asprintf(&buf, "%"PRIu32, UINT32_MAX);
+    char *buf = g_strdup_printf("%"PRIu32, UINT32_MAX);
     assert(buf != NULL);
 
     dd_save_text(dd, "max", buf);
-    free(buf);
+    g_free(buf);
     assert(dd_load_uint32(dd, "max", &value) == 0);
     assert(value == UINT32_MAX);
 
-    asprintf(&buf, "%lld", 1LL + UINT32_MAX);
+    buf = g_strdup_printf("%lld", 1LL + UINT32_MAX);
     assert(buf != NULL);
 
     dd_save_text(dd, "above_max", buf);
-    free(buf);
+    g_free(buf);
     assert(dd_load_uint32(dd, "above_max", &value) == -ERANGE);
 
     dd_save_text(dd, "string_suffix", "123abc");
@@ -1188,18 +1186,17 @@ int main(void)
     dd_save_text(dd, "below_min", "-9223372036854775809");
     assert(dd_load_int64(dd, "below_min", &value) == -ERANGE);
 
-    char *buf = NULL;
-    asprintf(&buf, "%"PRId64, INT64_MIN);
+    char *buf = g_strdup_printf("%"PRId64, INT64_MIN);
     assert(buf != NULL);
     dd_save_text(dd, "min", buf);
-    free(buf);
+    g_free(buf);
     assert(dd_load_int64(dd, "min", &value) == 0);
     assert(value == INT64_MIN || !"min");
 
-    asprintf(&buf, "%"PRId64, INT64_MAX);
+    buf = g_strdup_printf("%"PRId64, INT64_MAX);
     assert(buf != NULL);
     dd_save_text(dd, "max", buf);
-    free(buf);
+    g_free(buf);
     assert(dd_load_int64(dd, "max", &value) == 0);
     assert(value == INT64_MAX);
 

--- a/tests/event_config.at
+++ b/tests/event_config.at
@@ -41,7 +41,7 @@ TS_MAIN
 
     TS_ASSERT_FALSE(ec_restricted_access_enabled(ect));
 
-    free(eot->eo_value);
+    g_free(eot->eo_value);
     eot->eo_value = g_strdup("yes");
 
     TS_ASSERT_TRUE(ec_restricted_access_enabled(ect));

--- a/tests/helpers/testsuite.h
+++ b/tests/helpers/testsuite.h
@@ -377,7 +377,7 @@ FILE *g_testsuite_output_stream = 0;
         char *ts_fd_contents = libreport_xmalloc_read(ts_pipefd[0], NULL); \
         close(ts_pipefd[0]); \
         TS_ASSERT_STRING_EQ(ts_fd_contents, expected, message); \
-        free(ts_fd_contents); \
+        g_free(ts_fd_contents); \
     } while (0)
 
 #define TS_ASSERT_STDERR_EQ_BEGIN \

--- a/tests/iso_date.at
+++ b/tests/iso_date.at
@@ -42,7 +42,7 @@ int main(void)
             break;
     }
     assert((i != ARRAY_SIZE(local)) || !"None of attempts hit result date");
-    free(date);
+    g_free(date);
 
     time_t y2k = 946684800;
     assert(string_cmp("2000-01-01-00:00:00", libreport_iso_date_string(&y2k)));

--- a/tests/make_description.at
+++ b/tests/make_description.at
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
     assert(description != NULL || !"Returns NULL for empty problem data");
     assert(description[0] == '\0' || !"Returns non-empty description for empty problem data");
 
-    free(description);
+    g_free(description);
 
     problem_data_add_text_noteditable(pd, FILENAME_REPORTED_TO, "Bugzilla: URL=https://bugzilla.redhat.com/1000000\n");
 
@@ -36,8 +36,8 @@ int main(int argc, char **argv)
         assert(!"The description for a single Bugzilla URL does not match the expected description");
     }
 
-    free(description);
-    free(expected);
+    g_free(description);
+    g_free(expected);
     problem_data_free(pd);
 
     pd = problem_data_new();
@@ -60,8 +60,8 @@ int main(int argc, char **argv)
         assert(!"The description does not match the expected description");
     }
 
-    free(description);
-    free(expected);
+    g_free(description);
+    g_free(expected);
     problem_data_free(pd);
 
     pd = problem_data_new();
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
     assert(description != NULL || !"Returns NULL for non empty problem data");
     assert(description[0] == '\0' || !"Returns non-empty description for problem data without any URL");
 
-    free(description);
+    g_free(description);
     problem_data_free(pd);
 
     pd = problem_data_new();
@@ -109,8 +109,8 @@ int main(int argc, char **argv)
         assert(!"The description does not match the expected description");
     }
 
-    free(expected);
-    free(description);
+    g_free(expected);
+    g_free(description);
 
     const char *const backtrace = "Extremely long backtrace which does not make sense";
     problem_data_add(pd, FILENAME_BACKTRACE, backtrace,  CD_FLAG_TXT | CD_FLAG_ISNOTEDITABLE);
@@ -142,8 +142,8 @@ int main(int argc, char **argv)
         assert(!"The description does not match the expected description");
     }
 
-    free(expected);
-    free(description);
+    g_free(expected);
+    g_free(description);
     problem_data_free(pd);
 
     /* SHOW_URLS DID NOT BREAK THE OLD BEHAVIOUR */
@@ -176,8 +176,8 @@ int main(int argc, char **argv)
         assert(!"The description does not match the expected description");
     }
 
-    free(expected);
-    free(description);
+    g_free(expected);
+    g_free(description);
     problem_data_free(pd);
 
     return 0;

--- a/tests/problem_data.at
+++ b/tests/problem_data.at
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
             assert(current_size == old_size);
         }
         {
-            free(itm->content);
+            g_free(itm->content);
             itm->content = NULL;
             size_t current_size = PROBLEM_ITEM_UNINITIALIZED_SIZE;
             assert(problem_item_get_size(itm, &current_size) == 0);

--- a/tests/problem_report.at
+++ b/tests/problem_report.at
@@ -768,7 +768,7 @@ int main(int argc, char **argv)
                 abort();
             }
             else {
-                free(item->data);
+                g_free(item->data);
                 clone = g_list_delete_link(clone, item);
             }
 

--- a/tests/report_result.at
+++ b/tests/report_result.at
@@ -11,16 +11,16 @@ int main(void)
     result = report_result_parse("Test: URL=https://retrace.fedoraproject.org WORKFLOW=workflow_FedoraCCpp MSG=Just a message!", 4);
     field = report_result_get_label(result);
     g_assert_cmpstr(field, ==, "Test");
-    free(field);
+    g_free(field);
     field = report_result_get_url(result);
     g_assert_cmpstr(field, ==, "https://retrace.fedoraproject.org");
-    free(field);
+    g_free(field);
     field = report_result_get_workflow(result);
     g_assert_cmpstr(field, ==, "workflow_FedoraCCpp");
-    free(field);
+    g_free(field);
     field = report_result_get_message(result);
     g_assert_cmpstr(field, ==, "Just a message!");
-    free(field);
+    g_free(field);
 
     return EXIT_SUCCESS;
 }

--- a/tests/ureport.at
+++ b/tests/ureport.at
@@ -70,11 +70,11 @@ int main(void)
     struct ureport_server_config config;
     libreport_ureport_server_config_init(&config);
 
-    config.ur_url = strdup("url");
-    config.ur_client_cert = strdup("cert");
-    config.ur_client_key = strdup("key");
-    config.ur_username = strdup("username");
-    config.ur_password = strdup("password");
+    config.ur_url = g_strdup("url");
+    config.ur_client_cert = g_strdup("cert");
+    config.ur_client_key = g_strdup("key");
+    config.ur_username = g_strdup("username");
+    config.ur_password = g_strdup("password");
 
     assert(strcmp(config.ur_url, "url") == 0);
     assert(strcmp(config.ur_client_cert, "cert") == 0);
@@ -273,11 +273,11 @@ int main(void)
     struct ureport_server_config config;
     libreport_ureport_server_config_init(&config);
 
-    libreport_ureport_server_config_set_url(&config, strdup("url"));
+    libreport_ureport_server_config_set_url(&config, g_strdup("url"));
 
     assert(strcmp(config.ur_url, "url") == 0);
 
-    libreport_ureport_server_config_set_url(&config, strdup("next.url"));
+    libreport_ureport_server_config_set_url(&config, g_strdup("next.url"));
 
     assert(strcmp(config.ur_url, "next.url") == 0);
 
@@ -305,14 +305,6 @@ AT_TESTFUN([libreport_ureport_server_config_set_client_auth],
 #define TESTING_PYTHONPATH "../../ureport/"
 #define WRONG_TESTING_PYTHONPATH "../../ureportxxxxxx/"
 
-char *my_strdup(const char *str)
-{
-    if (str == NULL)
-        return NULL;
-    else
-        return strdup(str);
-}
-
 void set_ureport_server_config(struct ureport_server_config *config,
                                 const char *url,
                                 bool ver,
@@ -321,12 +313,12 @@ void set_ureport_server_config(struct ureport_server_config *config,
                                 const char *uname,
                                 const char *passwd)
 {
-    config->ur_url = my_strdup(url);
+    config->ur_url = g_strdup(url);
     config->ur_ssl_verify = ver;
-    config->ur_client_cert = my_strdup(cert);
-    config->ur_client_key = my_strdup(key);
-    config->ur_username = my_strdup(uname);
-    config->ur_password = my_strdup(passwd);
+    config->ur_client_cert = g_strdup(cert);
+    config->ur_client_key = g_strdup(key);
+    config->ur_username = g_strdup(uname);
+    config->ur_password = g_strdup(passwd);
 
     return;
 }
@@ -558,7 +550,7 @@ int main(void)
     struct ureport_server_config config;
     libreport_ureport_server_config_init(&config);
 
-    g_autofree char *url = strdup("url");
+    g_autofree char *url = g_strdup("url");
     libreport_ureport_server_config_set_url(&config, url);
 
     assert(libreport_ureport_server_response_from_reply(&ps, &config) == NULL);
@@ -643,7 +635,7 @@ int main(void)
 
     struct ureport_server_config config;
     libreport_ureport_server_config_init(&config);
-    libreport_ureport_server_config_set_url(&config, strdup("url"));
+    libreport_ureport_server_config_set_url(&config, g_strdup("url"));
 
     struct dump_dir *dd = dd_create("./test", (uid_t)-1L, DEFAULT_DUMP_DIR_MODE);
     assert(dd != NULL);
@@ -668,7 +660,7 @@ int main(void)
     /* not-reportable must not exist */
     assert(!dd_exist(dd, FILENAME_NOT_REPORTABLE));
 
-    free(config.ur_url);
+    g_free(config.ur_url);
     libreport_ureport_server_response_free(response);
     dd_close(dd);
     delete_dump_dir("./test");
@@ -687,7 +679,7 @@ int main(void)
                          'reporter': 'ABRT Server' } ] }";
 
     libreport_ureport_server_config_init(&config);
-    libreport_ureport_server_config_set_url(&config, strdup("url"));
+    libreport_ureport_server_config_set_url(&config, g_strdup("url"));
 
     dd = dd_create("./test", (uid_t)-1L, DEFAULT_DUMP_DIR_MODE);
     assert(dd != NULL);
@@ -712,7 +704,7 @@ int main(void)
     assert(strstr(not_reportable, "Your problem seems to be caused by solution_cause") != NULL);
 
 
-    free(config.ur_url);
+    g_free(config.ur_url);
     libreport_ureport_server_response_free(response);
     dd_close(dd);
     delete_dump_dir("./test");
@@ -754,7 +746,7 @@ int main(void)
 
     struct ureport_server_config config;
     libreport_ureport_server_config_init(&config);
-    libreport_ureport_server_config_set_url(&config, strdup("url"));
+    libreport_ureport_server_config_set_url(&config, g_strdup("url"));
 
     struct ureport_server_response *response = libreport_ureport_server_response_from_reply(&ps, &config);
 
@@ -765,7 +757,7 @@ int main(void)
 
     assert(strcmp(report_url, expect_report_url) == 0);
 
-    free(config.ur_url);
+    g_free(config.ur_url);
     libreport_ureport_server_response_free(response);
 
     return 0;
@@ -886,11 +878,11 @@ int main(void)
     char *json = ureport_json_attachment_new("data_bthash", "data_type", "data_data");
     assert(strcmp(json, "{ \"bthash\": \"data_bthash\", \"type\": \"data_type\", \"data\": \"data_data\" }") == 0);
 
-    free(json);
+    g_free(json);
     json = ureport_json_attachment_new("", "", "");
     assert(strcmp(json, "{ \"bthash\": \"\", \"type\": \"\", \"data\": \"\" }") == 0);
 
-    free(json);
+    g_free(json);
     return 0;
 }
 ]])
@@ -960,7 +952,7 @@ int main(void)
     /* no auth */
     char *ureport = libreport_ureport_from_dump_dir_ext("./test", NULL);
     assert(strstr(ureport, "auth") == NULL);
-    free(ureport);
+    g_free(ureport);
 
     /* auth */
     dd = dd_opendir("./test", 0);
@@ -980,7 +972,7 @@ int main(void)
     ureport = libreport_ureport_from_dump_dir_ext("./test", &config.ur_prefs);
     assert(strstr(ureport, "auth") != NULL);
     assert(strstr(ureport, "\"hostname\": \"env_hostname\"") != NULL);
-    free(ureport);
+    g_free(ureport);
 
     libreport_ureport_server_config_destroy(&config);
     if (settings)
@@ -999,7 +991,7 @@ int main(void)
     assert(strstr(ureport, "auth") != NULL);
     assert(strstr(ureport, "\"hostname\": \"env_hostname\"") != NULL);
     assert(strstr(ureport, "unknown") == NULL);
-    free(ureport);
+    g_free(ureport);
 
     libreport_ureport_server_config_destroy(&config);
     if (settings)

--- a/tests/uriparser.at
+++ b/tests/uriparser.at
@@ -75,7 +75,7 @@ int test(int retval, const char *uri, const char *result, const char *scheme, co
             else
             {
                 e += !string_cmp(names[i], expected[i], outputs[i]);
-                free(outputs[i]);
+                g_free(outputs[i]);
                 outputs[i] = (char *)0xDEADBEEF;
             }
         }
@@ -104,7 +104,7 @@ int test(int retval, const char *uri, const char *result, const char *scheme, co
     }
 
     e += !string_cmp(names[0], result, outputs[0]);
-    free(outputs[0]);
+    g_free(outputs[0]);
 
     return e;
 }


### PR DESCRIPTION
Replace `free()` with `g_free` in cases where the memory was allocated with `g_malloc()` and similar. Note that there are quite a few plain `free()`s left because the memory is allocated e.g. in `open_memstream()` or other opaque (to me anyway) functions or I'd simply give up digging for the place of allocation.

See also https://github.com/abrt/abrt/pull/1567

Also, replace a few forgotten `strdup()`s with `g_strdup()` and drop some old
commented-out code.