### PR TITLE
spec: Drop libproxy dependency

### DIFF
--- a/libreport-web.pc.in
+++ b/libreport-web.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: libreport
 Description: Library providing network API for libreport
 Version: @VERSION@
-Requires: glib-2.0 libcurl libproxy-1.0 libxml-2.0 xmlrpc xmlrpc_client @JSON_C_PACKAGE@ satyr libreport
+Requires: glib-2.0 libcurl libxml-2.0 xmlrpc xmlrpc_client @JSON_C_PACKAGE@ satyr libreport
 Libs: -L${libdir} -lreport-web
 Cflags:
 

--- a/libreport.spec
+++ b/libreport.spec
@@ -33,7 +33,6 @@ BuildRequires: texinfo
 BuildRequires: asciidoc
 BuildRequires: xmlto
 BuildRequires: newt-devel
-BuildRequires: libproxy-devel
 BuildRequires: satyr-devel >= 0.24
 BuildRequires: glib2-devel >= %{glib_ver}
 BuildRequires: git-core


### PR DESCRIPTION
Dependency on libproxy was factually removed in 11df7ffc. This change follows up by removing the formal dependency in the spec and pkgconfig files.