### PR TITLE
[rhbz] Retry XML-RPC calls when uploading attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Memory management issues
 - reporter-bugzilla: fix subcomponent handling for RHEL
+- Retry XML-RPC calls when uploading attachments
 
 ## [2.15.2] - 2021-06-02
 ### Changed

--- a/src/lib/abrt_xmlrpc.h
+++ b/src/lib/abrt_xmlrpc.h
@@ -63,6 +63,11 @@ xmlrpc_value *abrt_xmlrpc_call_params(xmlrpc_env *env, struct abrt_xmlrpc *ax,
 xmlrpc_value *abrt_xmlrpc_call_full(xmlrpc_env *enf, struct abrt_xmlrpc *ax,
                                    const char *method, const char *format, ...);
 
+xmlrpc_value *abrt_xmlrpc_call_with_retry(const char *fault_substring,
+                                          struct abrt_xmlrpc *ax,
+                                          const char *method,
+                                          const char *format, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/libreport-web.sym
+++ b/src/lib/libreport-web.sym
@@ -51,6 +51,7 @@ global:
     abrt_xmlrpc_call;
     abrt_xmlrpc_call_params;
     abrt_xmlrpc_call_full;
+    abrt_xmlrpc_call_with_retry;
 
     /* internal_libreport.h - these symbols are only to be used by libreport developers */
     libreport_trim_all_whitespace;

--- a/src/plugins/rhbz.c
+++ b/src/plugins/rhbz.c
@@ -643,8 +643,10 @@ int rhbz_attach_blob(struct abrt_xmlrpc *ax, const char *bug_id,
      *   i -> integer, single argument (int value)
      *   6 -> base64,  two arguments (char* plain data which will be encoded by xmlrpc-c to base64,
      *                                size_t number of bytes to encode)
+     *
+     * Retry if another user/bot attempted to change the same data.
      */
-    result = abrt_xmlrpc_call(ax, "Bug.add_attachment", "{s:(s),s:s,s:s,s:s,s:6,s:i}",
+    result = abrt_xmlrpc_call_with_retry("query serialization error", ax, "Bug.add_attachment", "{s:(s),s:s,s:s,s:s,s:6,s:i}",
                 "ids", bug_id,
                 "summary", fn,
                 "file_name", filename,


### PR DESCRIPTION
If there is a bot that automatically modifies newly opened bugs, then
it can lead to "query serialization error" from Bugzilla. Retry should
help us here.

Signed-off-by: Michal Srb <michal@redhat.com>