### PR TITLE
reporter-bugzilla: send API key in HTTP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- reporter-bugzilla: send API key in HTTP header for Red Hat Bugzilla
 
 ## [2.17.0] - 2022-02-17
 ### Changed

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -139,7 +139,7 @@ libreport_web_la_CPPFLAGS = \
     $(SATYR_CFLAGS) \
     -D_GNU_SOURCE
 libreport_web_la_LDFLAGS = \
-    -version-info 2:1:0
+    -version-info 3:0:1
 
 if HAVE_LD_VERSION_SCRIPT
 libreport_web_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libreport-web.sym

--- a/src/lib/abrt_xmlrpc.h
+++ b/src/lib/abrt_xmlrpc.h
@@ -37,6 +37,7 @@ struct abrt_xmlrpc {
     xmlrpc_client *ax_client;
     xmlrpc_server_info *ax_server_info;
     GList *ax_session_params;
+    const char *libreport_user_agent;
 };
 
 xmlrpc_value *abrt_xmlrpc_array_new(xmlrpc_env *env);
@@ -48,6 +49,7 @@ void abrt_xmlrpc_params_set_value(xmlrpc_env *env, xmlrpc_value *params, const c
 
 
 struct abrt_xmlrpc *abrt_xmlrpc_new_client(const char *url, int ssl_verify);
+struct abrt_xmlrpc *abrt_xmlrpc_new_redhat_client(const char *url, int ssl_verify, const char *api_key);
 void abrt_xmlrpc_free_client(struct abrt_xmlrpc *ax);
 void abrt_xmlrpc_client_add_session_param_string(xmlrpc_env *env, struct abrt_xmlrpc *ax, const char *name, const char *value);
 void abrt_xmlrpc_die(xmlrpc_env *env) __attribute__((noreturn));

--- a/src/lib/libreport-web.sym
+++ b/src/lib/libreport-web.sym
@@ -44,6 +44,7 @@ global:
     abrt_xmlrpc_params_set_value_str;
     abrt_xmlrpc_params_set_value;
     abrt_xmlrpc_new_client;
+    abrt_xmlrpc_new_redhat_client;
     abrt_xmlrpc_free_client;
     abrt_xmlrpc_client_add_session_param_string;
     abrt_xmlrpc_die;


### PR DESCRIPTION
But only if the target instance is Red Hat Bugzilla.

This change is required as Red Hat Bugzilla expects the API key
to be in the HTTP header and it won't find it in XML-RPC params.

xmlrpc-c doesn't support custom headers. Only User-Agent header
is supported. However, since HTTP is a text protocol, we can add
more headers by simply strategically placing line break characters
("\r\n" for HTTP) inside the User-Agent header.
HTTP will do the right thing and interpret such string as multiple
headers.

Signed-off-by: Michal Srb <michal@redhat.com>