### PR TITLE
GTK report wizard: Enable word wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - reporter-upload: Fix double free crash (#792)
+- gui-wizard-gtk: Enable word wrap for comments
 
 ## [2.17.11] - 2023-06-30
 ### Fixed

--- a/src/gui-wizard-gtk/wizard.glade
+++ b/src/gui-wizard-gtk/wizard.glade
@@ -325,6 +325,7 @@
           <object class="GtkTextView" id="tv_comment">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <property name="wrap-mode">word</property>
           </object>
         </child>
       </object>


### PR DESCRIPTION
Enable word wrap in GTK report wizard to avoid the need of horizontal scrolling