### PR TITLE
Fix compatibility with libxml2 2.12

### DIFF
--- a/src/plugins/mantisbt.h
+++ b/src/plugins/mantisbt.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif
 
 #include <libxml/encoding.h>
+#include <libxml/tree.h>
 #include "problem_report.h"
 
 #define SOAP_STRING "ns2:string"


### PR DESCRIPTION
Since libxml2 2.12, `xmlNodePtr` is no longer included by `libxml/encoding.h`. This leads to build errors such as:

      CC       reporter_mantisbt-reporter-mantisbt.o
    In file included from reporter-mantisbt.c:22:
    mantisbt.h:48:5: error: unknown type name ‘xmlNodePtr’
       48 |     xmlNodePtr sr_root;
          |     ^~~~~~~~~~
    mantisbt.h:49:5: error: unknown type name ‘xmlNodePtr’
       49 |     xmlNodePtr sr_body;
          |     ^~~~~~~~~~
    mantisbt.h:50:5: error: unknown type name ‘xmlNodePtr’
       50 |     xmlNodePtr sr_method;
          |     ^~~~~~~~~~

Fix this by including `libxml/tree.h`.