### PR TITLE
Avoid direct use of libproxy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -224,9 +224,6 @@ PKG_CHECK_MODULES([GIO], [
 PKG_CHECK_MODULES([GOBJECT], [gobject-2.0])
 PKG_CHECK_MODULES([LIBXML], [libxml-2.0])
 PKG_CHECK_MODULES([CURL], [libcurl])
-PKG_CHECK_MODULES([PROXY], [libproxy-1.0], [
-    AC_DEFINE([HAVE_PROXY], [1], [Use libproxy])
-], [:])
 PKG_CHECK_MODULES([SATYR], [satyr])
 PKG_CHECK_MODULES([JOURNAL], [libsystemd])
 PKG_CHECK_MODULES([AUGEAS], [augeas])

--- a/src/lib/curl.c
+++ b/src/lib/curl.c
@@ -102,7 +102,7 @@ CURLcode curl_easy_perform_with_proxy(CURL *handle, const char *url)
         curl_err = curl_easy_perform(handle);
     }
 
-    g_list_free_full(proxy_list, free);
+    g_list_free_full(proxy_list, g_free);
 
     return curl_err;
 }

--- a/src/lib/proxies.c
+++ b/src/lib/proxies.c
@@ -19,49 +19,34 @@
 #include "internal_libreport.h"
 #include "proxies.h"
 
-#ifdef HAVE_PROXY
-#include <proxy.h>
-
-static pxProxyFactory *px_factory;
+#include <gio/gio.h>
 
 GList *get_proxy_list(const char *url)
 {
     int i;
-    GList *l;
-    g_autofree char **proxies = NULL;
+    GList *l = NULL;
+    GProxyResolver *resolver;
+    g_auto(GStrv) proxies = NULL;
+    g_autoptr(GError) error = NULL;
 
-    if (!px_factory)
+    resolver = g_proxy_resolver_get_default();
+
+    proxies = g_proxy_resolver_lookup(resolver, url, NULL, &error);
+    if (!proxies)
     {
-        px_factory = px_proxy_factory_new();
-        if (!px_factory)
-            return NULL;
+        log_warning("Failed to perform proxy lookup for %s: %s", url, error->message);
+        return NULL;
     }
 
-    /* Cast to char * is needed with libproxy versions before 0.4.0 */
-    proxies = px_proxy_factory_get_proxies(px_factory, (char *)url);
-    if (!proxies)
-        return NULL;
-
     for (i = 0, l = NULL; proxies[i]; i++)
-        l = g_list_append(l, proxies[i]);
+        l = g_list_append(l, g_steal_pointer(&proxies[i]));
 
     /* Don't set proxy if the list contains just "direct://" */
     if (l && !g_list_next(l) && !strcmp(l->data, "direct://"))
     {
-        g_free(l->data);
         g_list_free(l);
         l = NULL;
     }
 
     return l;
 }
-
-#else
-
-GList *get_proxy_list(const char *url)
-{
-    /* Without libproxy just return an empty list */
-    return NULL;
-}
-
-#endif


### PR DESCRIPTION
GProxyResolver has been around since GLib 2.26. There's no reason to use
libproxy directly anymore. GProxyResolver will call into libproxy if
GLib thinks it's a good idea to do so, except in distributions that are
configured to build glib-networking without libproxy support.

Note that the existing code in get_proxy_list() was unsafely using
g_autofree and g_free() to free the memory allocated by libproxy. With
the switch to GProxyResolver, the memory is actually allocated by GLib
now, so this is now actually correct to do.

**Note that this commit is untested.** I just checked to make sure that it builds. **It will probably work, but please sanity-check to ensure it doesn't crash at runtime before merging.** The APIs are basically 1:1 except for some details around SOCKS proxies that libreport doesn't care about, so if it doesn't crash it will be good.