### PR TITLE
Drop last references to global_uuid file

### DIFF
--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -599,8 +599,6 @@ int main(int argc, char **argv)
 
     const char *component = problem_data_get_content_or_die(problem_data, FILENAME_COMPONENT);
     const char *duphash   = problem_data_get_content_or_NULL(problem_data, FILENAME_DUPHASH);
-//COMPAT, remove after 2.1 release
-    if (!duphash) duphash = problem_data_get_content_or_die(problem_data, "global_uuid");
 
     if (!rhbz.b_product || !*rhbz.b_product || !rhbz.b_product_version || !*rhbz.b_product_version) /* if not overridden or empty... */
     {
@@ -625,12 +623,9 @@ int main(int argc, char **argv)
         if (problem_formatter_generate_report(pf, problem_data, &pr))
             error_msg_and_die("Failed to format bug report from problem data");
 
-        printf("summary: %s\n"
-                "\n"
-                "%s"
-                "\n"
-                , problem_report_get_summary(pr)
-                , problem_report_get_description(pr)
+        printf("summary: %s\n\n%s\n",
+               problem_report_get_summary(pr),
+               problem_report_get_description(pr)
         );
 
         puts("attachments:");

--- a/src/plugins/reporter-bugzilla.c
+++ b/src/plugins/reporter-bugzilla.c
@@ -88,14 +88,14 @@ struct bugzilla_struct {
 
 static void set_default_settings(GHashTable *osinfo, GHashTable *settings)
 {
-    g_autofree char *default_BugzillaURL;
+    g_autofree char *default_BugzillaURL = NULL;
     libreport_parse_osinfo_for_bug_url(osinfo, &default_BugzillaURL);
     /* if BugzillaURL is defined in conf_file or env , it will replace this value */
     g_hash_table_replace(settings, g_strdup("BugzillaURL"), g_strdup(default_BugzillaURL));
     log_debug("Loaded BUG_REPORT_URL '%s' from os-release", default_BugzillaURL);
 
-    g_autofree char *default_Product;
-    g_autofree char *default_ProductVersion;
+    g_autofree char *default_Product = NULL;
+    g_autofree char *default_ProductVersion = NULL;
     libreport_parse_osinfo_for_bz(osinfo, &default_Product, &default_ProductVersion);
     /* if Product or ProductVersion is defined in conf_file or env , it will replace this value */
     g_hash_table_replace(settings, g_strdup("Product"), g_strdup(default_Product));

--- a/src/plugins/reporter-upload.c
+++ b/src/plugins/reporter-upload.c
@@ -116,8 +116,7 @@ static int create_and_upload_archive(
     {
         result = 0; /* success */
         log_warning(_("Archive is created: '%s'"), tempfile);
-        *remote_name = tempfile;
-        tempfile = NULL;
+        *remote_name = g_steal_pointer(&tempfile);
     }
 
  ret:

--- a/src/plugins/rhbz.c
+++ b/src/plugins/rhbz.c
@@ -307,17 +307,15 @@ int rhbz_get_bug_id_from_array0(xmlrpc_value* xml, unsigned ver)
     if (env.fault_occurred)
         abrt_xmlrpc_die(&env);
 
-    const char *id;
-    if (ver >= BUGZILLA_VERSION(4,2,0))
-        id = "id";
-    else
-        id = "bug_id";
+    const char *item_id = "id";
+    if (ver < BUGZILLA_VERSION(4,2,0))
+        item_id = "bug_id";
 
     xmlrpc_value *bug;
-    bug = rhbz_get_member(id, item);
+    bug = rhbz_get_member(item_id, item);
     xmlrpc_DECREF(item);
     if (!bug)
-        error_msg_and_die("Can't get member '%s' from bug data", id);
+        error_msg_and_die("Can't get member '%s' from bug data", item_id);
 
     int bug_id = -1;
     xmlrpc_read_int(&env, bug, &bug_id);
@@ -511,9 +509,6 @@ int rhbz_new_bug(struct abrt_xmlrpc *ax,
                                                                 FILENAME_ARCHITECTURE);
     const char *duphash      = problem_data_get_content_or_NULL(problem_data,
                                                                 FILENAME_DUPHASH);
-//COMPAT, remove after 2.1 release
-    if (!duphash) duphash    = problem_data_get_content_or_NULL(problem_data,
-                                                                "global_uuid");
 
     g_autofree char *summary = libreport_shorten_string_to_length(bzsummary, MAX_SUMMARY_LENGTH);
 

--- a/src/report-python/report/__init__.py
+++ b/src/report-python/report/__init__.py
@@ -43,36 +43,6 @@ OS_RELEASE_VERSION_FIELDS = ["REDHAT_BUGZILLA_PRODUCT_VERSION", "REDHAT_SUPPORT_
 _hardcoded_default_product = ""
 _hardcoded_default_version = ""
 
-"""
-def getProduct_fromRPM():
-    try:
-        import rpm
-        ts = rpm.TransactionSet()
-        for each_dep in SYSTEM_RELEASE_DEPS:
-            mi = ts.dbMatch('provides', each_dep)
-            for h in mi:
-                if h['name']:
-                    return h['name'].split("-")[0].capitalize()
-
-        return ""
-    except:
-        return ""
-
-def getVersion_fromRPM():
-    try:
-        import rpm
-        ts = rpm.TransactionSet()
-        for each_dep in SYSTEM_RELEASE_DEPS:
-            mi = ts.dbMatch('provides', each_dep)
-            for h in mi:
-                if h['version']:
-                    return str(h['version'])
-
-        return ""
-    except:
-        return ""
-"""
-
 def parse_os_release_lines(osreleaselines):
     osrel = {}
 


### PR DESCRIPTION
According to a comment in the code, we should be ignoring this file since a long time ago. We never create it anymore and these were the only instances left in code referencing it.

+ Various marginal code style clean ups.